### PR TITLE
feat(cinematography): add expanded analysis fields for Phase 2

### DIFF
--- a/core/film_glossary.py
+++ b/core/film_glossary.py
@@ -361,6 +361,86 @@ FILM_GLOSSARY: dict[str, dict[str, str]] = {
         "category": "Camera Angles",
         "definition": "Psychological effect of worm's eye view. Maximum subject dominance.",
     },
+    # Phase 2: Dutch Tilt
+    "dutch_slight": {
+        "name": "Slight Dutch Tilt",
+        "category": "Composition",
+        "definition": "Horizon tilted 5-15 degrees. Subtle unease without overt disorientation.",
+    },
+    "dutch_moderate": {
+        "name": "Moderate Dutch Tilt",
+        "category": "Composition",
+        "definition": "Horizon tilted 15-30 degrees. Clear visual instability creating tension.",
+    },
+    "dutch_extreme": {
+        "name": "Extreme Dutch Tilt",
+        "category": "Composition",
+        "definition": "Horizon tilted over 30 degrees. Maximum disorientation, often used for chaos or madness.",
+    },
+    # Phase 2: Camera Position
+    "frontal": {
+        "name": "Frontal Position",
+        "category": "Camera Angles",
+        "definition": "Camera directly facing the subject. Creates confrontation and direct engagement.",
+    },
+    "profile": {
+        "name": "Profile Position",
+        "category": "Camera Angles",
+        "definition": "Camera at 90 degrees to subject showing side view. Creates observational distance.",
+    },
+    # Phase 2: Lens Types
+    "wide_lens": {
+        "name": "Wide-Angle Lens",
+        "category": "Focus",
+        "definition": "Exaggerated perspective with barrel distortion. Makes close objects larger, good for interiors and dramatic close-ups.",
+    },
+    "normal_lens": {
+        "name": "Normal Lens",
+        "category": "Focus",
+        "definition": "Natural perspective matching human eye. Standard coverage without distortion.",
+    },
+    "telephoto_lens": {
+        "name": "Telephoto Lens",
+        "category": "Focus",
+        "definition": "Compressed perspective flattening depth. Flattering for portraits, isolates subjects.",
+    },
+    # Phase 2: Light Quality
+    "hard_light": {
+        "name": "Hard Light",
+        "category": "Lighting",
+        "definition": "Direct light source creating sharp, defined shadows. Creates drama and harsh reality.",
+    },
+    "soft_light": {
+        "name": "Soft Light",
+        "category": "Lighting",
+        "definition": "Diffused light with gradual shadow transitions. Flattering and naturalistic.",
+    },
+    "mixed_light": {
+        "name": "Mixed Lighting",
+        "category": "Lighting",
+        "definition": "Combination of hard and soft light sources. Creates complex, layered illumination.",
+    },
+    # Phase 2: Color Temperature
+    "warm": {
+        "name": "Warm Color Temperature",
+        "category": "Lighting",
+        "definition": "Orange and yellow tones suggesting warmth, intimacy, or sunset/indoor lighting.",
+    },
+    "cool": {
+        "name": "Cool Color Temperature",
+        "category": "Lighting",
+        "definition": "Blue tones suggesting coldness, sterility, or night/fluorescent lighting.",
+    },
+    "warm_temp": {
+        "name": "Warm Color Temperature",
+        "category": "Lighting",
+        "definition": "Orange and yellow tones suggesting warmth, intimacy, or sunset/indoor lighting.",
+    },
+    "cool_temp": {
+        "name": "Cool Color Temperature",
+        "category": "Lighting",
+        "definition": "Blue tones suggesting coldness, sterility, or night/fluorescent lighting.",
+    },
 }
 
 

