### PR TITLE
feat: Add editable fields to clip details sidebar

### DIFF
--- a/docs/plans/2026-01-26-feat-editable-clip-details-sidebar-plan.md
+++ b/docs/plans/2026-01-26-feat-editable-clip-details-sidebar-plan.md
@@ -1,0 +1,429 @@
+---
+title: "feat: Editable Clip Details Sidebar"
+type: feat
+date: 2026-01-26
+---
+
+# feat: Editable Clip Details Sidebar
+
+## Overview
+
+Make the clip details sidebar editable so users can modify clip attributes directly. Users will be able to edit:
+- **Clip name** (custom name, falling back to auto-generated if empty)
+- **Shot type** (dropdown with predefined categories)
+- **Transcript** (multi-line text area)
+
+Changes save automatically on blur (clicking away from field).
+
+## Problem Statement / Motivation
+
+Currently, the clip details sidebar is read-only. Users cannot:
+- Give clips meaningful names for easier identification
+- Correct or override AI-detected shot types
+- Edit or correct transcription errors
+
+This limits the usefulness of the metadata and forces users to accept auto-generated values.
+
+## Proposed Solution
+
+Transform specific fields in the clip details sidebar from read-only labels to inline-editable fields:
+
+1. **Clip Name**: Click to edit inline, auto-save on blur/Enter
+2. **Shot Type**: Click to open dropdown, save on selection
+3. **Transcript**: Click to expand multi-line text area, save on blur
+
+### What IS Editable
+
+| Field | Input Type | Save Trigger | Notes |
+|-------|------------|--------------|-------|
+| Clip name | Inline text input | Blur or Enter | Falls back to auto-generated if empty |
+| Shot type | Dropdown (QComboBox) | Selection | Categories: Wide, Medium, Close-up, Extreme CU |
+| Transcript | Multi-line text area | Blur | Enter inserts newline |
+
+### What is NOT Editable
+
+| Field | Reason |
+|-------|--------|
+| Duration | Derived from video frames |
+| Frames | Derived from scene detection |
+| Resolution | Derived from source video |
+| FPS | Derived from source video |
+| Dominant Colors | Skip for now (future feature) |
+| Source filename | Read-only reference |
+
+## Technical Approach
+
+### Architecture
+
+```
+ui/clip_details_sidebar.py
+├── ClipDetailsSidebar (QDockWidget)
+│   ├── video_player (VideoPlayer) - unchanged
+│   ├── EditableLabel - NEW: name editing
+│   ├── metadata_label (QLabel) - unchanged (read-only fields)
+│   ├── ShotTypeDropdown - NEW: shot type editing
+│   ├── EditableTextArea - NEW: transcript editing
+│   └── color_swatches - unchanged
+│
+models/clip.py
+├── Clip (dataclass)
+│   ├── name: str = "" - NEW FIELD
+│   └── (existing fields)
+```
+
+### Key Components
+
+**EditableLabel Widget (New)**
+- Dual-widget approach: QLabel (display) + QLineEdit (edit)
+- Click to enter edit mode
+- Auto-save on blur or Enter
+- Follows existing PlanStepWidget pattern from `ui/chat_widgets.py:654`
+
+**ShotTypeDropdown Widget (New)**
+- QComboBox with predefined shot types
+- Options: Wide, Medium, Close-up, Extreme CU, (Not set)
+- Save immediately on selection change
+
+**EditableTextArea Widget (New)**
+- QLabel (display) + QTextEdit (edit)
+- Click to enter edit mode
+- Enter inserts newline, blur saves
+- Escape cancels edit
+
+### Signal Flow
+
+```
+User edits field
+       ↓
+Widget emits value_changed signal
+       ↓
+ClipDetailsSidebar._on_field_changed(field, value)
+       ↓
+Update clip reference (single source of truth)
+       ↓
+Call project.update_clips([clip]) to notify observers
+       ↓
+ProjectSignalAdapter emits clips_updated signal
+       ↓
+Other views (clip browser, sequence) refresh as needed
+```
+
+### Integration Points
+
+| Location | Change |
+|----------|--------|
+| `models/clip.py` | Add `name: str = ""` field to Clip dataclass |
+| `ui/clip_details_sidebar.py` | Replace QLabels with editable widgets for name, shot type, transcript |
+| `ui/clip_browser.py` | Listen to `clips_updated` signal to refresh display |
+| `core/project.py` | Already has `update_clips()` method - no changes needed |
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [x] Clicking on clip name field enters edit mode (text input)
+- [x] Clip name saves on blur or Enter key
+- [x] Empty clip name falls back to auto-generated name (source filename + timecode)
+- [x] Clicking shot type field opens dropdown with options
+- [x] Shot type dropdown has options: Wide, Medium, Close-up, Extreme CU, (Not set)
+- [x] Selecting shot type saves immediately
+- [x] Clicking transcript segment text enters edit mode (per-segment)
+- [x] Transcript segment saves on blur
+- [x] Escape key cancels edit and reverts to previous value
+- [x] Non-editable fields (duration, frames, resolution, FPS) do not respond to clicks
+- [x] Changes persist to project (saved with project file)
+
+### Multi-Selection Behavior
+
+- [x] When multiple clips selected, sidebar shows "X clips selected"
+- [x] Editing is disabled when multiple clips selected
+- [x] Switching to single selection re-enables editing
+
+### Visual Requirements
+
+- [x] Editable fields show hover state (cursor change, subtle highlight)
+- [x] Edit mode shows clear visual distinction (border, background change)
+- [x] Non-editable fields appear visually different (no hover state)
+
+### Non-Functional Requirements
+
+- [x] Signal handlers have guard flags to prevent duplicate execution
+- [x] Clip reference follows single source of truth pattern (no duplicate state)
+- [x] Edit saves are debounced/guarded to prevent rapid-fire saves
+- [x] Theme changes update editable field styles correctly
+
+## Implementation Phases
+
+### Phase 1: Model Update
+
+**Files:**
+- `models/clip.py`
+
+**Tasks:**
+- [x] Add `name: str = ""` field to Clip dataclass
+- [x] Update `to_dict()` to include name field
+- [x] Update `from_dict()` to load name field (with default for backwards compatibility)
+- [x] Add `display_name` property that returns name or auto-generated fallback
+
+### Phase 2: EditableLabel Widget
+
+**Files:**
+- `ui/widgets/editable_label.py` (NEW)
+
+**Tasks:**
+- [x] Create EditableLabel class with dual-widget approach (QLabel + QLineEdit)
+- [x] Implement click-to-edit behavior
+- [x] Implement auto-save on blur/Enter
+- [x] Implement Escape to cancel
+- [x] Add `value_changed` signal
+- [x] Add hover state styling
+- [x] Add edit mode styling
+
+### Phase 3: ShotTypeDropdown Widget
+
+**Files:**
+- `ui/widgets/shot_type_dropdown.py` (NEW)
+
+**Tasks:**
+- [x] Create ShotTypeDropdown class extending QComboBox
+- [x] Populate with shot type options from `core/analysis/shots.py`
+- [x] Add "(Not set)" option for null/unset state
+- [x] Implement immediate save on selection change
+- [x] Add `value_changed` signal
+- [x] Style to match theme
+
+### Phase 4: EditableTextArea Widget
+
+**Files:**
+- `ui/widgets/editable_text_area.py` (NEW)
+
+**Tasks:**
+- [x] Create EditableTranscriptWidget class with per-segment editing
+- [x] Display timestamps (read-only) with editable text for each segment
+- [x] Click segment text to edit, blur saves
+- [x] Implement Escape to cancel
+- [x] Add `segments_changed` signal
+- [x] Handle multiple segments with scrolling
+
+### Phase 5: Integrate into Sidebar
+
+**Files:**
+- `ui/clip_details_sidebar.py`
+
+**Tasks:**
+- [x] Replace title QLabel with EditableLabel for clip name
+- [x] Replace shot type QLabel with ShotTypeDropdown
+- [x] Replace transcript QLabel with EditableTranscriptWidget
+- [x] Connect value_changed signals to handlers
+- [x] Implement `_on_name_changed()` handler with guard flag
+- [x] Implement `_on_shot_type_changed()` handler with guard flag
+- [x] Implement `_on_transcript_changed()` handler with guard flag
+- [x] Emit `clip_edited` signal for parent to update project
+- [x] Handle multi-selection (disable editing, show count)
+
+### Phase 6: View Synchronization
+
+**Files:**
+- `ui/clip_browser.py`
+- `ui/main_window.py`
+
+**Tasks:**
+- [x] Connect ClipBrowser to `clips_updated` signal via main_window
+- [x] Added `update_clips()` method to ClipBrowser for refreshing thumbnails
+- [x] Connected ProjectSignalAdapter.clips_updated to forward to clip browsers
+
+## Gotchas from Documented Learnings
+
+### Signal Handler Guards (CRITICAL)
+
+From `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`:
+
+```python
+# WRONG - no guard, may fire multiple times
+@Slot(str)
+def _on_name_changed(self, text: str):
+    self._clip_ref.name = text
+    self.project.update_clips([self._clip_ref])
+
+# RIGHT - guard prevents duplicate execution
+@Slot(str)
+def _on_name_changed(self, text: str):
+    if self._name_change_in_progress:
+        return
+    self._name_change_in_progress = True
+
+    self._clip_ref.name = text
+    self.project.update_clips([self._clip_ref])
+
+    self._name_change_in_progress = False
+```
+
+### Single Source of Truth (CRITICAL)
+
+From `docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md`:
+
+- Sidebar stores `self._clip_ref` - a REFERENCE, not a copy
+- All edits modify the reference directly
+- Never duplicate clip attributes in sidebar's own state
+- Use `@property` to delegate if needed
+
+### Block Signals During Programmatic Updates
+
+When updating widget values programmatically (e.g., when showing a different clip), block signals to prevent unwanted saves:
+
+```python
+def show_clip(self, clip: Clip, source: Source):
+    # Block signals while updating UI
+    self.name_edit.blockSignals(True)
+    self.shot_type_dropdown.blockSignals(True)
+    self.transcript_edit.blockSignals(True)
+
+    # Update widget values
+    self.name_edit.setText(clip.display_name)
+    self.shot_type_dropdown.set_value(clip.shot_type)
+    self.transcript_edit.setText(clip.get_transcript_text())
+
+    # Unblock signals
+    self.name_edit.blockSignals(False)
+    self.shot_type_dropdown.blockSignals(False)
+    self.transcript_edit.blockSignals(False)
+```
+
+## References
+
+### Internal Code Patterns
+
+| Pattern | File | Lines |
+|---------|------|-------|
+| Inline editing (dual widget) | `ui/chat_widgets.py` | 654-876 (PlanStepWidget) |
+| Clip model | `models/clip.py` | 114-209 |
+| Shot type categories | `core/analysis/shots.py` | 1-20 |
+| Project update signal | `core/project.py` | update_clips() method |
+| Signal adapter | `ui/project_adapter.py` | clips_updated signal |
+| ClipDetailsSidebar | `ui/clip_details_sidebar.py` | Full file |
+
+### Documented Learnings
+
+- `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md` - Signal guard pattern
+- `docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md` - Single source of truth
+- `docs/solutions/ui-bugs/pyside6-thumbnail-source-id-mismatch.md` - ID synchronization
+
+## MVP Implementation Sketch
+
+### models/clip.py - Add name field
+
+```python
+@dataclass
+class Clip:
+    id: str
+    source_id: str
+    start_frame: int
+    end_frame: int
+    name: str = ""  # NEW: custom clip name
+    thumbnail_path: Optional[Path] = None
+    dominant_colors: Optional[list[tuple[int, int, int]]] = None
+    shot_type: Optional[str] = None
+    transcript: Optional[list["TranscriptSegment"]] = None
+    tags: list[str] = field(default_factory=list)
+    notes: str = ""
+
+    @property
+    def display_name(self) -> str:
+        """Return custom name or auto-generated fallback."""
+        return self.name if self.name else None  # Caller provides fallback
+```
+
+### ui/widgets/editable_label.py
+
+```python
+"""Inline editable label widget."""
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QLabel, QLineEdit
+
+from ui.theme import theme
+
+
+class EditableLabel(QWidget):
+    """Label that can be clicked to edit inline."""
+
+    value_changed = Signal(str)
+
+    def __init__(self, text: str = "", placeholder: str = "", parent=None):
+        super().__init__(parent)
+        self._text = text
+        self._placeholder = placeholder
+        self._is_editing = False
+
+        self._setup_ui()
+        self._connect_signals()
+
+    def _setup_ui(self):
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Display label
+        self.label = QLabel(self._text or self._placeholder)
+        self.label.setCursor(Qt.PointingHandCursor)
+        self.label.mousePressEvent = self._start_editing
+        layout.addWidget(self.label)
+
+        # Edit field (hidden initially)
+        self.edit = QLineEdit(self._text)
+        self.edit.setPlaceholderText(self._placeholder)
+        self.edit.returnPressed.connect(self._finish_editing)
+        self.edit.hide()
+        layout.addWidget(self.edit)
+
+    def _connect_signals(self):
+        pass  # Signals connected in _setup_ui
+
+    def _start_editing(self, event):
+        if self._is_editing:
+            return
+        self._is_editing = True
+
+        self.label.hide()
+        self.edit.setText(self._text)
+        self.edit.show()
+        self.edit.setFocus()
+        self.edit.selectAll()
+
+    def _finish_editing(self):
+        if not self._is_editing:
+            return
+
+        new_text = self.edit.text().strip()
+        if new_text != self._text:
+            self._text = new_text
+            self.label.setText(new_text or self._placeholder)
+            self.value_changed.emit(new_text)
+
+        self.edit.hide()
+        self.label.show()
+        self._is_editing = False
+
+    def focusOutEvent(self, event):
+        if self._is_editing:
+            self._finish_editing()
+        super().focusOutEvent(event)
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Escape and self._is_editing:
+            # Cancel edit
+            self.edit.hide()
+            self.label.show()
+            self._is_editing = False
+            event.accept()
+        else:
+            super().keyPressEvent(event)
+
+    def setText(self, text: str):
+        """Set text programmatically (doesn't emit signal)."""
+        self._text = text
+        self.label.setText(text or self._placeholder)
+        self.edit.setText(text)
+
+    def text(self) -> str:
+        return self._text
+```

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -639,6 +639,25 @@ class ClipBrowser(QWidget):
         if thumb:
             thumb.set_thumbnail(thumb_path)
 
