### PR TITLE
refactor: simplify sidebar and editable text area code

### DIFF
--- a/ui/widgets/editable_text_area.py
+++ b/ui/widgets/editable_text_area.py
@@ -64,28 +64,21 @@ class EditableTextArea(QWidget):
 
     def _apply_style(self):
         """Apply theme-aware styling."""
-        # Label style - show hover indication
-        base_style = f"""
+        # Label style - use muted color for placeholder state
+        text_color = theme().text_muted if not self._text else theme().text_primary
+        font_style = "italic" if not self._text else "normal"
+
+        self.label.setStyleSheet(f"""
             QLabel {{
-                color: {theme().text_primary};
+                color: {text_color};
+                font-style: {font_style};
                 padding: 4px 8px;
                 border-radius: 4px;
             }}
             QLabel:hover {{
                 background-color: {theme().background_tertiary};
             }}
-        """
-
-        # Placeholder style when empty
-        if not self._text:
-            base_style += f"""
-                QLabel {{
-                    color: {theme().text_muted};
-                    font-style: italic;
-                }}
-            """
-
-        self.label.setStyleSheet(base_style)
+        """)
 
         # Edit field style
         self.edit.setStyleSheet(f"""


### PR DESCRIPTION
## Summary

Code simplifications identified by the code-simplifier agent.

## Changes

### clip_details_sidebar.py (-46 lines net)

**Consolidated guard flags:**
- Before: 5 separate `_*_change_in_progress` flags
- After: 1 unified `_change_in_progress` flag

**New helper methods:**
- `_emit_clip_edit()` - reduces duplication in change handlers
- `_block_editable_signals(block: bool)` - consolidates signal blocking/unblocking
- `_set_detected_objects_placeholder(text: str)` - consolidates placeholder styling

**Simplified change handlers:**
- Each handler now follows a consistent ~5 line pattern instead of 10-12 lines

### editable_text_area.py

- Simplified `_apply_style` with ternary expressions instead of string concatenation

## Testing

All 247 tests pass.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)