### PR TITLE
feat(models): P2 quality upgrades — DINOv2, Qwen3-VL, PaddleOCR

### DIFF
--- a/core/analysis/text_detection.py
+++ b/core/analysis/text_detection.py
@@ -1,5 +1,10 @@
 """Fast text detection using OpenCV EAST model.
 
+.. deprecated::
+    PaddleOCR PP-OCRv5 now handles text detection internally.
+    This module is kept for backward compatibility but is no longer
+    used by the default OCR pipeline. Use ``core.analysis.ocr`` instead.
+
 Pre-screens video frames for text presence before running expensive OCR/VLM.
 Uses the EAST (Efficient and Accurate Scene Text) neural network which runs
 in ~50-100ms on CPU, significantly faster than VLM calls.

--- a/core/cost_estimates.py
+++ b/core/cost_estimates.py
@@ -28,7 +28,7 @@ TIME_PER_CLIP: dict[str, dict[str, float]] = {
     "colors": {"local": 0.3},
     "shots": {"local": 1.0, "cloud": 1.5},
     "extract_text": {"local": 0.5, "cloud": 0.8},
-    "describe": {"local": 3.0, "cloud": 0.8},
+    "describe": {"local": 1.5, "cloud": 0.8},  # Qwen3-VL on Apple Silicon; Moondream ~3.0s
     "brightness": {"local": 0.1},
     "volume": {"local": 0.2},
     "embeddings": {"local": 0.8},

--- a/core/project.py
+++ b/core/project.py
@@ -18,7 +18,7 @@ from models.sequence import Sequence
 logger = logging.getLogger(__name__)
 
 # Current project file schema version
-SCHEMA_VERSION = "1.1"
+SCHEMA_VERSION = "1.2"
 
 
 class ProjectError(Exception):

--- a/core/remix/__init__.py
+++ b/core/remix/__init__.py
@@ -361,8 +361,8 @@ def _auto_compute_volume(clips: List[Tuple[Any, Any]]) -> None:
 
 
 def _auto_compute_embeddings(clips: List[Tuple[Any, Any]]) -> None:
-    """Compute CLIP embeddings for clips that don't have them."""
-    from core.analysis.embeddings import extract_clip_embeddings_batch
+    """Compute DINOv2 embeddings for clips that don't have them."""
+    from core.analysis.embeddings import extract_clip_embeddings_batch, _EMBEDDING_MODEL_TAG
 
     needs_embedding = [
         (clip, source) for clip, source in clips
@@ -376,13 +376,14 @@ def _auto_compute_embeddings(clips: List[Tuple[Any, Any]]) -> None:
         embeddings = extract_clip_embeddings_batch(thumbnail_paths)
         for (clip, _), emb in zip(needs_embedding, embeddings):
             clip.embedding = emb
+            clip.embedding_model = _EMBEDDING_MODEL_TAG
     except Exception as e:
         logger.warning(f"Failed to compute embeddings: {e}")
 
 
 def _auto_compute_boundary_embeddings(clips: List[Tuple[Any, Any]]) -> None:
-    """Compute first/last frame CLIP embeddings for clips that don't have them."""
-    from core.analysis.embeddings import extract_boundary_embeddings
+    """Compute first/last frame DINOv2 embeddings for clips that don't have them."""
+    from core.analysis.embeddings import extract_boundary_embeddings, _EMBEDDING_MODEL_TAG
 
     for clip, source in clips:
         if clip.first_frame_embedding is None or clip.last_frame_embedding is None:
@@ -395,6 +396,7 @@ def _auto_compute_boundary_embeddings(clips: List[Tuple[Any, Any]]) -> None:
                 )
                 clip.first_frame_embedding = first_emb
                 clip.last_frame_embedding = last_emb
