### PR TITLE
feat(linux): add Linux distribution support

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,0 +1,117 @@
+name: Linux Build
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number for AppImage'
+        required: false
+        default: '0.1.0'
+
+jobs:
+  test-linux:
+    name: Test on Ubuntu
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            ffmpeg \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-plugins-ugly \
+            gstreamer1.0-libav \
+            libxcb-xinerama0 \
+            libegl1 \
+            libgl1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Verify FFmpeg
+        run: ffmpeg -version
+
+      - name: Run import test
+        run: |
+          python -c "from ui.main_window import MainWindow; print('MainWindow import: OK')"
+          python -c "from core.scene_detect import SceneDetector; print('SceneDetector import: OK')"
+          python -c "from core.settings import Settings; s = Settings(); print(f'Settings import: OK, download_dir={s.download_dir}')"
+
+      - name: Run unit tests
+        run: |
+          if [ -d "tests" ]; then
+            python -m pytest tests/ -v
+          else
+            echo "No tests directory found, skipping"
+          fi
+
+  build-appimage:
+    name: Build AppImage
+    runs-on: ubuntu-22.04
+    needs: test-linux
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install appimage-builder
+        run: |
+          pip install appimage-builder
+          # Install additional tools for AppImage creation
+          sudo apt-get update
+          sudo apt-get install -y \
+            patchelf \
+            desktop-file-utils \
+            libgdk-pixbuf2.0-dev \
+            fakeroot
+
+      - name: Build AppImage
+        run: |
+          cd packaging/linux
+          VERSION="${{ github.event.inputs.version || '0.1.0' }}"
+          ./build-appimage.sh "$VERSION"
+        continue-on-error: true
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Scene-Ripper-AppImage
+          path: |
+            *.AppImage
+            packaging/linux/*.AppImage
+          if-no-files-found: warn
+
+      - name: Upload build logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: |
+            appimage-builder-cache/
+            *.log
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -120,10 +120,43 @@ numpy>=1.24
 yt-dlp>=2024.1
 ```
 
-Plus FFmpeg installed via system package manager:
-- macOS: `brew install ffmpeg`
-- Ubuntu: `sudo apt install ffmpeg`
-- Windows: Download from ffmpeg.org
+### System Dependencies
+
+**macOS:**
+```bash
+brew install ffmpeg
+```
+
+**Linux (Ubuntu/Debian):**
+```bash
+# FFmpeg and Qt multimedia backend (GStreamer)
+sudo apt install ffmpeg \
+    gstreamer1.0-plugins-good \
+    gstreamer1.0-plugins-bad \
+    gstreamer1.0-plugins-ugly \
+    gstreamer1.0-libav
+```
+
+**Linux (Fedora):**
+```bash
+sudo dnf install ffmpeg \
+    gstreamer1-plugins-good \
+    gstreamer1-plugins-bad-free \
+    gstreamer1-plugins-ugly-free \
+    gstreamer1-libav
+```
+
+**Linux (Arch):**
+```bash
+sudo pacman -S ffmpeg \
+    gst-plugins-good \
+    gst-plugins-bad \
+    gst-plugins-ugly \
+    gst-libav
+```
+
+**Windows:**
+Download FFmpeg from [ffmpeg.org](https://ffmpeg.org/download.html) and add to PATH
 
 ## Roadmap
 

--- a/packaging/linux/AppImageBuilder.yml
+++ b/packaging/linux/AppImageBuilder.yml
@@ -1,0 +1,70 @@
+version: 1
+
+script:
+  # Install Python dependencies into AppDir
+  - pip install --target="${APPDIR}/usr/lib/python3/site-packages" -r requirements.txt
+
+AppDir:
+  path: ./AppDir
+
+  app_info:
+    id: com.algorithmic-filmmaking.scene-ripper
+    name: Scene Ripper
+    icon: scene-ripper
+    version: !ENV ${VERSION:-0.1.0}
+    exec: usr/bin/python3
+    exec_args: "$APPDIR/usr/src/main.py $@"
+
+  apt:
+    arch: amd64
+    sources:
+      - sourceline: deb http://archive.ubuntu.com/ubuntu jammy main universe
+      - sourceline: deb http://archive.ubuntu.com/ubuntu jammy-updates main universe
+
+    include:
+      # Python runtime
+      - python3
+      - python3-pip
+      - python3-dev
+
+      # OpenGL/EGL for Qt
+      - libgl1
+      - libegl1
+      - libxcb-xinerama0
+
+      # GStreamer for Qt Multimedia
+      - gstreamer1.0-plugins-good
+      - gstreamer1.0-plugins-bad
+      - gstreamer1.0-libav
+      - gstreamer1.0-gl
+
+      # Qt platform plugins
+      - libxkbcommon0
+
+  files:
+    include:
+      - usr/src/
+
+    exclude:
+      - usr/share/doc
+      - usr/share/man
+      - usr/share/info
+
+  runtime:
+    env:
+      PYTHONPATH: "${APPDIR}/usr/lib/python3/site-packages"
+      QT_PLUGIN_PATH: "${APPDIR}/usr/lib/x86_64-linux-gnu/qt6/plugins"
+      GST_PLUGIN_PATH: "${APPDIR}/usr/lib/x86_64-linux-gnu/gstreamer-1.0"
+
+  test:
+    fedora-30:
+      image: fedora:30
+      command: ./AppRun --help
+    ubuntu-22.04:
+      image: ubuntu:22.04
+      command: ./AppRun --help
+
+AppImage:
+  arch: x86_64
+  update-information: guess
+  sign-key: None

--- a/packaging/linux/build-appimage.sh
+++ b/packaging/linux/build-appimage.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Build AppImage for Scene Ripper
+#
+# Prerequisites:
+#   - appimage-builder installed (pip install appimage-builder)
+#   - Docker (for AppImage testing)
+#
+# Usage:
+#   ./build-appimage.sh [VERSION]
+#
+# Example:
+#   ./build-appimage.sh 0.2.0
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VERSION="${1:-0.1.0}"
+
+echo "Building Scene Ripper AppImage v${VERSION}"
+echo "Project root: ${PROJECT_ROOT}"
+
+cd "$PROJECT_ROOT"
+
+# Clean previous build
+echo "Cleaning previous build..."
+rm -rf AppDir *.AppImage
+
+# Create AppDir structure
+echo "Creating AppDir structure..."
+mkdir -p AppDir/usr/src
+mkdir -p AppDir/usr/share/applications
+mkdir -p AppDir/usr/share/icons/hicolor/256x256/apps
+mkdir -p AppDir/usr/share/icons/hicolor/scalable/apps
+
+# Copy application source
+echo "Copying application source..."
+cp -r main.py core/ models/ ui/ AppDir/usr/src/
+cp requirements.txt AppDir/usr/src/
+
+# Copy desktop entry
+echo "Copying desktop entry..."
+cp "$SCRIPT_DIR/scene-ripper.desktop" AppDir/usr/share/applications/
+
+# Copy icon (create placeholder if doesn't exist)
+if [ -f "$PROJECT_ROOT/assets/icon.png" ]; then
+    cp "$PROJECT_ROOT/assets/icon.png" AppDir/usr/share/icons/hicolor/256x256/apps/scene-ripper.png
+else
+    echo "Warning: No icon found at assets/icon.png, using placeholder"
+    # Create a simple placeholder icon using ImageMagick if available
+    if command -v convert &> /dev/null; then
+        convert -size 256x256 xc:#4a90d9 -gravity center \
+            -pointsize 48 -fill white -annotate 0 "SR" \
+            AppDir/usr/share/icons/hicolor/256x256/apps/scene-ripper.png
+    fi
+fi
+
+# Create AppRun script (fallback if appimage-builder doesn't create one)
+cat > AppDir/AppRun << 'APPRUN'
+#!/bin/bash
+APPDIR="$(dirname "$(readlink -f "$0")")"
+export PATH="${APPDIR}/usr/bin:${PATH}"
+export PYTHONPATH="${APPDIR}/usr/lib/python3/site-packages:${PYTHONPATH}"
+export QT_PLUGIN_PATH="${APPDIR}/usr/lib/x86_64-linux-gnu/qt6/plugins"
+export GST_PLUGIN_PATH="${APPDIR}/usr/lib/x86_64-linux-gnu/gstreamer-1.0"
+export LD_LIBRARY_PATH="${APPDIR}/usr/lib:${APPDIR}/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH}"
+exec "${APPDIR}/usr/bin/python3" "${APPDIR}/usr/src/main.py" "$@"
+APPRUN
+chmod +x AppDir/AppRun
+
+# Build AppImage using appimage-builder
+echo "Building AppImage with appimage-builder..."
+export VERSION="$VERSION"
+appimage-builder --recipe "$SCRIPT_DIR/AppImageBuilder.yml" --skip-test
+
+# Rename output
+mv Scene_Ripper-*.AppImage "Scene_Ripper-${VERSION}-x86_64.AppImage" 2>/dev/null || true
+
+echo ""
+echo "Build complete!"
+echo "Output: Scene_Ripper-${VERSION}-x86_64.AppImage"
+echo ""
+echo "To run:"
+echo "  chmod +x Scene_Ripper-${VERSION}-x86_64.AppImage"
+echo "  ./Scene_Ripper-${VERSION}-x86_64.AppImage"

--- a/packaging/linux/scene-ripper.desktop
+++ b/packaging/linux/scene-ripper.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Application
+Name=Scene Ripper
+GenericName=Video Scene Detector
+Comment=Automatic scene detection and algorithmic video remixing
+Exec=scene-ripper %F
+Icon=scene-ripper
+Terminal=false
+Categories=AudioVideo;Video;
+MimeType=video/mp4;video/x-matroska;video/webm;video/quicktime;video/x-msvideo;video/mpeg;
+Keywords=video;scene;detection;editing;remix;
+StartupNotify=true


### PR DESCRIPTION
## Summary

- Add XDG-compliant default paths for Linux (`~/Videos` instead of `~/Movies`)
- Document GStreamer dependencies for Qt Multimedia on Linux
- Create AppImage packaging configuration
- Add GitHub Actions workflow for Linux testing and AppImage builds

## Changes

### Platform-specific paths (`core/settings.py`)
- New `_get_videos_dir()` function detects platform
- Uses `XDG_VIDEOS_DIR` environment variable on Linux, falls back to `~/Videos`
- macOS continues to use `~/Movies`

### Documentation (`README.md`)
- Added Linux dependencies section with commands for:
  - Ubuntu/Debian
  - Fedora
  - Arch Linux
- Documents required GStreamer plugins for Qt Multimedia

### AppImage Packaging (`packaging/linux/`)
- `AppImageBuilder.yml` - Recipe for appimage-builder
- `scene-ripper.desktop` - Desktop entry for Linux app menus
- `build-appimage.sh` - Build script

### CI/CD (`.github/workflows/linux-build.yml`)
- Tests on Ubuntu 22.04
- Installs system dependencies (FFmpeg, GStreamer)
- Runs import tests
- Builds AppImage artifact

## Testing

- [x] Import test passes on macOS
- [ ] Needs testing on actual Linux system
- [ ] AppImage build needs testing on Linux

## Follow-up Work

- Create proper app icon (currently uses placeholder)
- Test AppImage on multiple distros
- Add troubleshooting documentation
- Consider Flatpak for production distribution

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)