+    def update_clips(self, clips: list[Clip]):
+        """Update thumbnails for the given clips (called when clips are edited).
+
+        Args:
+            clips: List of clips that were updated
+        """
+        for clip in clips:
+            thumb = self._thumbnail_by_id.get(clip.id)
+            if thumb:
+                # Update shot type badge
+                if clip.shot_type:
+                    thumb.set_shot_type(clip.shot_type)
+                # Update transcript overlay
+                if clip.transcript:
+                    thumb.set_transcript(clip.transcript)
+                # Update colors
+                if clip.dominant_colors:
+                    thumb.set_colors(clip.dominant_colors)
+
     def _on_filter_changed(self, filter_option: str):
         """Handle shot type filter dropdown change."""
         self._current_filter = filter_option

--- a/ui/widgets/editable_transcript.py
+++ b/ui/widgets/editable_transcript.py
@@ -1,0 +1,294 @@
+"""Editable transcript widget.
+
+Displays transcript segments with timestamps and allows editing the text
+portion while preserving the timing information.
+"""
+
+from typing import Optional
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QScrollArea,
+    QFrame,
+)
+
+from ui.theme import theme
+
+# Import for type hints only to avoid circular imports
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from core.transcription import TranscriptSegment
+
+
+class TranscriptSegmentWidget(QFrame):
+    """Single transcript segment with timestamp and editable text."""
+
+    text_changed = Signal(int, str)  # (segment_index, new_text)
+
+    def __init__(self, index: int, segment: "TranscriptSegment", parent=None):
+        """Create a transcript segment widget.
+
+        Args:
+            index: Segment index in the transcript list
+            segment: The transcript segment data
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self._index = index
+        self._segment = segment
+        self._is_editing = False
+
+        self._setup_ui()
+        self._apply_style()
+
+    def _setup_ui(self):
+        """Build the segment UI."""
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 6, 8, 6)
+        layout.setSpacing(8)
+
+        # Timestamp label (read-only)
+        time_str = self._format_time_range(self._segment.start_time, self._segment.end_time)
+        self.time_label = QLabel(time_str)
+        self.time_label.setFixedWidth(100)
+        self.time_label.setAlignment(Qt.AlignRight | Qt.AlignVCenter)
+        layout.addWidget(self.time_label)
+
+        # Separator
+        separator = QLabel(":")
+        separator.setFixedWidth(10)
+        layout.addWidget(separator)
+
+        # Text label (display mode)
+        self.text_label = QLabel(self._segment.text)
+        self.text_label.setWordWrap(True)
+        self.text_label.setCursor(Qt.PointingHandCursor)
+        self.text_label.installEventFilter(self)
+        layout.addWidget(self.text_label, 1)
+
+        # Text edit (edit mode, hidden initially)
+        self.text_edit = QLineEdit(self._segment.text)
+        self.text_edit.returnPressed.connect(self._finish_editing)
+        self.text_edit.installEventFilter(self)
+        self.text_edit.hide()
+        layout.addWidget(self.text_edit, 1)
+
+    def _apply_style(self):
+        """Apply theme-aware styling."""
+        self.setStyleSheet(f"""
+            QFrame {{
+                background-color: transparent;
+                border-radius: 4px;
+            }}
+            QFrame:hover {{
+                background-color: {theme().background_tertiary};
+            }}
+        """)
+
+        self.time_label.setStyleSheet(f"""
+            color: {theme().text_muted};
+            font-family: monospace;
+            font-size: 11px;
+        """)
+
+        self.text_label.setStyleSheet(f"""
+            color: {theme().text_secondary};
+            padding: 2px;
+        """)
+
+        self.text_edit.setStyleSheet(f"""
+            QLineEdit {{
+                color: {theme().text_primary};
+                background-color: {theme().background_tertiary};
+                border: 1px solid {theme().border_focus};
+                border-radius: 4px;
+                padding: 2px 4px;
+            }}
+            QLineEdit:focus {{
+                border: 2px solid {theme().accent_blue};
+            }}
+        """)
+
+    def _format_time_range(self, start: float, end: float) -> str:
+        """Format time range as mm:ss - mm:ss."""
+        def fmt(t):
+            m = int(t // 60)
+            s = int(t % 60)
+            return f"{m}:{s:02d}"
+        return f"{fmt(start)} - {fmt(end)}"
+
+    def eventFilter(self, obj, event):
+        """Handle events for label and edit widgets."""
+        if obj == self.text_label:
+            if event.type() == event.Type.MouseButtonPress:
+                self._start_editing()
+                return True
+        elif obj == self.text_edit:
+            if event.type() == event.Type.FocusOut:
+                self._finish_editing()
+                return False
+            elif event.type() == event.Type.KeyPress:
+                if event.key() == Qt.Key_Escape:
+                    self._cancel_editing()
+                    return True
+        return super().eventFilter(obj, event)
+
+    def _start_editing(self):
+        """Enter edit mode."""
+        if self._is_editing:
+            return
+        self._is_editing = True
+
+        self.text_label.hide()
+        self.text_edit.setText(self._segment.text)
+        self.text_edit.show()
+        self.text_edit.setFocus()
+        self.text_edit.selectAll()
+
+    def _finish_editing(self):
+        """Exit edit mode and save changes."""
+        if not self._is_editing:
+            return
+        self._is_editing = False
+
+        new_text = self.text_edit.text().strip()
+        if new_text and new_text != self._segment.text:
+            self._segment.text = new_text
+            self.text_label.setText(new_text)
+            self.text_changed.emit(self._index, new_text)
+
+        self.text_edit.hide()
+        self.text_label.show()
+
+    def _cancel_editing(self):
+        """Cancel edit and revert to previous value."""
+        if not self._is_editing:
+            return
+        self._is_editing = False
+
+        self.text_edit.hide()
+        self.text_label.show()
+
+    def setEnabled(self, enabled: bool):
+        """Enable or disable editing."""
+        super().setEnabled(enabled)
+        if enabled:
+            self.text_label.setCursor(Qt.PointingHandCursor)
+        else:
+            self.text_label.setCursor(Qt.ArrowCursor)
+            if self._is_editing:
+                self._cancel_editing()
+
+
+class EditableTranscriptWidget(QWidget):
+    """Widget displaying editable transcript segments.
+
+    Signals:
+        segments_changed(list): Emitted when any segment text is edited
+    """
+
+    segments_changed = Signal(list)  # list[TranscriptSegment]
+
+    def __init__(self, parent=None):
+        """Create editable transcript widget.
+
+        Args:
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self._segments: list["TranscriptSegment"] = []
+        self._segment_widgets: list[TranscriptSegmentWidget] = []
+        self._change_in_progress = False
+
+        self._setup_ui()
+        theme().changed.connect(self._apply_style)
+
+    def _setup_ui(self):
+        """Build the widget UI."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # Container for segment widgets
+        self.container = QWidget()
+        self.container_layout = QVBoxLayout(self.container)
+        self.container_layout.setContentsMargins(0, 0, 0, 0)
+        self.container_layout.setSpacing(2)
+
+        # Empty state label
+        self.empty_label = QLabel("No transcript available")
+        self._apply_empty_style()
+        self.container_layout.addWidget(self.empty_label)
+
+        self.container_layout.addStretch()
+
+        layout.addWidget(self.container)
+
+    def _apply_style(self):
+        """Apply theme-aware styling."""
+        self._apply_empty_style()
+        for widget in self._segment_widgets:
+            widget._apply_style()
+
+    def _apply_empty_style(self):
+        """Apply styling to empty label."""
+        self.empty_label.setStyleSheet(f"""
+            color: {theme().text_muted};
+            font-style: italic;
+            padding: 8px;
+        """)
+
+    def setSegments(self, segments: Optional[list["TranscriptSegment"]]):
+        """Set transcript segments (doesn't emit signal).
+
+        Args:
+            segments: List of transcript segments, or None
+        """
+        self._change_in_progress = True
+
+        # Clear existing widgets
+        for widget in self._segment_widgets:
+            widget.deleteLater()
+        self._segment_widgets.clear()
+
+        self._segments = segments or []
+
+        if not self._segments:
+            self.empty_label.show()
+        else:
+            self.empty_label.hide()
+            # Create segment widgets
+            for i, segment in enumerate(self._segments):
+                widget = TranscriptSegmentWidget(i, segment)
+                widget.text_changed.connect(self._on_segment_changed)
+                self.container_layout.insertWidget(i, widget)
+                self._segment_widgets.append(widget)
+
+        self._change_in_progress = False
+
+    def segments(self) -> list["TranscriptSegment"]:
+        """Get current transcript segments."""
+        return self._segments
+
+    @Slot(int, str)
+    def _on_segment_changed(self, index: int, new_text: str):
+        """Handle segment text change."""
+        if self._change_in_progress:
+            return
+        self._change_in_progress = True
+
+        # Segment is already updated in-place by the widget
+        self.segments_changed.emit(self._segments)
+
+        self._change_in_progress = False
+
+    def setEnabled(self, enabled: bool):
+        """Enable or disable editing."""
+        super().setEnabled(enabled)
+        for widget in self._segment_widgets:
+            widget.setEnabled(enabled)

--- a/ui/widgets/shot_type_dropdown.py
+++ b/ui/widgets/shot_type_dropdown.py
@@ -1,0 +1,131 @@
+"""Shot type dropdown widget.
+
+A styled QComboBox for selecting shot type with immediate save on selection.
+"""
+
+from PySide6.QtCore import Signal, Slot
+from PySide6.QtWidgets import QComboBox
+
+from core.analysis.shots import SHOT_TYPES, SHOT_TYPE_DISPLAY
+from ui.theme import theme
+
+
+# Special value for unset shot type
+NOT_SET_VALUE = ""
+NOT_SET_DISPLAY = "(Not set)"
+
+
+class ShotTypeDropdown(QComboBox):
+    """Dropdown for selecting shot type.
+
+    Signals:
+        value_changed(str): Emitted when selection changes (value is shot type string or empty)
+    """
+
+    value_changed = Signal(str)
+
+    def __init__(self, parent=None):
+        """Create shot type dropdown.
+
+        Args:
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self._current_value = NOT_SET_VALUE
+        self._change_in_progress = False
+
+        self._setup_items()
+        self._apply_style()
+
+        self.currentIndexChanged.connect(self._on_selection_changed)
+        theme().changed.connect(self._apply_style)
+
+    def _setup_items(self):
+        """Populate dropdown with shot type options."""
+        # Add "Not set" option first
+        self.addItem(NOT_SET_DISPLAY, NOT_SET_VALUE)
+
+        # Add shot types with display names
+        for shot_type in SHOT_TYPES:
+            display_name = SHOT_TYPE_DISPLAY.get(shot_type, shot_type.title())
+            self.addItem(display_name, shot_type)
+
+    def _apply_style(self):
+        """Apply theme-aware styling."""
+        self.setStyleSheet(f"""
+            QComboBox {{
+                color: {theme().text_primary};
+                background-color: {theme().background_tertiary};
+                border: 1px solid {theme().border_secondary};
+                border-radius: 4px;
+                padding: 6px 12px;
+                min-width: 120px;
+            }}
+            QComboBox:hover {{
+                border-color: {theme().border_focus};
+            }}
+            QComboBox:focus {{
+                border: 2px solid {theme().accent_blue};
+            }}
+            QComboBox::drop-down {{
+                border: none;
+                padding-right: 8px;
+            }}
+            QComboBox::down-arrow {{
+                image: none;
+                border-left: 5px solid transparent;
+                border-right: 5px solid transparent;
+                border-top: 6px solid {theme().text_secondary};
+            }}
+            QComboBox QAbstractItemView {{
+                color: {theme().text_primary};
+                background-color: {theme().background_elevated};
+                border: 1px solid {theme().border_primary};
+                selection-background-color: {theme().accent_blue};
+                selection-color: {theme().text_inverted};
+            }}
+        """)
+
+    @Slot(int)
+    def _on_selection_changed(self, index: int):
+        """Handle selection change."""
+        if self._change_in_progress:
+            return
+        self._change_in_progress = True
+
+        new_value = self.itemData(index)
+        if new_value != self._current_value:
+            self._current_value = new_value
+            self.value_changed.emit(new_value)
+
+        self._change_in_progress = False
+
+    def setValue(self, shot_type: str | None):
+        """Set current value programmatically (doesn't emit signal).
+
+        Args:
+            shot_type: Shot type string or None/empty for "Not set"
+        """
+        self._change_in_progress = True
+
+        value = shot_type or NOT_SET_VALUE
+        self._current_value = value
+
+        # Find matching item
+        for i in range(self.count()):
+            if self.itemData(i) == value:
+                self.setCurrentIndex(i)
+                break
+        else:
+            # Value not found, default to "Not set"
+            self.setCurrentIndex(0)
+
+        self._change_in_progress = False
+
+    def value(self) -> str:
+        """Get current shot type value.
+
+        Returns:
+            Shot type string, or empty string if not set
+        """
+        return self._current_value


### PR DESCRIPTION
## Summary

This PR makes the clip details sidebar editable, allowing users to:

- **Edit clip name** - Click to edit inline, auto-save on blur/Enter, falls back to auto-generated name if empty
- **Edit shot type** - Dropdown with predefined categories (Wide, Medium, Close-up, Extreme CU, Not set)
- **Edit transcript** - Per-segment editing with timestamps displayed, preserving timing data while allowing text corrections

Changes persist to the project file automatically.

## Implementation

### New Widgets
- `ui/widgets/editable_label.py` - Dual-widget approach (QLabel + QLineEdit) with click-to-edit
- `ui/widgets/shot_type_dropdown.py` - Styled QComboBox with immediate save on selection
- `ui/widgets/editable_transcript.py` - Segment-by-segment editing with timestamp display

### Model Changes
- Added `name: str = ""` field to `Clip` dataclass
- Added `display_name()` method for fallback to auto-generated names
- Updated serialization for backwards compatibility

### Integration
- Sidebar emits `clip_edited` signal when fields change
- Main window forwards to `project.update_clips()` for persistence
- `clips_updated` signal propagates to ClipBrowser for display refresh
- Multi-selection disables editing and shows clip count

### Documented Patterns
- Signal handler guard flags prevent duplicate execution
- Signals blocked during programmatic updates
- Single source of truth via clip reference (not copies)

## Test Plan
- [x] Click clip name → enters edit mode
- [x] Blur/Enter saves name, Escape cancels
- [x] Empty name shows auto-generated placeholder
- [x] Shot type dropdown opens and saves immediately
- [x] Transcript segments show timestamps and editable text
- [x] Multi-selection shows count and disables editing
- [x] Changes persist after project save/load
- [x] All existing tests pass

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)