+                clip.embedding_model = _EMBEDDING_MODEL_TAG
             except Exception as e:
                 logger.warning(
                     f"Failed to compute boundary embeddings for clip {clip.id}: {e}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ torch>=2.0
 Pillow>=10.0
 faster-whisper>=1.0.0
 lightning-whisper-mlx>=0.4.0  # MLX Whisper for Apple Silicon (optional, auto-detected)
+mlx-vlm>=0.1.0               # MLX VLM for Apple Silicon local descriptions (optional, auto-detected)
 google-api-python-client>=2.100.0
 keyring>=24.0
 
@@ -27,8 +28,7 @@ torchvision>=0.15.0  # MobileNet (compatible with torch>=2.0)
 einops>=0.7.0
 
 # OCR / Text Extraction
-pytesseract>=0.3.10  # Tesseract OCR wrapper (requires tesseract binary)
-paddleocr>=3.0.0     # PaddleOCR for karaoke/text scene detection (requires paddlepaddle)
+paddleocr>=3.0.0     # PaddleOCR PP-OCRv5 for text extraction (replaces Tesseract)
 rapidfuzz>=3.0.0     # Fast fuzzy string matching for text comparison
 
 # Audio Analysis

--- a/tests/test_cost_estimates.py
+++ b/tests/test_cost_estimates.py
@@ -36,7 +36,7 @@ class MockSettings:
 
     description_model_tier: str = "cpu"
     shot_classifier_tier: str = "cpu"
-    text_extraction_method: str = "tesseract"
+    text_extraction_method: str = "paddleocr"
     color_analysis_parallelism: int = 4
     description_parallelism: int = 3
     transcription_parallelism: int = 2

--- a/tests/test_frame_model.py
+++ b/tests/test_frame_model.py
@@ -597,8 +597,8 @@ class TestProjectFramePersistence:
         assert loaded.frames[0].analyzed is True
 
     def test_schema_version_bumped(self):
-        """Schema version should be 1.1."""
-        assert SCHEMA_VERSION == "1.1"
+        """Schema version should be 1.2."""
+        assert SCHEMA_VERSION == "1.2"
 
     def test_repr_includes_frames(self):
         """Project repr includes frame count."""

--- a/tests/test_p1_model_upgrades.py
+++ b/tests/test_p1_model_upgrades.py
@@ -15,15 +15,15 @@ from core.settings import Settings
 # --- P1.1a: Embeddings decoupled from shots ---
 
 class TestEmbeddingsDecoupled:
-    """Verify embeddings.py has its own CLIP model, separate from shots.py."""
+    """Verify embeddings.py has its own model, separate from shots.py."""
 
-    def test_embeddings_has_own_clip_model_name(self):
-        from core.analysis.embeddings import _CLIP_MODEL_NAME
-        assert _CLIP_MODEL_NAME == "openai/clip-vit-base-patch32"
+    def test_embeddings_has_dinov2_model_name(self):
+        from core.analysis.embeddings import _DINOV2_MODEL_NAME
+        assert _DINOV2_MODEL_NAME == "facebook/dinov2-base"
 
-    def test_embeddings_has_own_revision_pin(self):
-        from core.analysis.embeddings import _CLIP_MODEL_REVISION
-        assert _CLIP_MODEL_REVISION == "e6a30b603a447e251fdaca1c3056b2a16cdfebeb"
+    def test_embeddings_produces_768_dim(self):
+        from core.analysis.embeddings import _EMBEDDING_DIM
+        assert _EMBEDDING_DIM == 768
 
     def test_embeddings_does_not_import_from_shots(self):
         """embeddings.py must not import model loading from shots.py."""

--- a/tests/test_p2_quality_upgrades.py
+++ b/tests/test_p2_quality_upgrades.py
@@ -1,0 +1,302 @@
+"""Tests pinning P2 quality upgrades.
+
+Covers:
+- P2.0: Embedding architecture migration (dimension-aware validation)
+- P2.1: DINOv2 for visual similarity embeddings
+- P2.2: Qwen3-VL 4B for local VLM descriptions
+- P2.3: PaddleOCR PP-OCRv5 for text extraction
+"""
+
+import json
+import platform
+
+from core.settings import Settings, _settings_to_json, _load_from_json
+
+
+# --- P2.0: Embedding architecture migration ---
+
+class TestEmbeddingArchitecture:
+    """Verify embedding dimension-aware validation and model tagging."""
+
+    def test_valid_embedding_dims_include_512_and_768(self):
+        from models.clip import VALID_EMBEDDING_DIMS
+        assert 512 in VALID_EMBEDDING_DIMS
+        assert 768 in VALID_EMBEDDING_DIMS
+
+    def test_clip_has_embedding_model_field(self):
+        from models.clip import Clip
+        c = Clip(
+            id="test",
+            source_id="s1",
+            start_frame=0,
+            end_frame=100,
+        )
+        assert hasattr(c, "embedding_model")
+        assert c.embedding_model is None
+
+    def test_embedding_model_roundtrip(self):
+        from models.clip import Clip
+        c = Clip(
+            id="test",
+            source_id="s1",
+            start_frame=0,
+            end_frame=100,
+            embedding_model="dinov2-vit-b-14",
+        )
+        data = c.to_dict()
+        assert data["embedding_model"] == "dinov2-vit-b-14"
+
+        restored = Clip.from_dict(data)
+        assert restored.embedding_model == "dinov2-vit-b-14"
+
+    def test_512_dim_embedding_still_valid(self):
+        """Old 512-dim CLIP embeddings should still pass validation."""
+        from models.clip import Clip
+        c = Clip(
+            id="test",
+            source_id="s1",
+            start_frame=0,
+            end_frame=100,
+            embedding=[0.0] * 512,
+        )
+        assert len(c.embedding) == 512
+
+    def test_768_dim_embedding_valid(self):
+        """New 768-dim DINOv2 embeddings should pass validation."""
+        from models.clip import Clip
+        c = Clip(
+            id="test",
+            source_id="s1",
+            start_frame=0,
+            end_frame=100,
+            embedding=[0.0] * 768,
+        )
+        assert len(c.embedding) == 768
+
+    def test_invalid_dim_embedding_discarded_on_load(self):
+        """Embeddings with invalid dimensions should be discarded on from_dict."""
+        from models.clip import Clip
+        data = {
+            "id": "test",
+            "source_id": "s1",
+            "start_frame": 0,
+            "end_frame": 100,
+            "embedding": [0.0] * 256,
+        }
+        c = Clip.from_dict(data)
+        assert c.embedding is None
+
+    def test_schema_version_bumped(self):
+        from core.project import SCHEMA_VERSION
+        assert SCHEMA_VERSION >= "1.2"
+
+
+# --- P2.1: DINOv2 for visual similarity embeddings ---
+
+class TestDINOv2Embeddings:
+    """Verify DINOv2 replaces CLIP for embeddings."""
+
+    def test_dinov2_model_name(self):
+        from core.analysis.embeddings import _DINOV2_MODEL_NAME
+        assert _DINOV2_MODEL_NAME == "facebook/dinov2-base"
+
+    def test_embedding_dim_768(self):
+        from core.analysis.embeddings import _EMBEDDING_DIM
+        assert _EMBEDDING_DIM == 768
+
+    def test_model_tag(self):
+        from core.analysis.embeddings import _EMBEDDING_MODEL_TAG
+        assert _EMBEDDING_MODEL_TAG == "dinov2-vit-b-14"
+
+    def test_no_clip_import(self):
+        """embeddings.py should not use openai/clip."""
+        import inspect
+        import core.analysis.embeddings as emb
+        source = inspect.getsource(emb)
+        assert "openai/clip" not in source
+
+    def test_zero_embedding_is_768(self):
+        """Zero embeddings should be 768-dim for DINOv2."""
+        from core.analysis.embeddings import _EMBEDDING_DIM
+        zero = [0.0] * _EMBEDDING_DIM
+        assert len(zero) == 768
+
+    def test_embedding_model_tag_set_in_remix(self):
+        """remix/__init__.py should tag clips with embedding model."""
+        import inspect
+        import core.remix as remix
+        source = inspect.getsource(remix)
+        assert "_EMBEDDING_MODEL_TAG" in source
+
+
+# --- P2.2: Qwen3-VL 4B for local VLM descriptions ---
+
+class TestQwen3VLDescriptions:
+    """Verify Qwen3-VL replaces Moondream for local descriptions."""
+
+    def test_local_vlm_name(self):
+        from core.analysis.description import _LOCAL_VLM_NAME
+        assert _LOCAL_VLM_NAME == "mlx-community/Qwen3-VL-4B-4bit"
+
+    def test_moondream_fallback_preserved(self):
+        from core.analysis.description import _LOCAL_VLM_FALLBACK
+        assert "moondream" in _LOCAL_VLM_FALLBACK.lower()
+
+    def test_is_mlx_vlm_available_function_exists(self):
+        from core.analysis.description import is_mlx_vlm_available
+        assert callable(is_mlx_vlm_available)
+
+    def test_describe_frame_local_function_exists(self):
+        from core.analysis.description import describe_frame_local
+        assert callable(describe_frame_local)
+
+    def test_describe_frame_cpu_backward_compat(self):
+        """describe_frame_cpu should still exist as an alias."""
+        from core.analysis.description import describe_frame_cpu
+        assert callable(describe_frame_cpu)
+
+    def test_description_tier_default_is_local(self):
+        settings = Settings()
+        assert settings.description_model_tier == "local"
+
+    def test_description_model_local_default(self):
+        settings = Settings()
+        assert settings.description_model_local == "mlx-community/Qwen3-VL-4B-4bit"
+
+    def test_tier_migration_cpu_to_local(self, tmp_path):
+        """Legacy 'cpu' tier should be migrated to 'local' on load."""
+        config = {
+            "description": {
+                "model_tier": "cpu",
+                "model_cpu": "vikhyatk/moondream2",
+            }
+        }
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(config))
+
+        loaded = Settings()
+        _load_from_json(config_path, loaded)
+        assert loaded.description_model_tier == "local"
+
+    def test_tier_migration_gpu_to_local(self, tmp_path):
+        """Legacy 'gpu' tier should be migrated to 'local' on load."""
+        config = {
+            "description": {
+                "model_tier": "gpu",
+            }
+        }
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(config))
+
+        loaded = Settings()
+        _load_from_json(config_path, loaded)
+        assert loaded.description_model_tier == "local"
+
+    def test_describe_time_estimate_updated(self):
+        """Local describe time should reflect Qwen3-VL speeds."""
+        from core.cost_estimates import TIME_PER_CLIP
+        time_local = TIME_PER_CLIP["describe"]["local"]
+        assert time_local <= 2.0, (
+            f"Describe time should be <=2.0s (Qwen3-VL), got {time_local}"
+        )
+
+    def test_video_capable_model_includes_qwen(self):
+        from core.analysis.description import is_video_capable_model
+        assert is_video_capable_model("qwen3-vl-4b")
+
+    def test_model_local_setting_roundtrip(self, tmp_path):
+        s = Settings()
+        s.description_model_local = "custom-local-model"
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(_settings_to_json(s)))
+
+        loaded = Settings()
+        _load_from_json(config_path, loaded)
+        assert loaded.description_model_local == "custom-local-model"
+
+
+# --- P2.3: PaddleOCR PP-OCRv5 for text extraction ---
+
+class TestPaddleOCR:
+    """Verify PaddleOCR replaces Tesseract for text extraction."""
+
+    def test_paddleocr_availability_function_exists(self):
+        from core.analysis.ocr import is_paddleocr_available
+        assert callable(is_paddleocr_available)
+
+    def test_tesseract_alias_exists(self):
+        """is_tesseract_available should still exist as a legacy alias."""
+        from core.analysis.ocr import is_tesseract_available
+        assert callable(is_tesseract_available)
+
+    def test_extract_text_from_frame_function_exists(self):
+        from core.analysis.ocr import extract_text_from_frame
+        assert callable(extract_text_from_frame)
+
+    def test_extract_text_from_frame_returns_paddleocr_source(self):
+        """Return tuple should use 'paddleocr' as source tag."""
+        import inspect
+        import core.analysis.ocr as ocr
+        source_code = inspect.getsource(ocr)
+        assert '"paddleocr"' in source_code
+
+    def test_no_pytesseract_import(self):
+        """ocr.py should not import pytesseract."""
+        import inspect
+        import core.analysis.ocr as ocr
+        source_code = inspect.getsource(ocr)
+        assert "import pytesseract" not in source_code
+
+    def test_settings_method_default(self):
+        settings = Settings()
+        assert settings.text_extraction_method == "hybrid"
+
+    def test_settings_method_migration_tesseract_to_paddleocr(self, tmp_path):
+        """Legacy 'tesseract' method should be migrated to 'paddleocr'."""
+        config = {
+            "text_extraction": {
+                "method": "tesseract",
+            }
+        }
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(config))
+
+        loaded = Settings()
+        _load_from_json(config_path, loaded)
+        assert loaded.text_extraction_method == "paddleocr"
+
+    def test_settings_method_hybrid_preserved(self, tmp_path):
+        """'hybrid' method should not be migrated."""
+        config = {
+            "text_extraction": {
+                "method": "hybrid",
+            }
+        }
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps(config))
+
+        loaded = Settings()
+        _load_from_json(config_path, loaded)
+        assert loaded.text_extraction_method == "hybrid"
+
+    def test_text_detection_module_deprecated(self):
+        """text_detection.py should be marked deprecated."""
+        import inspect
+        import core.analysis.text_detection as td
+        docstring = inspect.getmodule(td).__doc__
+        assert "deprecated" in docstring.lower()
+
+    def test_extracted_text_source_documents_paddleocr(self):
+        """ExtractedText source field should document paddleocr."""
+        from models.clip import ExtractedText
+        et = ExtractedText(
+            frame_number=0,
+            text="hello",
+            confidence=0.9,
+            source="paddleocr",
+        )
+        assert et.source == "paddleocr"
+
+    def test_cost_estimate_extract_text_has_local(self):
+        from core.cost_estimates import TIME_PER_CLIP
+        assert "local" in TIME_PER_CLIP["extract_text"]

