### PR TITLE
feat(sequence): add intention-first workflow

### DIFF
--- a/core/intention_workflow.py
+++ b/core/intention_workflow.py
@@ -1,0 +1,562 @@
+"""Intention-First Workflow Coordinator.
+
+Orchestrates the multi-step flow when a user clicks a sequence card with no clips:
+Import -> Download (if URLs) -> Detect scenes -> Generate thumbnails -> Analyze (if needed) -> Build sequence
+"""
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtCore import QObject, Signal
+
+logger = logging.getLogger(__name__)
+
+
+class WorkflowState(Enum):
+    """States of the intention-first workflow."""
+
+    IDLE = auto()
+    DOWNLOADING = auto()
+    DETECTING = auto()
+    THUMBNAILS = auto()
+    ANALYZING = auto()
+    BUILDING = auto()
+    COMPLETE = auto()
+    CANCELLED = auto()
+    ERROR = auto()
+
+
+@dataclass
+class WorkflowProgress:
+    """Progress information for the current workflow step."""
+
+    state: WorkflowState
+    current_step: int  # 1-based step number
+    total_steps: int
+    step_progress: float  # 0.0 to 1.0
+    message: str
+    sources_processed: int = 0
+    sources_total: int = 0
+    clips_created: int = 0
+
+
+@dataclass
+class WorkflowResult:
+    """Result of the workflow execution."""
+
+    success: bool
+    algorithm: str
+    clips_created: int
+    sources_processed: int
+    sources_failed: int
+    error_message: Optional[str] = None
+    failed_sources: list = field(default_factory=list)
+
+
+class IntentionWorkflowCoordinator(QObject):
+    """Coordinates the intention-first workflow for sequence creation.
+
+    This class orchestrates the multi-step flow when a user clicks a sequence
+    card but has no clips. It manages:
+    1. URL downloads (if any URLs provided)
+    2. Scene detection for each source
+    3. Thumbnail generation
+    4. Analysis (if required by the algorithm, e.g., colors for Color sequence)
+    5. Sequence building
+
+    The coordinator uses guard flags to prevent duplicate signal handling
+    (a documented gotcha from docs/solutions/).
+    """
+
+    # Signals for progress updates
+    progress_updated = Signal(object)  # WorkflowProgress
+    step_started = Signal(str, int, int)  # step_name, current, total
+    step_completed = Signal(str)  # step_name
+    step_skipped = Signal(str)  # step_name
+    workflow_completed = Signal(object)  # WorkflowResult
+    workflow_cancelled = Signal()
+    workflow_error = Signal(str)  # error message
+
+    # Analysis requirements by algorithm
+    ANALYSIS_REQUIREMENTS = {
+        "color": ["colors"],  # Needs color analysis
+        "duration": [],  # Duration comes from detection
+        "shuffle": [],  # No analysis needed
+        "sequential": [],  # No analysis needed
+    }
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        # Workflow state
+        self._state = WorkflowState.IDLE
+        self._algorithm: str = ""
+        self._direction: Optional[str] = None
+        self._local_files: list[Path] = []
+        self._urls: list[str] = []
+        self._cancelled = False
+
+        # Processing state
+        self._sources_to_process: list = []  # Sources waiting for detection
+        self._sources_processed: list = []  # Successfully processed sources
+        self._sources_failed: list[dict] = []  # Failed sources with errors
+        self._all_clips: list = []  # All clips created
+        self._current_source_index = 0
+
+        # Guard flags to prevent duplicate signal handling
+        # (Critical pattern from docs/solutions/qthread-destroyed-duplicate-signal-delivery)
+        self._download_finished_handled = False
+        self._detection_finished_handled = False
+        self._thumbnails_finished_handled = False
+        self._analysis_finished_handled = False
+
+        # Worker references (set by MainWindow when connecting)
+        self._download_worker = None
+        self._detection_worker = None
+        self._thumbnail_worker = None
+        self._color_worker = None
+
+        logger.info("IntentionWorkflowCoordinator initialized")
+
+    @property
+    def state(self) -> WorkflowState:
+        """Current workflow state."""
+        return self._state
+
+    @property
+    def algorithm(self) -> str:
+        """The sequence algorithm being built."""
+        return self._algorithm
+
+    @property
+    def is_running(self) -> bool:
+        """Whether the workflow is currently running."""
+        return self._state not in (
+            WorkflowState.IDLE,
+            WorkflowState.COMPLETE,
+            WorkflowState.CANCELLED,
+            WorkflowState.ERROR,
+        )
+
+    def start(
+        self,
+        algorithm: str,
+        local_files: list[Path],
+        urls: list[str],
+        direction: Optional[str] = None,
+    ) -> bool:
+        """Start the intention workflow.
+
+        Args:
+            algorithm: The sequence algorithm (color, duration, shuffle, sequential)
+            local_files: List of local video file paths
+            urls: List of YouTube/Vimeo URLs to download
+            direction: Optional direction for the algorithm (e.g., "rainbow" for color)
+
+        Returns:
+            True if workflow started, False if already running
+        """
+        if self.is_running:
+            logger.warning("Workflow already running, cannot start new workflow")
+            return False
+
+        logger.info(f"Starting intention workflow: algorithm={algorithm}, "
+                    f"files={len(local_files)}, urls={len(urls)}")
+
+        # Reset state
+        self._reset()
+        self._algorithm = algorithm
+        self._direction = direction
+        self._local_files = list(local_files)
+        self._urls = list(urls)
+
+        # Determine first step
+        if urls:
+            self._state = WorkflowState.DOWNLOADING
+            self._emit_progress("Starting downloads...")
+            self.step_started.emit("downloading", 1, self._calculate_total_steps())
+        elif local_files:
+            # Skip download, go straight to detection
+            self._sources_to_process = [{"path": f, "type": "local"} for f in local_files]
+            self._state = WorkflowState.DETECTING
+            self._emit_progress("Starting scene detection...")
+            self.step_started.emit("detecting", 1, self._calculate_total_steps())
+        else:
+            # No inputs - error
+            self._state = WorkflowState.ERROR
+            self.workflow_error.emit("No files or URLs provided")
+            return False
+
+        return True
+
+    def cancel(self):
+        """Cancel the running workflow."""
+        if not self.is_running:
+            return
+
+        logger.info("Cancelling intention workflow")
+        self._cancelled = True
+        self._state = WorkflowState.CANCELLED
+
+        # Cancel any running workers
+        if self._download_worker and hasattr(self._download_worker, 'cancel'):
+            self._download_worker.cancel()
+        if self._detection_worker and hasattr(self._detection_worker, 'cancel'):
+            self._detection_worker.cancel()
+        if self._color_worker and hasattr(self._color_worker, 'cancel'):
+            self._color_worker.cancel()
+
+        self.workflow_cancelled.emit()
+
+    def _reset(self):
+        """Reset all workflow state for a new run."""
+        self._state = WorkflowState.IDLE
+        self._algorithm = ""
+        self._direction = None
+        self._local_files = []
+        self._urls = []
+        self._cancelled = False
+
+        self._sources_to_process = []
+        self._sources_processed = []
+        self._sources_failed = []
+        self._all_clips = []
+        self._current_source_index = 0
+
+        # Reset guard flags
+        self._download_finished_handled = False
+        self._detection_finished_handled = False
+        self._thumbnails_finished_handled = False
+        self._analysis_finished_handled = False
+
+    def _calculate_total_steps(self) -> int:
+        """Calculate total number of steps in the workflow."""
+        steps = 0
+        if self._urls:
+            steps += 1  # Download
+        steps += 1  # Detection
+        steps += 1  # Thumbnails
+        if self._needs_analysis():
+            steps += 1  # Analysis
+        steps += 1  # Build sequence
+        return steps
+
+    def _needs_analysis(self) -> bool:
+        """Check if the algorithm requires analysis."""
+        requirements = self.ANALYSIS_REQUIREMENTS.get(self._algorithm, [])
+        return len(requirements) > 0
+
+    def _get_current_step_number(self) -> int:
+        """Get the current step number (1-based)."""
+        step = 0
+        if self._state == WorkflowState.DOWNLOADING:
+            return 1
+        if self._urls:
+            step += 1
+
+        if self._state == WorkflowState.DETECTING:
+            return step + 1
+        step += 1
+
+        if self._state == WorkflowState.THUMBNAILS:
+            return step + 1
+        step += 1
+
+        if self._state == WorkflowState.ANALYZING:
+            return step + 1
+        if self._needs_analysis():
+            step += 1
+
+        if self._state == WorkflowState.BUILDING:
+            return step + 1
+
+        return step + 1
+
+    def _emit_progress(self, message: str, step_progress: float = 0.0):
+        """Emit a progress update."""
+        progress = WorkflowProgress(
+            state=self._state,
+            current_step=self._get_current_step_number(),
+            total_steps=self._calculate_total_steps(),
+            step_progress=step_progress,
+            message=message,
+            sources_processed=len(self._sources_processed),
+            sources_total=len(self._local_files) + len(self._urls),
+            clips_created=len(self._all_clips),
+        )
+        self.progress_updated.emit(progress)
+
+    # --- Download phase handlers ---
+
+    def on_download_progress(self, current: int, total: int, message: str):
+        """Handle download progress from URLBulkDownloadWorker."""
+        if self._state != WorkflowState.DOWNLOADING or self._cancelled:
+            return
+        progress = current / total if total > 0 else 0
+        self._emit_progress(message, progress)
+
+    def on_download_video_finished(self, url: str, result):
+        """Handle individual video download completion."""
+        if self._state != WorkflowState.DOWNLOADING or self._cancelled:
+            return
+
+        if result and result.success and result.file_path:
+            # Add to sources to process
+            self._sources_to_process.append({
+                "path": Path(result.file_path),
+                "type": "downloaded",
+                "url": url,
+            })
+            logger.info(f"Download complete: {url} -> {result.file_path}")
+        else:
+            error = result.error if result else "Unknown error"
+            self._sources_failed.append({"url": url, "error": error})
+            logger.warning(f"Download failed: {url} - {error}")
+
+    def on_download_all_finished(self, results: list):
+        """Handle all downloads completed."""
+        if self._download_finished_handled:
+            logger.warning("Download finished already handled, ignoring duplicate")
+            return
+        self._download_finished_handled = True
+
+        if self._cancelled:
+            return
+
+        logger.info(f"All downloads complete: {len(self._sources_to_process)} succeeded, "
+                    f"{len(self._sources_failed)} failed")
+
+        # Add local files to the processing queue
+        for f in self._local_files:
+            self._sources_to_process.append({"path": f, "type": "local"})
+
+        self.step_completed.emit("downloading")
+
+        # Move to detection phase
+        if self._sources_to_process:
+            self._state = WorkflowState.DETECTING
+            self.step_started.emit("detecting", self._get_current_step_number(),
+                                   self._calculate_total_steps())
+            self._emit_progress("Starting scene detection...")
+            # Signal that detection should start - MainWindow will handle
+        else:
+            # All downloads failed
+            self._complete_with_error("All downloads failed")
+
+    # --- Detection phase handlers ---
+
+    def on_detection_progress(self, progress: float, message: str):
+        """Handle detection progress."""
+        if self._state != WorkflowState.DETECTING or self._cancelled:
+            return
+
+        # Calculate overall progress across all sources
+        source_count = len(self._sources_to_process)
+        if source_count > 0:
+            base_progress = self._current_source_index / source_count
+            source_progress = progress / source_count
+            overall = base_progress + source_progress
+        else:
+            overall = progress
+
+        self._emit_progress(message, overall)
+
+    def on_detection_completed(self, source, clips: list):
+        """Handle detection completion for a single source."""
+        if self._detection_finished_handled:
+            logger.warning("Detection finished already handled, ignoring duplicate")
+            return
+
+        if self._cancelled:
+            return
+
+        logger.info(f"Detection complete for source: {source.id}, {len(clips)} clips")
+
+        # Store results
+        self._sources_processed.append(source)
+        self._all_clips.extend(clips)
+
+        # Move to next source or next phase
+        self._current_source_index += 1
+
+        if self._current_source_index < len(self._sources_to_process):
+            # More sources to detect
+            self._emit_progress(
+                f"Detecting scenes ({self._current_source_index + 1}/{len(self._sources_to_process)})..."
+            )
+            # MainWindow will start next detection
+        else:
+            # All sources detected, move to thumbnails
+            self._detection_finished_handled = True
+            self.step_completed.emit("detecting")
+            self._advance_to_thumbnails()
+
+    def on_detection_error(self, error: str):
+        """Handle detection error for a source."""
+        if self._cancelled:
+            return
+
+        logger.warning(f"Detection error: {error}")
+
+        # Record the failure
+        if self._current_source_index < len(self._sources_to_process):
+            source_info = self._sources_to_process[self._current_source_index]
+            self._sources_failed.append({
+                "path": str(source_info.get("path", "unknown")),
+                "error": error,
+            })
+
+        # Move to next source
+        self._current_source_index += 1
+
+        if self._current_source_index < len(self._sources_to_process):
+            # More sources to detect
+            self._emit_progress(
+                f"Detecting scenes ({self._current_source_index + 1}/{len(self._sources_to_process)})..."
+            )
+        else:
+            # All sources attempted
+            self._detection_finished_handled = True
+            self.step_completed.emit("detecting")
+
+            if self._all_clips:
+                # We have some clips, continue
+                self._advance_to_thumbnails()
+            else:
+                # No clips at all
+                self._complete_with_error("Scene detection failed for all sources")
+
+    def _advance_to_thumbnails(self):
+        """Advance workflow to thumbnail generation phase."""
+        self._state = WorkflowState.THUMBNAILS
+        self.step_started.emit("thumbnails", self._get_current_step_number(),
+                               self._calculate_total_steps())
+        self._emit_progress("Generating thumbnails...")
+
+    # --- Thumbnail phase handlers ---
+
+    def on_thumbnail_progress(self, current: int, total: int):
+        """Handle thumbnail generation progress."""
+        if self._state != WorkflowState.THUMBNAILS or self._cancelled:
+            return
+        progress = current / total if total > 0 else 0
+        self._emit_progress(f"Generating thumbnails ({current}/{total})...", progress)
+
+    def on_thumbnails_finished(self):
+        """Handle thumbnail generation completion."""
+        if self._thumbnails_finished_handled:
+            logger.warning("Thumbnails finished already handled, ignoring duplicate")
+            return
+        self._thumbnails_finished_handled = True
+
+        if self._cancelled:
+            return
+
+        logger.info("Thumbnail generation complete")
+        self.step_completed.emit("thumbnails")
+
+        # Decide next step
+        if self._needs_analysis():
+            self._state = WorkflowState.ANALYZING
+            self.step_started.emit("analyzing", self._get_current_step_number(),
+                                   self._calculate_total_steps())
+            self._emit_progress("Analyzing clips...")
+        else:
+            self.step_skipped.emit("analyzing")
+            self._advance_to_building()
+
+    # --- Analysis phase handlers ---
+
+    def on_analysis_progress(self, current: int, total: int):
+        """Handle analysis progress."""
+        if self._state != WorkflowState.ANALYZING or self._cancelled:
+            return
+        progress = current / total if total > 0 else 0
+        self._emit_progress(f"Analyzing clips ({current}/{total})...", progress)
+
+    def on_analysis_finished(self):
+        """Handle analysis completion."""
+        if self._analysis_finished_handled:
+            logger.warning("Analysis finished already handled, ignoring duplicate")
+            return
+        self._analysis_finished_handled = True
+
+        if self._cancelled:
+            return
+
+        logger.info("Analysis complete")
+        self.step_completed.emit("analyzing")
+        self._advance_to_building()
+
+    def _advance_to_building(self):
+        """Advance workflow to sequence building phase."""
+        self._state = WorkflowState.BUILDING
+        self.step_started.emit("building", self._get_current_step_number(),
+                               self._calculate_total_steps())
+        self._emit_progress("Building sequence...")
+
+    # --- Building phase handlers ---
+
+    def on_building_complete(self, sequence_clips: list):
+        """Handle sequence building completion."""
+        if self._cancelled:
+            return
+
+        logger.info(f"Sequence built with {len(sequence_clips)} clips")
+        self.step_completed.emit("building")
+        self._state = WorkflowState.COMPLETE
+
+        result = WorkflowResult(
+            success=True,
+            algorithm=self._algorithm,
+            clips_created=len(self._all_clips),
+            sources_processed=len(self._sources_processed),
+            sources_failed=len(self._sources_failed),
+            failed_sources=self._sources_failed,
+        )
+
+        self.workflow_completed.emit(result)
+
+    def _complete_with_error(self, message: str):
+        """Complete workflow with an error."""
+        logger.error(f"Workflow error: {message}")
+        self._state = WorkflowState.ERROR
+
+        result = WorkflowResult(
+            success=False,
+            algorithm=self._algorithm,
+            clips_created=len(self._all_clips),
+            sources_processed=len(self._sources_processed),
+            sources_failed=len(self._sources_failed),
+            error_message=message,
+            failed_sources=self._sources_failed,
+        )
+
+        self.workflow_completed.emit(result)
+
+    # --- Methods for MainWindow to query state ---
+
+    def get_sources_to_detect(self) -> list[Path]:
+        """Get list of source paths that need detection."""
+        return [s["path"] for s in self._sources_to_process]
+
+    def get_current_source_path(self) -> Optional[Path]:
+        """Get the path of the current source being processed."""
+        if self._current_source_index < len(self._sources_to_process):
+            return self._sources_to_process[self._current_source_index]["path"]
+        return None
+
+    def get_all_clips(self) -> list:
+        """Get all clips created during the workflow."""
+        return self._all_clips
+
+    def get_all_sources(self) -> list:
+        """Get all sources successfully processed."""
+        return self._sources_processed
+
+    def get_algorithm_with_direction(self) -> tuple[str, Optional[str]]:
+        """Get the algorithm and direction for sequence generation."""
+        return self._algorithm, self._direction

