### PR TITLE
feat: Add color, shot type, and duration sorting to remix

### DIFF
--- a/core/remix/__init__.py
+++ b/core/remix/__init__.py
@@ -2,8 +2,13 @@
 
 from typing import List, Tuple, Any
 from core.remix.shuffle import constrained_shuffle
+from core.analysis.color import get_primary_hue
+from core.analysis.shots import SHOT_TYPES
 
 __all__ = ["constrained_shuffle", "generate_sequence"]
+
+# Shot type order for sorting (wide to close)
+SHOT_TYPE_ORDER = {shot: i for i, shot in enumerate(SHOT_TYPES)}
 
 
 def generate_sequence(
@@ -15,7 +20,8 @@ def generate_sequence(
     Generate a sequence of clips using the specified algorithm.
 
     Args:
-        algorithm: Algorithm name ("shuffle" or "sequential")
+        algorithm: Algorithm name ("shuffle", "sequential", "color", "shot_type",
+                   "duration_long", "duration_short")
         clips: List of (Clip, Source) tuples to sequence
         clip_count: Maximum number of clips to include
 
@@ -31,6 +37,42 @@ def generate_sequence(
             get_category=lambda x: x[1].id,  # x is (Clip, Source), category by source
             max_consecutive=1,
         )
+    elif algorithm == "color":
+        # Sort by primary hue (HSV color wheel order)
+        def get_hue(item: Tuple[Any, Any]) -> float:
+            clip, _ = item
+            if clip.dominant_colors:
+                return get_primary_hue(clip.dominant_colors)
+            return 0.0
+
+        return sorted(clips_to_use, key=get_hue)
+
+    elif algorithm == "shot_type":
+        # Sort by shot type (wide -> medium -> close-up -> extreme close-up)
+        def get_shot_order(item: Tuple[Any, Any]) -> int:
+            clip, _ = item
+            if clip.shot_type:
+                return SHOT_TYPE_ORDER.get(clip.shot_type, 999)
+            return 999  # Unknown shot types at end
+
+        return sorted(clips_to_use, key=get_shot_order)
+
+    elif algorithm == "duration_long":
+        # Sort by duration (longest first)
+        def get_duration(item: Tuple[Any, Any]) -> float:
+            clip, source = item
+            return -clip.duration_seconds(source.fps)  # Negative for descending
+
+        return sorted(clips_to_use, key=get_duration)
+
+    elif algorithm == "duration_short":
+        # Sort by duration (shortest first)
+        def get_duration(item: Tuple[Any, Any]) -> float:
+            clip, source = item
+            return clip.duration_seconds(source.fps)
+
+        return sorted(clips_to_use, key=get_duration)
+
     else:
         # Sequential - use original order
         return clips_to_use

--- a/ui/timeline/timeline_widget.py
+++ b/ui/timeline/timeline_widget.py
@@ -98,9 +98,16 @@ class TimelineWidget(QWidget):
         # Remix algorithm selector
         toolbar.addWidget(QLabel("Remix:"))
         self.remix_combo = QComboBox()
-        self.remix_combo.addItems(["Shuffle", "Sequential"])
+        self.remix_combo.addItems([
+            "Shuffle",
+            "Sequential",
+            "Color (HSV)",
+            "Shot Type",
+            "Duration (Long)",
+            "Duration (Short)",
+        ])
         self.remix_combo.setToolTip("Algorithm for generating sequences")
-        self.remix_combo.setMinimumWidth(100)
+        self.remix_combo.setMinimumWidth(120)
         toolbar.addWidget(self.remix_combo)
 
         # Clip count spinner
@@ -214,12 +221,23 @@ class TimelineWidget(QWidget):
         else:
             self.view.reset_zoom()
 
+    # Map display names to algorithm keys
+    ALGORITHM_MAP = {
+        "Shuffle": "shuffle",
+        "Sequential": "sequential",
+        "Color (HSV)": "color",
+        "Shot Type": "shot_type",
+        "Duration (Long)": "duration_long",
+        "Duration (Short)": "duration_short",
+    }
+
     def _on_generate(self):
         """Handle Generate button click."""
         if not self._available_clips:
             return
 
-        algorithm = self.remix_combo.currentText().lower()
+        display_name = self.remix_combo.currentText()
+        algorithm = self.ALGORITHM_MAP.get(display_name, "sequential")
         clip_count = self.clip_count_spin.value()
 
         # Clear existing timeline


### PR DESCRIPTION
## Summary

Adds new sequence generation options to the timeline remix dropdown:

- **Color (HSV)** - Sort clips by primary hue (red → orange → yellow → green → blue → purple)
- **Shot Type** - Sort by shot type (wide → medium → close-up → extreme close-up)
- **Duration (Long)** - Longest clips first
- **Duration (Short)** - Shortest clips first

## Changes

- **core/remix/__init__.py** - Added sorting algorithms for color, shot_type, duration_long, duration_short
- **ui/timeline/timeline_widget.py** - Added new options to remix dropdown with algorithm mapping

## Usage

1. Import a video and run scene detection
2. Wait for color analysis and shot type classification to complete
3. In the Timeline toolbar, select a Remix option from the dropdown
4. Set the number of clips
5. Click "Generate" to create a sorted sequence

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)