--- a/tests/test_srt_export.py
+++ b/tests/test_srt_export.py
@@ -109,7 +109,7 @@ class TestExportSrt:
                     frame_number=0,
                     text=text,
                     confidence=0.9,
-                    source="tesseract",
+                    source="paddleocr",
                 )
                 for text in ocr_texts
             ]

--- a/ui/dialogs/exquisite_corpus_dialog.py
+++ b/ui/dialogs/exquisite_corpus_dialog.py
@@ -414,11 +414,10 @@ class ExquisiteCorpusDialog(QDialog):
         vlm_only = (method == "vlm")
         use_vlm = (method in ("vlm", "hybrid"))
         vlm_model = settings.text_extraction_vlm_model if use_vlm else None
-        use_text_detection = settings.text_detection_enabled
 
         logger.info(
             f"Starting text extraction for {len(self.clips)} clips "
-            f"(method={method}, vlm_only={vlm_only}, text_detection={use_text_detection})"
+            f"(method={method}, vlm_only={vlm_only})"
         )
 
         self.worker = TextExtractionWorker(
@@ -428,7 +427,6 @@ class ExquisiteCorpusDialog(QDialog):
             use_vlm_fallback=use_vlm,
             vlm_model=vlm_model,
             vlm_only=vlm_only,
-            use_text_detection=use_text_detection,
             parent=self,
         )
         self.worker.progress.connect(self._on_extraction_progress, Qt.UniqueConnection)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -2802,7 +2802,6 @@ class MainWindow(QMainWindow):
         vlm_only = (method == "vlm")
         use_vlm = (method in ("vlm", "hybrid"))
         vlm_model = self.settings.text_extraction_vlm_model if use_vlm else None