--- a/docs/plans/2026-02-01-feat-film-language-integration-documentation-plan.md
+++ b/docs/plans/2026-02-01-feat-film-language-integration-documentation-plan.md
@@ -949,21 +949,22 @@ FILM_GLOSSARY = {
 - Tooltip links may not be clickable on all platforms—provide "?" button as fallback
 - Long definitions should truncate in tooltip, expand in glossary dialog
 
-### Phase 2: Expanded Cinematography Analysis (Medium Effort)
+### Phase 2: Expanded Cinematography Analysis (Medium Effort) ✅ COMPLETED
 
 **Goal:** Add missing visual analysis concepts.
 
-| Feature | Description | Effort |
-|---------|-------------|--------|
-| Dutch Tilt Detection | Add horizon tilt analysis | 2 days |
-| Camera Position | Frontal/profile/back detection | 2 days |
-| Lens Type Estimation | Wide/normal/telephoto classification | 3 days |
-| Light Quality | Hard/soft classification | 2 days |
-| Color Temperature | Warm/cool estimation | 1 day |
+| Feature | Description | Effort | Status |
+|---------|-------------|--------|--------|
+| Dutch Tilt Detection | Add horizon tilt analysis | 2 days | ✅ Done |
+| Camera Position | Frontal/profile/back detection | 2 days | ✅ Done |
+| Lens Type Estimation | Wide/normal/telephoto classification | 3 days | ✅ Done |
+| Light Quality | Hard/soft classification | 2 days | ✅ Done |
+| Color Temperature | Warm/cool estimation | 1 day | ✅ Done |
 
-**Files to create/modify:**
-- `models/cinematography.py` - Add new fields
-- `core/analysis/cinematography.py` - Update VLM prompts
+**Files modified:**
+- `models/cinematography.py` - Added new fields and value lists
+- `core/analysis/cinematography.py` - Updated VLM schema and prompts
+- `core/film_glossary.py` - Added glossary entries for new terms
 
 #### Research Insights
 
@@ -1426,11 +1427,11 @@ The agent should be able to execute this complete workflow:
 
 ### Analysis Enhancements
 
-- [ ] Dutch tilt detection with confidence score
-- [ ] Camera position (frontal/profile/back) detection
-- [ ] Lens type estimation from visual characteristics
-- [ ] Light quality (hard/soft) classification
-- [ ] Color temperature estimation
+- [x] Dutch tilt detection (none/slight/moderate/extreme/unknown)
+- [x] Camera position (frontal/three_quarter/profile/back) detection
+- [x] Lens type estimation from visual characteristics
+- [x] Light quality (hard/soft/mixed) classification
+- [x] Color temperature estimation (warm/neutral/cool)
 
 ### Audio-Guided Sequencing
 


### PR DESCRIPTION
## Summary

Phase 2 of the Film Language Integration plan adds five new cinematography analysis dimensions:

- **Dutch Tilt Detection** - Horizon tilt amount (none/slight/moderate/extreme/unknown)
- **Camera Position** - Subject-relative horizontal position (frontal/three_quarter/profile/back)  
- **Lens Type Estimation** - Inferred from visual characteristics (wide/normal/telephoto)
- **Light Quality** - Hard/soft light classification based on shadow edges
- **Color Temperature** - Warm/neutral/cool temperature detection

### Changes

**Data Model (`models/cinematography.py`):**
- Added 5 new field value lists
- Added new fields to `CinematographyAnalysis` dataclass
- Updated `to_dict()` / `from_dict()` for serialization
- Updated badge display methods to show new notable values

**VLM Analysis (`core/analysis/cinematography.py`):**
- Extended JSON schema with new field definitions
- Updated prompts for frame and video analysis modes
- Added validation/normalization for all new fields
- Updated `CinematographyAnalysis` constructor calls

**Glossary (`core/film_glossary.py`):**
- Added entries for dutch tilt variants
- Added camera position terms
- Added lens type definitions
- Added light quality terms
- Added color temperature entries

## Test plan

- [x] Verify new fields have correct defaults (`unknown`)
- [x] Verify `to_dict()` omits `unknown` values
- [x] Verify `from_dict()` handles missing fields (backward compat)
- [x] Verify badge display shows notable values
- [x] Verify glossary lookups work for new terms
- [x] Verify badge tooltips resolve for new badges
- [x] Run full test suite (287 passed, 2 pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)