### PR TITLE
fix(cost-estimate): update clip count heuristic to 12 clips/minute

### DIFF
--- a/tests/test_intention_import_heuristic.py
+++ b/tests/test_intention_import_heuristic.py
@@ -1,0 +1,25 @@
+"""Tests for the clip count estimation heuristic in the intention import dialog."""
+
+from ui.dialogs.intention_import_dialog import (
+    _CLIPS_PER_MINUTE,
+    _DEFAULT_URL_DURATION_SECONDS,
+)
+
+
+def test_clips_per_minute_constant():
+    """Guard against accidental changes to the heuristic."""
+    assert _CLIPS_PER_MINUTE == 12.0
+
+
+def test_clip_count_heuristic_5min_video():
+    """A 5-minute video should estimate ~60 clips."""
+    total_minutes = _DEFAULT_URL_DURATION_SECONDS / 60.0
+    expected = max(1, round(total_minutes * _CLIPS_PER_MINUTE))
+    assert expected == 60
+
+
+def test_clip_count_heuristic_short_video():
+    """A 3-second video should estimate at least 1 clip."""
+    total_minutes = 3.0 / 60.0
+    expected = max(1, round(total_minutes * _CLIPS_PER_MINUTE))
+    assert expected == 1

--- a/ui/dialogs/intention_import_dialog.py
+++ b/ui/dialogs/intention_import_dialog.py
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 
 VIDEO_EXTENSIONS = {".mp4", ".mkv", ".mov", ".avi", ".webm", ".m4v"}
 
-# Heuristic: average clips per minute of video at default detection threshold (~3.0)
-_CLIPS_PER_MINUTE = 2.0
+# Heuristic: ~5 seconds per clip at default detection threshold (~3.0)
+_CLIPS_PER_MINUTE = 12.0
 
 # Default assumed duration for URLs (can't probe before download)
 _DEFAULT_URL_DURATION_SECONDS = 300.0  # 5 minutes


### PR DESCRIPTION
## Summary
- Updated `_CLIPS_PER_MINUTE` from `2.0` to `12.0` (5-second average clip duration)
- Previous heuristic underestimated clip counts by 6x, leading to misleadingly low cost/time estimates
- Added 3 lightweight tests to pin the heuristic value and verify edge cases

## Test plan
- [x] 3 new tests pass (`test_intention_import_heuristic.py`)
- [x] All 36 existing cost estimate tests still pass
- [ ] Manual: open intention import dialog, add a 5-minute video, verify ~60 clips shown

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>