--- a/docs/plans/2026-01-30-feat-intention-first-sequence-workflow-plan.md
+++ b/docs/plans/2026-01-30-feat-intention-first-sequence-workflow-plan.md
@@ -1,0 +1,254 @@
+---
+title: "feat: Intention-First Sequence Workflow"
+type: feat
+date: 2026-01-30
+---
+
+# Intention-First Sequence Workflow
+
+## Overview
+
+Enable filmmakers to start from the Sequence tab with an intention (e.g., "I want a color-sorted montage") and be guided through importing, detecting, and analyzing video—reversing the traditional Collect → Cut → Analyze → Sequence flow.
+
+When a user clicks any sequence card (Color, Duration, Shuffle, Sequential) and no clips exist in the project, an import modal appears. After import, videos are automatically cut into clips, analyzed based on the sequence type's requirements, and populated into the timeline.
+
+## Problem Statement / Motivation
+
+**Current pain point:** Users must navigate through 3-4 tabs before seeing their creative output. The workflow assumes users start with video and discover what they can make. But many filmmakers start with an *intention* ("I want to create a color-sorted montage") and want the app to guide them there.
+
+**User story:** As a filmmaker, I want to select "Color" sequence first, then be prompted to import my footage, so I can start with my creative goal and let the app handle the technical steps.
+
+## Proposed Solution
+
+### High-Level Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     SEQUENCE TAB                            │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐           │
+│  │  Color  │ │Duration │ │ Shuffle │ │Sequential│           │
+│  │   🌈    │ │   ⏱️    │ │   🎲    │ │   📋    │           │
+│  └────┬────┘ └─────────┘ └─────────┘ └─────────┘           │
+│       │                                                     │
+│       ▼ (no clips exist)                                    │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │              IMPORT MODAL                            │   │
+│  │  ┌─────────────────────────────────────────────┐    │   │
+│  │  │     Drag & drop videos here                 │    │   │
+│  │  │         or click to browse                  │    │   │
+│  │  └─────────────────────────────────────────────┘    │   │
+│  │                                                      │   │
+│  │  Or enter YouTube/Vimeo URLs (one per line):        │   │
+│  │  ┌─────────────────────────────────────────────┐    │   │
+│  │  │ https://youtube.com/watch?v=...            │    │   │
+│  │  │ https://vimeo.com/...                       │    │   │
+│  │  └─────────────────────────────────────────────┘    │   │
+│  │                                                      │   │
+│  │  [Cancel]                        [Start Import]      │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   PROCESSING (same modal)                   │
+│                                                             │
+│   Creating your Color sequence...                          │
+│                                                             │
+│   ✓ Downloading videos (2 of 2)                            │
+│   ● Detecting scenes... 45%                                │
+│   ○ Generating thumbnails                                   │
+│   ○ Analyzing colors                                        │
+│   ○ Building sequence                                       │
+│                                                             │
+│   [Cancel]                                                  │
+└─────────────────────────────────────────────────────────────┘
+        │
+        ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   TIMELINE VIEW                             │
+│   ┌─────────────────────────────────────────────────────┐   │
+│   │  Video Player                                        │   │
+│   └─────────────────────────────────────────────────────┘   │
+│   ┌─────────────────────────────────────────────────────┐   │
+│   │  Timeline with auto-populated clips                 │   │
+│   │  [clip1][clip2][clip3][clip4][clip5]...             │   │
+│   └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Decision Matrix
+
+| Condition | Action |
+|-----------|--------|
+| Clips exist with required analysis | Generate sequence immediately |
+| Clips exist but missing analysis (e.g., no colors for Color) | Run required analysis, then generate |
+| No clips but sources exist | Run detection on existing sources, then analysis, then generate |
+| No clips, no sources | Show import modal |
+
+### Analysis Requirements by Sequence Type
+
+| Sequence Type | Required Analysis | Optional Analysis |
+|---------------|-------------------|-------------------|
+| Color | `dominant_colors` | None |
+| Duration | None (duration from detection) | None |
+| Shuffle | None | None |
+| Sequential | None | None |
+
+## Technical Considerations
+
+### Architecture
+
+**New Components:**
+- `IntentionImportDialog` - Modal dialog for file/URL import
+- `IntentionWorkflowCoordinator` - Orchestrates the multi-step flow
+
+**Modified Components:**
+- `sequence_tab.py` - Handle card click with no clips
+- `sorting_card_grid.py` - Emit signal with algorithm info on click
+- `main_window.py` - Connect workflow coordinator to existing workers
+
+### State Management
+
+**Critical learnings from `docs/solutions/`:**
+
+1. **Single Source of Truth** (from `timeline-widget-sequence-mismatch-20260124.md`)
+   - The `IntentionWorkflowCoordinator` owns workflow state
+   - UI components read via properties, don't maintain copies
+
+2. **Source ID Synchronization** (from `pyside6-thumbnail-source-id-mismatch.md`)
+   - After detection, sync `clip.source_id` to match existing `Source.id`
+   - Workers may create new Source objects with different UUIDs
+
+3. **Duplicate Signal Guards** (from `qthread-destroyed-duplicate-signal-delivery-20260124.md`)
+   - Use guard flags for each step transition
+   - Reset guards when starting new workflow
+   - Use `Qt.UniqueConnection` for all signal connections
+
+### Worker Chain
+
+```python
+# Sequential processing for simplicity
+for source in sources:
+    download_if_url(source)      # URLDownloadWorker
+    detect_scenes(source)         # DetectionWorker
+    generate_thumbnails(source)   # ThumbnailWorker
+    if needs_analysis(algorithm):
+        run_analysis(clips)       # ColorWorker / etc.
+
+# After all sources processed
+generate_sequence(algorithm, all_clips)
+```
+
+### Error Handling Strategy
+
+- **Download failure:** Log error, skip source, continue with others
+- **Detection failure:** Log error, skip source, continue with others
+- **Analysis failure:** Log warning, use clips without analysis, degrade gracefully
+- **All sources failed:** Show error message, return to card grid
+
+### Key Files to Modify
+
+| File | Changes |
+|------|---------|
+| `ui/tabs/sequence_tab.py` | Add workflow trigger on card click |
+| `ui/widgets/sorting_card_grid.py` | Emit algorithm info with click signal |
+| `ui/main_window.py` | Add `IntentionWorkflowCoordinator` |
+| `ui/dialogs/intention_import_dialog.py` | **NEW** - Import modal UI |
+| `core/intention_workflow.py` | **NEW** - Workflow state machine |
+
+## Acceptance Criteria
+
+### Core Flow
+- [x] Clicking sequence card with no clips shows import modal
+- [x] Import modal accepts local files via drag-drop
+- [x] Import modal accepts local files via file browser
+- [x] Import modal accepts YouTube/Vimeo URLs (multiple, one per line)
+- [x] Progress shows current step and overall progress
+- [x] Cancel button stops workflow at any point
+- [x] Successful completion shows populated timeline
+
+### Conditional Analysis
+- [x] Color sequence triggers color analysis before population
+- [x] Duration/Shuffle/Sequential skip analysis step
+- [x] Clips missing required analysis are analyzed before use
+
+### Error Handling
+- [x] Failed downloads show error but continue with other sources
+- [x] Failed detections show error but continue with other sources
+- [x] Partial success shows summary: "Created sequence with 45 clips from 2 of 3 videos"
+- [x] Complete failure returns to card grid with error message
+
+### State Management
+- [x] Imported sources appear in Collect tab
+- [x] Detected clips appear in Cut tab
+- [x] Project auto-saves after workflow completion
+- [ ] Navigation to other tabs works correctly mid-flow
+
+### Edge Cases
+- [x] Clicking card when clips already exist generates sequence immediately
+- [ ] Clicking card when clips exist but need analysis runs analysis first
+- [ ] Clicking card when sources exist but no clips runs detection first
+
+## Success Metrics
+
+- Users can create their first sequence in under 2 minutes (vs current ~5 min)
+- 70% of new users start from Sequence tab (measure via analytics)
+- Workflow completion rate > 80% (users don't abandon mid-flow)
+
+## Dependencies & Risks
+
+### Dependencies
+- Existing `DetectionWorker`, `ThumbnailWorker`, `ColorWorker` infrastructure
+- `generate_sequence()` algorithm implementations
+- yt-dlp for URL downloads
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Long processing time discourages users | Show granular progress, estimated time for large files |
+| Worker thread crashes leave inconsistent state | Guard flags, cleanup on cancel, auto-save checkpoints |
+| Memory issues with many large videos | Process sequentially, not in parallel |
+| Source ID mismatch breaks clip lookups | Apply documented ID sync pattern from learnings |
+
+## References & Research
+
+### Internal References
+- Sorting card click handling: `ui/widgets/sorting_card_grid.py:65-85`
+- Sequence generation: `core/remix/__init__.py:40-171`
+- Detection worker pattern: `ui/main_window.py:82-122`
+- Empty state widget: `ui/widgets/empty_state.py:1-45`
+- URL download worker: `ui/main_window.py` (`URLBulkDownloadWorker`)
+
+### Documented Learnings
+- State duplication gotcha: `docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md`
+- Source ID mismatch: `docs/solutions/ui-bugs/pyside6-thumbnail-source-id-mismatch.md`
+- Signal delivery duplication: `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`
+
+### Related Agent Tools
+- `download_videos(urls)` - Bulk URL download
+- `detect_all_unanalyzed(sensitivity)` - Batch detection
+- `analyze_colors_live(clip_ids)` - Color analysis
+- `generate_sequence(algorithm, ...)` - Sequence creation
+
+## Implementation Outline
+
+### Phase 1: Import Modal
+1. Create `IntentionImportDialog` with drag-drop + URL input
+2. Add "no clips" detection to `_on_card_clicked` in `sequence_tab.py`
+3. Show modal and collect sources
+
+### Phase 2: Workflow Coordinator
+1. Create `IntentionWorkflowCoordinator` state machine
+2. Connect to existing workers (download, detection, thumbnail, analysis)
+3. Implement progress reporting
+
+### Phase 3: Integration
+1. Wire coordinator to `MainWindow`
+2. Handle cancel and error cases
+3. Populate timeline on completion
+
+### Phase 4: Polish
+1. Add step-by-step progress indicators
+2. Handle edge cases (existing clips, partial analysis)
+3. Add error summaries

--- a/ui/dialogs/__init__.py
+++ b/ui/dialogs/__init__.py
@@ -1,0 +1,5 @@
+"""Dialog components for Scene Ripper."""
+
+from .intention_import_dialog import IntentionImportDialog
+
+__all__ = ["IntentionImportDialog"]

--- a/ui/dialogs/intention_import_dialog.py
+++ b/ui/dialogs/intention_import_dialog.py
@@ -1,0 +1,551 @@
+"""Import dialog for the intention-first workflow.
+
+This dialog appears when a user clicks a sequence card but has no clips.
+It allows importing videos via drag-drop or URLs, then shows progress
+as the workflow processes the videos.
+"""
+
+import logging
+from pathlib import Path
+from enum import Enum, auto
+
+from PySide6.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QHBoxLayout,
+    QLabel,
+    QFrame,
+    QPushButton,
+    QTextEdit,
+    QListWidget,
+    QListWidgetItem,
+    QStackedWidget,
+    QFileDialog,
+    QProgressBar,
+    QWidget,
+)
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QFont, QDragEnterEvent, QDropEvent
+
+from ui.theme import theme
+
+logger = logging.getLogger(__name__)
+
+
+VIDEO_EXTENSIONS = {".mp4", ".mkv", ".mov", ".avi", ".webm", ".m4v"}
+
+
+class WorkflowStep(Enum):
+    """Steps in the intention workflow."""
+    DOWNLOADING = auto()
+    DETECTING = auto()
+    THUMBNAILS = auto()
+    ANALYZING = auto()
+    BUILDING = auto()
+
+
+class DropZone(QFrame):
+    """Drag-and-drop zone for video files."""
+
+    files_dropped = Signal(list)  # List of Paths
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+        self.setMinimumHeight(120)
+        self._setup_ui()
+        self._apply_theme()
+
+        if theme().changed:
+            theme().changed.connect(self._apply_theme)
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setAlignment(Qt.AlignCenter)
+
+        self.icon_label = QLabel("📁")
+        icon_font = QFont()
+        icon_font.setPointSize(32)
+        self.icon_label.setFont(icon_font)
+        self.icon_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.icon_label)
+
+        self.text_label = QLabel("Drag & drop videos here")
+        self.text_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.text_label)
+
+        self.sub_label = QLabel("or click to browse")
+        self.sub_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.sub_label)
+
+    def _apply_theme(self, dragging: bool = False):
+        if dragging:
+            self.setStyleSheet(f"""
+                DropZone {{
+                    background-color: rgba(76, 175, 80, 0.1);
+                    border: 2px dashed {theme().accent_green};
+                    border-radius: 8px;
+                }}
+            """)
+        else:
+            self.setStyleSheet(f"""
+                DropZone {{
+                    background-color: {theme().card_background};
+                    border: 2px dashed {theme().border_primary};
+                    border-radius: 8px;
+                }}
+                DropZone:hover {{
+                    background-color: {theme().card_hover};
+                    border-color: {theme().border_focus};
+                }}
+            """)
+        self.text_label.setStyleSheet(f"font-size: 14px; font-weight: bold; color: {theme().text_secondary};")
+        self.sub_label.setStyleSheet(f"font-size: 11px; color: {theme().text_muted};")
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self._browse_for_files()
+
+    def _browse_for_files(self):
+        file_paths, _ = QFileDialog.getOpenFileNames(
+            self,
+            "Select Video Files",
+            "",
+            "Video Files (*.mp4 *.mkv *.mov *.avi *.webm *.m4v);;All Files (*)",
+        )
+        if file_paths:
+            self.files_dropped.emit([Path(p) for p in file_paths])
+
+    def dragEnterEvent(self, event: QDragEnterEvent):
+        if event.mimeData().hasUrls():
+            for url in event.mimeData().urls():
+                if url.isLocalFile():
+                    path = Path(url.toLocalFile())
+                    if path.is_dir() or path.suffix.lower() in VIDEO_EXTENSIONS:
+                        event.acceptProposedAction()
+                        self._apply_theme(dragging=True)
+                        return
+        event.ignore()
+
+    def dragLeaveEvent(self, event):
+        self._apply_theme(dragging=False)
+
+    def dropEvent(self, event: QDropEvent):
+        self._apply_theme(dragging=False)
+        paths = []
+        for url in event.mimeData().urls():
+            if url.isLocalFile():
+                path = Path(url.toLocalFile())
+                if path.is_dir():
+                    paths.extend(self._scan_folder(path))
+                elif path.suffix.lower() in VIDEO_EXTENSIONS:
+                    paths.append(path)
+        if paths:
+            self.files_dropped.emit(paths)
+            event.acceptProposedAction()
+
+    def _scan_folder(self, folder: Path) -> list[Path]:
+        """Recursively scan folder for video files."""
+        videos = []
+        for item in folder.rglob("*"):
+            if item.is_file() and item.suffix.lower() in VIDEO_EXTENSIONS:
+                videos.append(item)
+        return sorted(videos)
+
+
+class IntentionImportDialog(QDialog):
+    """Dialog for importing videos in the intention-first workflow.
+
+    Two views:
+    1. Import view: drag-drop zone + URL input + pending list
+    2. Progress view: step indicators + progress bar
+
+    Signals:
+        import_requested: Emitted with (local_paths, urls, algorithm) when Start Import clicked
+        cancelled: Emitted when Cancel clicked during import or progress
+    """
+
+    import_requested = Signal(list, list, str)  # local_paths, urls, algorithm
+    cancelled = Signal()
+
+    # View indices
+    VIEW_IMPORT = 0
+    VIEW_PROGRESS = 1
+
+    def __init__(self, algorithm: str, parent=None):
+        super().__init__(parent)
+        self._algorithm = algorithm
+        self._local_paths: list[Path] = []
+        self._urls: list[str] = []
+        self._current_step: WorkflowStep | None = None
+        self._step_progress: dict[WorkflowStep, tuple[bool, float]] = {}  # step -> (complete, progress)
+
+        self.setWindowTitle(f"Create {algorithm.capitalize()} Sequence")
+        self.setMinimumSize(500, 450)
+        self.setModal(True)
+
+        self._setup_ui()
+        self._apply_theme()
+
+        if theme().changed:
+            theme().changed.connect(self._apply_theme)
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setSpacing(16)
+
+        # Stack for switching between import and progress views
+        self.view_stack = QStackedWidget()
+
+        # Import view
+        import_widget = self._create_import_view()
+        self.view_stack.addWidget(import_widget)
+
+        # Progress view
+        progress_widget = self._create_progress_view()
+        self.view_stack.addWidget(progress_widget)
+
+        layout.addWidget(self.view_stack)
+
+        # Start in import view
+        self.view_stack.setCurrentIndex(self.VIEW_IMPORT)
+
+    def _create_import_view(self) -> QWidget:
+        """Create the import view with drag-drop, URL input, and pending list."""
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Header
+        header = QLabel(f"Import videos for {self._algorithm.capitalize()} sequence")
+        header_font = QFont()
+        header_font.setPointSize(14)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        layout.addWidget(header)
+        self._import_header = header
+
+        # Drop zone
+        self.drop_zone = DropZone()
+        self.drop_zone.files_dropped.connect(self._on_files_dropped)
+        layout.addWidget(self.drop_zone)
+
+        # URL section
+        url_label = QLabel("Or enter YouTube/Vimeo URLs (one per line):")
+        layout.addWidget(url_label)
+        self._url_label = url_label
+
+        self.url_input = QTextEdit()
+        self.url_input.setPlaceholderText("https://youtube.com/watch?v=...\nhttps://vimeo.com/...")
+        self.url_input.setMaximumHeight(80)
+        self.url_input.textChanged.connect(self._update_pending_list)
+        layout.addWidget(self.url_input)
+
+        # Pending imports list
+        pending_label = QLabel("Pending imports:")
+        layout.addWidget(pending_label)
+        self._pending_label = pending_label
+
+        self.pending_list = QListWidget()
+        self.pending_list.setMaximumHeight(120)
+        layout.addWidget(self.pending_list)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+
+        self.cancel_btn = QPushButton("Cancel")
+        self.cancel_btn.clicked.connect(self._on_cancel)
+        button_layout.addWidget(self.cancel_btn)
+
+        self.start_btn = QPushButton("Start Import")
+        self.start_btn.setEnabled(False)
+        self.start_btn.clicked.connect(self._on_start)
+        button_layout.addWidget(self.start_btn)
+
+        layout.addLayout(button_layout)
+
+        return widget
+
+    def _create_progress_view(self) -> QWidget:
+        """Create the progress view with step indicators."""
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Header
+        self.progress_header = QLabel(f"Creating your {self._algorithm.capitalize()} sequence...")
+        header_font = QFont()
+        header_font.setPointSize(14)
+        header_font.setBold(True)
+        self.progress_header.setFont(header_font)
+        layout.addWidget(self.progress_header)
+
+        layout.addSpacing(20)
+
+        # Step indicators
+        self.step_labels: dict[WorkflowStep, QLabel] = {}
+        self.step_progress_bars: dict[WorkflowStep, QProgressBar] = {}
+
+        steps = [
+            (WorkflowStep.DOWNLOADING, "Downloading videos"),
+            (WorkflowStep.DETECTING, "Detecting scenes"),
+            (WorkflowStep.THUMBNAILS, "Generating thumbnails"),
+            (WorkflowStep.ANALYZING, "Analyzing clips"),
+            (WorkflowStep.BUILDING, "Building sequence"),
+        ]
+
+        for step, label_text in steps:
+            step_layout = QHBoxLayout()
+
+            # Status indicator
+            indicator = QLabel("○")
+            indicator.setFixedWidth(24)
+            step_layout.addWidget(indicator)
+            self.step_labels[step] = indicator
+
+            # Label
+            label = QLabel(label_text)
+            label.setMinimumWidth(150)
+            step_layout.addWidget(label)
+
+            # Progress bar
+            progress = QProgressBar()
+            progress.setMaximum(100)
+            progress.setValue(0)
+            progress.setVisible(False)
+            step_layout.addWidget(progress)
+            self.step_progress_bars[step] = progress
+
+            layout.addLayout(step_layout)
+
+        layout.addStretch()
+
+        # Status message
+        self.status_label = QLabel("")
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        # Cancel button
+        button_layout = QHBoxLayout()
+        button_layout.addStretch()
+
+        self.progress_cancel_btn = QPushButton("Cancel")
+        self.progress_cancel_btn.clicked.connect(self._on_cancel)
+        button_layout.addWidget(self.progress_cancel_btn)
+
+        layout.addLayout(button_layout)
+
+        return widget
+
+    def _apply_theme(self):
+        """Apply theme colors."""
+        self.setStyleSheet(f"""
+            QDialog {{
+                background-color: {theme().background_primary};
+            }}
+            QLabel {{
+                color: {theme().text_primary};
+            }}
+            QTextEdit {{
+                background-color: {theme().input_background};
+                color: {theme().text_primary};
+                border: 1px solid {theme().border_primary};
+                border-radius: 4px;
+                padding: 8px;
+            }}
+            QListWidget {{
+                background-color: {theme().input_background};
+                color: {theme().text_primary};
+                border: 1px solid {theme().border_primary};
+                border-radius: 4px;
+            }}
+            QListWidget::item {{
+                padding: 4px;
+            }}
+            QPushButton {{
+                background-color: {theme().button_background};
+                color: {theme().button_text};
+                border: 1px solid {theme().border_primary};
+                border-radius: 4px;
+                padding: 8px 16px;
+            }}
+            QPushButton:hover {{
+                background-color: {theme().button_hover};
+            }}
+            QPushButton:disabled {{
+                background-color: {theme().background_secondary};
+                color: {theme().text_muted};
+            }}
+            QProgressBar {{
+                background-color: {theme().background_secondary};
+                border: 1px solid {theme().border_primary};
+                border-radius: 4px;
+                text-align: center;
+            }}
+            QProgressBar::chunk {{
+                background-color: {theme().accent_primary};
+                border-radius: 3px;
+            }}
+        """)
+
+        if hasattr(self, '_import_header'):
+            self._import_header.setStyleSheet(f"color: {theme().text_primary};")
+        if hasattr(self, '_url_label'):
+            self._url_label.setStyleSheet(f"color: {theme().text_secondary};")
+        if hasattr(self, '_pending_label'):
+            self._pending_label.setStyleSheet(f"color: {theme().text_secondary};")
+
+    def _on_files_dropped(self, paths: list[Path]):
+        """Handle dropped files."""
+        for path in paths:
+            if path not in self._local_paths:
+                self._local_paths.append(path)
+        self._update_pending_list()
+
+    def _update_pending_list(self):
+        """Update the pending imports list."""
+        self.pending_list.clear()
+
+        # Add local files
+        for path in self._local_paths:
+            item = QListWidgetItem(f"📁 {path.name}")
+            item.setData(Qt.UserRole, ("file", path))
+            self.pending_list.addItem(item)
+
+        # Add URLs from text input
+        self._urls = []
+        url_text = self.url_input.toPlainText().strip()
+        if url_text:
+            for line in url_text.split("\n"):
+                url = line.strip()
+                if url and (url.startswith("http://") or url.startswith("https://")):
+                    self._urls.append(url)
+                    # Determine icon based on domain
+                    if "youtube.com" in url or "youtu.be" in url:
+                        icon = "🎬"
+                    elif "vimeo.com" in url:
+                        icon = "🎥"
+                    else:
+                        icon = "🔗"
+                    item = QListWidgetItem(f"{icon} {url[:50]}...")
+                    item.setData(Qt.UserRole, ("url", url))
+                    self.pending_list.addItem(item)
+
+        # Enable/disable start button
+        has_items = bool(self._local_paths or self._urls)
+        self.start_btn.setEnabled(has_items)
+
+    def _on_start(self):
+        """Handle Start Import click."""
+        if not self._local_paths and not self._urls:
+            return
+
+        # Switch to progress view
+        self.view_stack.setCurrentIndex(self.VIEW_PROGRESS)
+
+        # Initialize step states
+        for step in WorkflowStep:
+            self._step_progress[step] = (False, 0.0)
+
+        # Emit signal to start workflow
+        self.import_requested.emit(self._local_paths.copy(), self._urls.copy(), self._algorithm)
+
+    def _on_cancel(self):
+        """Handle Cancel click."""
+        self.cancelled.emit()
+        self.reject()
+
+    def closeEvent(self, event):
+        """Handle dialog close (X button)."""
+        # If we're in progress view and not complete, treat as cancel
+        if self.stack.currentIndex() == 1:  # Progress view
+            if self.progress_cancel_btn.text() != "Close":
+                self.cancelled.emit()
+        event.accept()
+
+    # --- Progress update methods (called by coordinator) ---
+
+    def set_step_active(self, step: WorkflowStep, message: str = ""):
+        """Mark a step as currently active."""
+        self._current_step = step
+
+        for s, label in self.step_labels.items():
+            if s == step:
+                label.setText("●")
+                label.setStyleSheet(f"color: {theme().accent_primary}; font-size: 16px;")
+                self.step_progress_bars[s].setVisible(True)
+            elif self._step_progress.get(s, (False, 0))[0]:
+                label.setText("✓")
+                label.setStyleSheet(f"color: {theme().accent_green}; font-size: 16px;")
+                self.step_progress_bars[s].setVisible(False)
+            else:
+                label.setText("○")
+                label.setStyleSheet(f"color: {theme().text_muted}; font-size: 16px;")
+                self.step_progress_bars[s].setVisible(False)
+
+        if message:
+            self.status_label.setText(message)
+
+    def set_step_progress(self, step: WorkflowStep, progress: float, message: str = ""):
+        """Update progress for a step (0-100)."""
+        self._step_progress[step] = (False, progress)
+        if step in self.step_progress_bars:
+            self.step_progress_bars[step].setValue(int(progress))
+        if message:
+            self.status_label.setText(message)
+
+    def set_step_complete(self, step: WorkflowStep, message: str = ""):
+        """Mark a step as complete."""
+        self._step_progress[step] = (True, 100.0)
+
+        if step in self.step_labels:
+            self.step_labels[step].setText("✓")
+            self.step_labels[step].setStyleSheet(f"color: {theme().accent_green}; font-size: 16px;")
+        if step in self.step_progress_bars:
+            self.step_progress_bars[step].setValue(100)
+            self.step_progress_bars[step].setVisible(False)
+        if message:
+            self.status_label.setText(message)
+
+    def set_step_skipped(self, step: WorkflowStep, message: str = ""):
+        """Mark a step as skipped (e.g., no analysis needed)."""
+        self._step_progress[step] = (True, 100.0)
+
+        if step in self.step_labels:
+            self.step_labels[step].setText("—")
+            self.step_labels[step].setStyleSheet(f"color: {theme().text_muted}; font-size: 16px;")
+        if step in self.step_progress_bars:
+            self.step_progress_bars[step].setVisible(False)
+        if message:
+            self.status_label.setText(message)
+
+    def set_error(self, message: str):
+        """Show an error message."""
+        self.status_label.setText(f"⚠️ {message}")
+        self.status_label.setStyleSheet(f"color: {theme().accent_warning};")
+
+    def set_complete(
+        self,
+        clip_count: int = 0,
+        sources_processed: int = 0,
+        sources_failed: int = 0,
+    ):
+        """Mark workflow as complete with summary.
+
+        Args:
+            clip_count: Number of clips created
+            sources_processed: Number of sources successfully processed
+            sources_failed: Number of sources that failed
+        """
+        self.progress_header.setText("Complete!")
+
+        # Build summary message
+        if sources_failed > 0:
+            message = f"Created {clip_count} clips from {sources_processed} of {sources_processed + sources_failed} videos"
+        else:
+            message = f"Created {clip_count} clips from {sources_processed} videos"
+
+        self.status_label.setText(message)
+        self.status_label.setStyleSheet(f"color: {theme().accent_green};")
+        self.progress_cancel_btn.setText("Close")