-        use_text_detection = self.settings.text_detection_enabled
 
         logger.info(f"Creating TextExtractionWorker (pipeline) for {len(clips_to_process)} clips")
         self.text_extraction_worker = TextExtractionWorker(
@@ -2812,7 +2811,6 @@ class MainWindow(QMainWindow):
             use_vlm_fallback=use_vlm,
             vlm_model=vlm_model,
             vlm_only=vlm_only,
-            use_text_detection=use_text_detection,
         )
         self.text_extraction_worker.progress.connect(self._on_text_extraction_progress)
         self.text_extraction_worker.clip_completed.connect(self._on_text_extraction_clip_ready)

--- a/ui/workers/text_extraction_worker.py
+++ b/ui/workers/text_extraction_worker.py
@@ -53,8 +53,8 @@ class TextExtractionWorker(CancellableWorker):
             num_keyframes: Number of frames to sample per clip (1-5)
             use_vlm_fallback: Whether to use VLM for low-confidence results
             vlm_model: VLM model to use (default: from settings)
-            vlm_only: If True, skip Tesseract and only use VLM
-            use_text_detection: Whether to use EAST pre-filter (default: True)
+            vlm_only: If True, skip PaddleOCR and only use VLM
+            use_text_detection: Deprecated (PaddleOCR handles detection internally)
             analysis_targets: Optional list of AnalysisTarget objects (alternative to clips)
             parent: Optional parent QObject
         """


### PR DESCRIPTION
## Summary

P2 quality upgrades replacing three analysis subsystems with better alternatives:

- **P2.0: Embedding architecture migration** — dimension-aware validation (`VALID_EMBEDDING_DIMS = {512, 768}`), `Clip.embedding_model` field, schema v1.2
- **P2.1: DINOv2 for visual similarity** — replace CLIP ViT-B/32 (512-dim) with `facebook/dinov2-base` (768-dim) self-supervised embeddings
- **P2.2: Qwen3-VL 4B for local descriptions** — replace Moondream with `mlx-community/Qwen3-VL-4B-4bit` via mlx-vlm, rename cpu/gpu → local/cloud tiers
- **P2.3: PaddleOCR PP-OCRv5 for text extraction** — replace EAST + Tesseract pipeline with PaddleOCR single-pass, remove pytesseract dependency

## Changes

| Area | Files | What Changed |
|------|-------|-------------|
| Embeddings | `core/analysis/embeddings.py`, `core/remix/__init__.py`, `models/clip.py` | DINOv2-base, 768-dim, model tagging |
| Descriptions | `core/analysis/description.py`, `core/settings.py` | Qwen3-VL via mlx-vlm, tier migration |
| OCR | `core/analysis/ocr.py`, `core/analysis/text_detection.py` | PaddleOCR engine, EAST deprecated |
| Settings UI | `ui/settings_dialog.py`, `ui/main_window.py` | PaddleOCR labels, removed EAST controls |
| Dependencies | `requirements.txt` | Removed pytesseract |
| Tests | `tests/test_p2_quality_upgrades.py` + 5 existing test files | 36 new pinning tests, fixed 5 pre-existing |

## Test plan

- [x] 36 new P2 pinning tests pass (embedding dims, model names, migrations, function existence)
- [x] Full suite: 686 passed, 0 failed
- [x] Backward compatibility: old 512-dim CLIP embeddings still valid, `describe_frame_cpu()` alias works, `is_tesseract_available()` alias exists
- [x] Settings migrations: `tesseract` → `paddleocr`, `cpu`/`gpu` → `local`

🤖 Generated with [Claude Code](https://claude.com/claude-code)