### PR TITLE
fix(description): limit default prompt to 3 sentences

### DIFF
--- a/cli/commands/analyze.py
+++ b/cli/commands/analyze.py
@@ -117,8 +117,8 @@ def describe(
 
     # Prepare prompt
     default_prompt = (
-        "Describe this video frame in detail. Focus on main subjects, "
-        "action, setting, and mood."
+        "Describe this video frame in 3 sentences or less. "
+        "Focus on the main subjects, action, and setting."
     )
     final_prompt = prompt or default_prompt
     

--- a/core/analysis/description.py
+++ b/core/analysis/description.py
@@ -187,7 +187,7 @@ def describe_frame_cloud(image_path: Path, prompt: str = "Describe this image.")
 def describe_frame(
     image_path: Path,
     tier: Optional[str] = None,
-    prompt: str = "Describe this video frame in detail. Focus on main subjects, action, setting, and mood."
+    prompt: str = "Describe this video frame in 3 sentences or less. Focus on the main subjects, action, and setting."
 ) -> tuple[str, str]:
     """Generate description for a video frame.
 

--- a/core/chat_tools.py
+++ b/core/chat_tools.py
@@ -438,7 +438,7 @@ def describe_content_live(
         return {"success": False, "error": "Description generation already in progress"}
 
     # Set default prompt if not provided
-    final_prompt = prompt or "Describe this video frame in detail. Keep the description concise, no longer than a single paragraph."
+    final_prompt = prompt or "Describe this video frame in 3 sentences or less. Focus on the main subjects, action, and setting."
 
     return {
         "_wait_for_worker": "description",

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -609,7 +609,7 @@ class DescriptionWorker(QThread):
                     description, model = describe_frame(
                         clip.thumbnail_path,
                         tier=self.tier,
-                        prompt=self.prompt or "Describe this video frame in detail."
+                        prompt=self.prompt or "Describe this video frame in 3 sentences or less. Focus on the main subjects, action, and setting."
                     )
                     # Only emit valid descriptions (not error messages)
                     if description and not description.startswith("Error"):


### PR DESCRIPTION
## Summary

Update the default prompt for description generation to request 3 sentences or less instead of detailed descriptions.

**Before:** "Describe this video frame in detail. Focus on main subjects, action, setting, and mood."

**After:** "Describe this video frame in 3 sentences or less. Focus on the main subjects, action, and setting."

## Why

More concise descriptions are:
- Easier to scan when reviewing many clips
- More consistent in length
- Better suited for display in the UI sidebar

## Files Changed

- `core/analysis/description.py` - Main function default
- `ui/main_window.py` - DescriptionWorker fallback  
- `cli/commands/analyze.py` - CLI default
- `core/chat_tools.py` - Agent tool default

All 4 locations now use the same consistent prompt.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)