### PR DESCRIPTION
## Summary

Enables users to start from the Sequence tab with a creative intention and be guided through importing, detecting, and analyzing video—reversing the traditional Collect → Cut → Analyze → Sequence flow.

- When clicking any sequence card (Color, Duration, Shuffle, Sequential) with no clips in project, an import modal appears
- Import supports drag-drop local files, file browser, and YouTube/Vimeo URLs
- After import, videos are automatically processed: download → detect scenes → generate thumbnails → analyze (if needed) → build sequence
- Partial success continues with available clips when some sources fail

## Changes

**New files:**
- `ui/dialogs/intention_import_dialog.py` - Import modal with drag-drop and progress view
- `core/intention_workflow.py` - Workflow coordinator state machine
- `docs/plans/2026-01-30-feat-intention-first-sequence-workflow-plan.md` - Feature plan

**Modified:**
- `ui/tabs/sequence_tab.py` - Trigger workflow when no clips exist
- `ui/main_window.py` - Wire coordinator to existing workers

## Test plan

- [ ] Click sequence card with empty project → import modal appears
- [ ] Add local video files via drag-drop
- [ ] Add YouTube URL and verify download + detection
- [ ] Verify progress indicators update correctly
- [ ] Cancel mid-workflow and verify cleanup
- [ ] Verify Color sequence runs color analysis before building
- [ ] Verify Duration/Shuffle/Sequential skip analysis

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)