### PR TITLE
feat(chat): add export chat history to Markdown and JSON

### DIFF
--- a/core/chat_export.py
+++ b/core/chat_export.py
@@ -1,0 +1,330 @@
+"""Chat export functionality for exporting agent conversations to files."""
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class ChatExportConfig:
+    """Configuration for chat export."""
+
+    output_dir: Path
+    format: str  # "markdown", "json", "both"
+    include_user: bool = True
+    include_assistant: bool = True
+    include_tools: bool = True
+    include_tool_args: bool = False  # Verbose mode
+    project_name: str = ""
+
+
+def generate_export_filename(format_type: str) -> str:
+    """Generate a timestamped export filename.
+
+    Args:
+        format_type: File format ("md" or "json")
+
+    Returns:
+        Filename like "chat_2026-01-28_143022.md"
+    """
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+    return f"chat_{timestamp}.{format_type}"
+
+
+def _sanitize_path_in_content(content: str) -> str:
+    """Replace user home directory with ~ in content.
+
+    Args:
+        content: Text content that may contain paths
+
+    Returns:
+        Content with home directory replaced by ~
+    """
+    if not content:
+        return content
+
+    home_dir = os.path.expanduser("~")
+    return content.replace(home_dir, "~")
+
+
+def _format_tool_call_markdown(tool_call: dict, include_args: bool = False) -> str:
+    """Format a tool call for Markdown output.
+
+    Args:
+        tool_call: Tool call dict with id, type, function fields
+        include_args: Whether to include function arguments
+
+    Returns:
+        Formatted Markdown string
+    """
+    func = tool_call.get("function", {})
+    name = func.get("name", "unknown")
+
+    lines = [f"> **Tool:** {name}"]
+
+    if include_args:
+        args_str = func.get("arguments", "{}")
+        try:
+            args = json.loads(args_str) if isinstance(args_str, str) else args_str
+            if args:
+                args_formatted = json.dumps(args, indent=2)
+                lines.append(f"> **Arguments:**\n> ```json\n> {args_formatted}\n> ```")
+        except json.JSONDecodeError:
+            pass
+
+    return "\n".join(lines)
+
+
+def _format_tool_result_markdown(message: dict, include_args: bool = False) -> str:
+    """Format a tool result message for Markdown output.
+
+    Args:
+        message: Tool result message with role=tool
+        include_args: Whether to include full result content
+
+    Returns:
+        Formatted Markdown string
+    """
+    name = message.get("name", "unknown")
+    content = message.get("content", "")
+
+    lines = [f"> **Tool Result:** {name}"]
+
+    if include_args and content:
+        # Try to parse as JSON for pretty printing
+        try:
+            result = json.loads(content)
+            success = result.get("success", None)
+            if success is not None:
+                status = "Success" if success else "Failed"
+                lines.append(f"> **Status:** {status}")
+        except json.JSONDecodeError:
+            pass
+
+    return "\n".join(lines)
+
+
+def _filter_messages(
+    messages: list[dict],
+    include_user: bool,
+    include_assistant: bool,
+    include_tools: bool
+) -> list[dict]:
+    """Filter messages based on configuration.
+
+    Args:
+        messages: List of message dicts
+        include_user: Include user messages
+        include_assistant: Include assistant messages
+        include_tools: Include tool calls and results
+
+    Returns:
+        Filtered list of messages
+    """
+    filtered = []
+    for msg in messages:
+        role = msg.get("role", "")
+
+        if role == "user" and include_user:
+            filtered.append(msg)
+        elif role == "assistant":
+            if include_assistant:
+                # Check if it's a tool call message
+                has_tool_calls = "tool_calls" in msg
+                if has_tool_calls and not include_tools:
+                    # Skip tool call messages if tools not included
+                    continue
+                filtered.append(msg)
+        elif role == "tool" and include_tools:
+            filtered.append(msg)
+
+    return filtered
+
+
+def export_chat_as_markdown(
+    messages: list[dict],
+    config: ChatExportConfig
+) -> tuple[bool, str]:
+    """Export chat history as a Markdown file.
+
+    Args:
+        messages: List of message dicts from chat history
+        config: Export configuration
+
+    Returns:
+        Tuple of (success, filepath_or_error)
+    """
+    # Filter messages
+    filtered = _filter_messages(
+        messages,
+        config.include_user,
+        config.include_assistant,
+        config.include_tools
+    )
+
+    if not filtered:
+        return False, "No messages to export after filtering"
+
+    # Build Markdown content
+    lines = [
+        "# Agent Chat Export",
+        "",
+        f"**Exported:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+    ]
+
+    if config.project_name:
+        lines.append(f"**Project:** {config.project_name}")
+
+    lines.extend([
+        f"**Messages:** {len(filtered)}",
+        "",
+        "---",
+        ""
+    ])
+
+    for msg in filtered:
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+
+        # Sanitize paths in content
+        content = _sanitize_path_in_content(content)
+
+        if role == "user":
+            lines.extend([
+                "## User",
+                "",
+                content,
+                "",
+                "---",
+                ""
+            ])
+        elif role == "assistant":
+            lines.extend([
+                "## Assistant",
+                ""
+            ])
+
+            if content:
+                lines.extend([content, ""])
+
+            # Handle tool calls
+            if "tool_calls" in msg and config.include_tools:
+                for tool_call in msg["tool_calls"]:
+                    lines.extend([
+                        _format_tool_call_markdown(tool_call, config.include_tool_args),
+                        ""
+                    ])
+
+            lines.extend(["---", ""])
+
+        elif role == "tool":
+            lines.extend([
+                _format_tool_result_markdown(msg, config.include_tool_args),
+                "",
+                "---",
+                ""
+            ])
+
+    # Generate filename and write
+    filename = generate_export_filename("md")
+    output_path = config.output_dir / filename
+
+    try:
+        output_path.write_text("\n".join(lines), encoding="utf-8")
+        return True, str(output_path)
+    except (OSError, IOError) as e:
+        return False, f"Failed to write file: {e}"
+
+
+def export_chat_as_json(
+    messages: list[dict],
+    config: ChatExportConfig
+) -> tuple[bool, str]:
+    """Export chat history as a JSON file.
+
+    Args:
+        messages: List of message dicts from chat history
+        config: Export configuration
+
+    Returns:
+        Tuple of (success, filepath_or_error)
+    """
+    # Filter messages
+    filtered = _filter_messages(
+        messages,
+        config.include_user,
+        config.include_assistant,
+        config.include_tools
+    )
+
+    if not filtered:
+        return False, "No messages to export after filtering"
+
+    # Sanitize paths in messages
+    sanitized_messages = []
+    for msg in filtered:
+        sanitized = msg.copy()
+        if "content" in sanitized:
+            sanitized["content"] = _sanitize_path_in_content(sanitized["content"])
+        sanitized_messages.append(sanitized)
+
+    # Build JSON structure
+    export_data = {
+        "version": "1.0",
+        "exported_at": datetime.now().isoformat(),
+        "project": {
+            "name": config.project_name or "Unnamed Project"
+        },
+        "message_count": len(sanitized_messages),
+        "messages": sanitized_messages
+    }
+
+    # Generate filename and write
+    filename = generate_export_filename("json")
+    output_path = config.output_dir / filename
+
+    try:
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(export_data, f, indent=2, ensure_ascii=False)
+        return True, str(output_path)
+    except (OSError, IOError) as e:
+        return False, f"Failed to write file: {e}"
+
+
+def export_chat(
+    messages: list[dict],
+    config: ChatExportConfig
+) -> tuple[bool, list[str], str]:
+    """Export chat history based on configuration.
+
+    Args:
+        messages: List of message dicts from chat history
+        config: Export configuration
+
+    Returns:
+        Tuple of (success, list_of_created_files, error_message)
+    """
+    created_files = []
+    errors = []
+
+    if config.format in ("markdown", "both"):
+        success, result = export_chat_as_markdown(messages, config)
+        if success:
+            created_files.append(result)
+        else:
+            errors.append(f"Markdown: {result}")
+
+    if config.format in ("json", "both"):
+        success, result = export_chat_as_json(messages, config)
+        if success:
+            created_files.append(result)
+        else:
+            errors.append(f"JSON: {result}")
+
+    if errors:
+        return False, created_files, "; ".join(errors)
+
+    return True, created_files, ""

--- a/docs/plans/2026-01-28-feat-export-agent-chat-history-plan.md
+++ b/docs/plans/2026-01-28-feat-export-agent-chat-history-plan.md
@@ -1,0 +1,301 @@
+---
+title: Export Agent Chat History
+type: feat
+date: 2026-01-28
+---
+
+# Export Agent Chat History
+
+## Overview
+
+Add the ability to export agent chat conversations to files for later review and error analysis. Supports both Markdown (human-readable) and JSON (machine-parseable) formats with configurable content options.
+
+## Problem Statement / Motivation
+
+Users need to:
+1. **Review conversations later** - Reference past agent interactions for learning or documentation
+2. **Report issues** - Provide chat history when reporting bugs or unexpected agent behavior
+3. **Share workflows** - Export successful workflows to share with others or as templates
+
+Currently, chat history only exists in memory and is lost when the app closes or chat is cleared.
+
+## Proposed Solution
+
+Add an "Export Chat" button to the chat panel header that opens an export dialog with format and content options. When exporting both formats, user selects a folder and files are auto-generated with timestamped names.
+
+### User Flow
+
+```
+User clicks "Export Chat" button (next to Clear)
+         │
+         ▼
+┌─────────────────────────────┐
+│   Export Chat Dialog        │
+├─────────────────────────────┤
+│ Format:                     │
+│ ○ Markdown (.md)            │
+│ ○ JSON (.json)              │
+│ ● Both formats              │
+├─────────────────────────────┤
+│ Include:                    │
+│ ☑ User messages             │
+│ ☑ Assistant responses       │
+│ ☑ Tool calls & results      │
+│ ☐ Tool arguments (verbose)  │
+├─────────────────────────────┤
+│        [Cancel] [Export]    │
+└─────────────────────────────┘
+         │
+         ▼ (User clicks Export)
+┌─────────────────────────────┐
+│ Select Export Folder        │
+│ (QFileDialog directory)     │
+└─────────────────────────────┘
+         │
+         ▼
+Files created:
+  chat_2026-01-28_143022.md
+  chat_2026-01-28_143022.json
+         │
+         ▼
+Success toast + "Open Folder" option
+```
+
+## Technical Approach
+
+### Architecture
+
+```
+ui/chat_panel.py
+    │
+    ├── _export_button (QPushButton)
+    │       │
+    │       └── clicked → _on_export_clicked()
+    │                          │
+    │                          ▼
+    │                   ExportChatDialog
+    │                          │
+    │                          ▼
+    │                   QFileDialog.getExistingDirectory()
+    │                          │
+    │                          ▼
+    └──────────────────► core/chat_export.py
+                              │
+                              ├── export_chat_as_markdown()
+                              └── export_chat_as_json()
+```
+
+### Files to Create/Modify
+
+| File | Changes |
+|------|---------|
+| `core/chat_export.py` | **NEW** - Export logic with `ChatExportConfig`, `export_chat_as_markdown()`, `export_chat_as_json()` |
+| `ui/chat_panel.py` | Add Export button, `_on_export_clicked()` handler |
+| `ui/export_chat_dialog.py` | **NEW** - Export options dialog |
+| `ui/main_window.py` | Pass chat history to export functions |
+
+### Data Structures
+
+**ChatExportConfig:**
+```python
+@dataclass
+class ChatExportConfig:
+    output_dir: Path
+    format: str  # "markdown", "json", "both"
+    include_user: bool = True
+    include_assistant: bool = True
+    include_tools: bool = True
+    include_tool_args: bool = False  # Verbose mode
+    project_name: str = ""
+```
+
+**Message Structure (existing in `_chat_history`):**
+```python
+# User message
+{"role": "user", "content": "..."}
+
+# Assistant message
+{"role": "assistant", "content": "..."}
+
+# Assistant with tool call
+{"role": "assistant", "content": "", "tool_calls": [
+    {"id": "...", "type": "function", "function": {"name": "...", "arguments": "..."}}
+]}
+
+# Tool result
+{"role": "tool", "tool_call_id": "...", "name": "...", "content": "..."}
+```
+
+### Export Formats
+
+**Markdown Format:**
+```markdown
+# Agent Chat Export
+
+**Exported:** 2026-01-28 14:30:22
+**Project:** My Video Project
+**Messages:** 15
+
+---
+
+## User
+
+Detect scenes in my video
+
+---
+
+## Assistant
+
+I'll analyze your video for scenes.
+
+> **Tool:** detect_scenes
+> **Status:** Success
+
+---
+
+## Assistant
+
+I detected 12 scenes in your video. Here's what I found...
+
+---
+```
+
+**JSON Format:**
+```json
+{
+  "version": "1.0",
+  "exported_at": "2026-01-28T14:30:22",
+  "project": {
+    "name": "My Video Project",
+    "path": "/path/to/project.sceneripper"
+  },
+  "message_count": 15,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Detect scenes in my video"
+    },
+    {
+      "role": "assistant",
+      "content": "I'll analyze your video for scenes.",
+      "tool_calls": [...]
+    }
+  ]
+}
+```
+
+### Implementation Phases
+
+#### Phase 1: Core Export Logic
+
+Create `core/chat_export.py`:
+
+- [x] Create `ChatExportConfig` dataclass
+- [x] Implement `export_chat_as_markdown(messages, config) -> bool`
+- [x] Implement `export_chat_as_json(messages, config) -> bool`
+- [x] Implement `_format_tool_call_markdown(tool_call, include_args) -> str`
+- [x] Implement `_sanitize_path_in_content(content) -> str` (replace home dir with `~`)
+- [x] Add `generate_export_filename(format: str) -> str` helper
+
+#### Phase 2: Export Dialog
+
+Create `ui/export_chat_dialog.py`:
+
+- [x] Create `ExportChatDialog(QDialog)` class
+- [x] Add format radio buttons (Markdown / JSON / Both)
+- [x] Add content checkboxes (user, assistant, tools, tool args)
+- [x] Add preview count label ("X messages will be exported")
+- [x] Implement `get_config() -> ChatExportConfig` method
+- [x] Style dialog to match app theme
+
+#### Phase 3: Chat Panel Integration
+
+Modify `ui/chat_panel.py`:
+
+- [x] Add "Export" button next to "Clear" button in header
+- [x] Implement `_on_export_clicked()` slot
+- [x] Disable Export button when chat is empty
+- [x] Disable Export button during streaming
+- [x] Add tooltip explaining disabled state
+
+#### Phase 4: MainWindow Wiring
+
+Modify `ui/main_window.py`:
+
+- [x] Add `export_chat_requested` signal handling
+- [x] Pass `_chat_history` to export dialog
+- [x] Show folder selection dialog after options confirmed
+- [x] Call export functions with config
+- [x] Show success/error feedback
+- [x] Offer "Open Folder" after successful export
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [x] Export button visible next to Clear button in chat panel header
+- [x] Export button disabled when chat is empty (with tooltip)
+- [x] Export button disabled during streaming
+- [x] Export dialog shows format options (Markdown, JSON, Both)
+- [x] Export dialog shows content checkboxes
+- [x] Selecting "Both" exports two files to chosen folder
+- [x] Exported Markdown is human-readable with clear formatting
+- [x] Exported JSON is valid and parseable
+- [x] User home directory paths replaced with `~` in exports
+- [x] Success toast shown after export with "Open Folder" option
+- [x] Error handling for write failures (permissions, disk full)
+
+### Non-Functional Requirements
+
+- [x] Export completes in < 1 second for typical conversations (< 100 messages)
+- [x] Files use UTF-8 encoding
+- [x] JSON is pretty-printed with 2-space indent
+- [x] Filenames include timestamp to prevent overwrites
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Empty chat | Export button disabled, tooltip: "No messages to export" |
+| Streaming in progress | Export button disabled, tooltip: "Wait for response to complete" |
+| Write permission denied | Error dialog with specific message |
+| Very long conversation (1000+ messages) | Export proceeds normally (no truncation) |
+| Tool call with no result yet | Skip tool result, include call only |
+| Cancelled response in history | Include with "(Cancelled)" indicator |
+
+## Privacy Considerations
+
+Content that gets sanitized:
+- User home directory paths → replaced with `~`
+- Absolute project paths → replaced with relative or `~` prefix
+
+Content that is NOT filtered (user responsibility):
+- Video URLs (may contain identifying info)
+- Custom prompts
+- Error messages (may contain paths)
+
+## Dependencies & Prerequisites
+
+- Existing `_chat_history` list in MainWindow
+- Existing `QFileDialog` patterns in codebase
+- Existing export patterns in `core/dataset_export.py`
+
+## Success Metrics
+
+- Users can successfully export chat to reviewable files
+- Exported JSON can be loaded back for analysis
+- No data loss in export (all selected content preserved)
+
+## References
+
+### Internal References
+
+- Chat history storage: `ui/main_window.py:1252-1256`
+- Existing export patterns: `core/dataset_export.py`, `core/edl_export.py`
+- File dialog patterns: `ui/main_window.py:3961-3972`
+- Chat panel header: `ui/chat_panel.py`
+
+### Institutional Learnings
+
+- Path sanitization security: `docs/solutions/security-issues/ffmpeg-path-escaping-20260124.md`
+- Export config pattern: `docs/plans/archive/2026-01-24-feat-edl-export-plan.md`

--- a/ui/export_chat_dialog.py
+++ b/ui/export_chat_dialog.py
@@ -1,0 +1,146 @@
+"""Export chat dialog for configuring chat history export."""
+
+from pathlib import Path
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QRadioButton,
+    QVBoxLayout,
+)
+
+from core.chat_export import ChatExportConfig
+
+
+class ExportChatDialog(QDialog):
+    """Dialog for configuring chat export options."""
+
+    def __init__(self, message_count: int, parent=None):
+        """Initialize the export chat dialog.
+
+        Args:
+            message_count: Number of messages in chat history
+            parent: Parent widget
+        """
+        super().__init__(parent)
+        self._message_count = message_count
+        self._setup_ui()
+
+    def _setup_ui(self):
+        """Set up the dialog UI."""
+        self.setWindowTitle("Export Chat")
+        self.setMinimumWidth(350)
+        self.setModal(True)
+
+        layout = QVBoxLayout(self)
+        layout.setSpacing(16)
+
+        # Format selection
+        format_group = QGroupBox("Export Format")
+        format_layout = QVBoxLayout(format_group)
+
+        self._format_group = QButtonGroup(self)
+
+        self._md_radio = QRadioButton("Markdown (.md)")
+        self._md_radio.setToolTip("Human-readable format, good for reviewing")
+        self._format_group.addButton(self._md_radio)
+        format_layout.addWidget(self._md_radio)
+
+        self._json_radio = QRadioButton("JSON (.json)")
+        self._json_radio.setToolTip("Machine-parseable format, good for analysis")
+        self._format_group.addButton(self._json_radio)
+        format_layout.addWidget(self._json_radio)
+
+        self._both_radio = QRadioButton("Both formats")
+        self._both_radio.setToolTip("Export both Markdown and JSON files")
+        self._both_radio.setChecked(True)
+        self._format_group.addButton(self._both_radio)
+        format_layout.addWidget(self._both_radio)
+
+        layout.addWidget(format_group)
+
+        # Content selection
+        content_group = QGroupBox("Include Content")
+        content_layout = QVBoxLayout(content_group)
+
+        self._user_check = QCheckBox("User messages")
+        self._user_check.setChecked(True)
+        self._user_check.stateChanged.connect(self._update_preview)
+        content_layout.addWidget(self._user_check)
+
+        self._assistant_check = QCheckBox("Assistant responses")
+        self._assistant_check.setChecked(True)
+        self._assistant_check.stateChanged.connect(self._update_preview)
+        content_layout.addWidget(self._assistant_check)
+
+        self._tools_check = QCheckBox("Tool calls && results")
+        self._tools_check.setChecked(True)
+        self._tools_check.stateChanged.connect(self._update_preview)
+        content_layout.addWidget(self._tools_check)
+
+        self._tool_args_check = QCheckBox("Tool arguments (verbose)")
+        self._tool_args_check.setChecked(False)
+        self._tool_args_check.setToolTip("Include full tool arguments and results")
+        content_layout.addWidget(self._tool_args_check)
+
+        layout.addWidget(content_group)
+
+        # Preview count
+        self._preview_label = QLabel()
+        self._preview_label.setStyleSheet("color: #666; font-style: italic;")
+        self._update_preview()
+        layout.addWidget(self._preview_label)
+
+        # Dialog buttons
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.Cancel | QDialogButtonBox.Ok
+        )
+        button_box.button(QDialogButtonBox.Ok).setText("Export")
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def _update_preview(self):
+        """Update the preview message count."""
+        # Simple estimate - actual filtering happens during export
+        count = self._message_count
+        self._preview_label.setText(f"Approximately {count} messages will be exported")
+
+    def get_format(self) -> str:
+        """Get the selected export format.
+
+        Returns:
+            "markdown", "json", or "both"
+        """
+        if self._md_radio.isChecked():
+            return "markdown"
+        elif self._json_radio.isChecked():
+            return "json"
+        else:
+            return "both"
+
+    def get_config(self, output_dir: Path, project_name: str = "") -> ChatExportConfig:
+        """Get the export configuration based on dialog selections.
+
+        Args:
+            output_dir: Directory to export files to
+            project_name: Name of the current project
+
+        Returns:
+            ChatExportConfig with selected options
+        """
+        return ChatExportConfig(
+            output_dir=output_dir,
+            format=self.get_format(),
+            include_user=self._user_check.isChecked(),
+            include_assistant=self._assistant_check.isChecked(),
+            include_tools=self._tools_check.isChecked(),
+            include_tool_args=self._tool_args_check.isChecked(),
+            project_name=project_name
+        )


### PR DESCRIPTION
## Summary

- Add Export button to chat panel header (next to Clear button)
- Support exporting to Markdown, JSON, or both formats simultaneously
- Configurable content options: user messages, assistant responses, tool calls, verbose tool arguments
- Auto-generated timestamped filenames prevent overwrites
- Path sanitization replaces home directory with `~` for privacy
- Success dialog offers "Open Folder" option after export

## Test plan

- [ ] Click Export button when chat is empty (should be disabled with tooltip)
- [ ] Send a few messages to agent, then click Export
- [ ] Verify export dialog shows format and content options
- [ ] Export as Markdown only - verify readable format with headers
- [ ] Export as JSON only - verify valid, pretty-printed JSON
- [ ] Export as Both - verify two files created with same timestamp
- [ ] Verify "Open Folder" button in success dialog works
- [ ] Verify home directory paths are replaced with `~` in exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)