### PR TITLE
refactor(remix): address all 14 PR #58 review findings

### DIFF
--- a/models/sequence.py
+++ b/models/sequence.py
@@ -142,7 +142,6 @@ class Sequence:
     reference_source_id: Optional[str] = None  # Source used as structural guide
     dimension_weights: Optional[dict[str, float]] = None  # Dimension -> weight (0.0-1.0)
     allow_repeats: bool = False  # Allow same clip matched to multiple positions
-    match_reference_timing: bool = False  # Use reference clip durations
 
     def __post_init__(self):
         """Ensure at least one track exists."""
@@ -201,8 +200,6 @@ class Sequence:
             data["dimension_weights"] = self.dimension_weights
         if self.allow_repeats:
             data["allow_repeats"] = self.allow_repeats
-        if self.match_reference_timing:
-            data["match_reference_timing"] = self.match_reference_timing
         return data
 
     @classmethod
@@ -221,7 +218,6 @@ class Sequence:
             reference_source_id=data.get("reference_source_id"),
             dimension_weights=data.get("dimension_weights"),
             allow_repeats=data.get("allow_repeats", False),
-            match_reference_timing=data.get("match_reference_timing", False),
         )
         # If no tracks were loaded, ensure at least one exists
         if not seq.tracks:

--- a/tests/test_reference_match.py
+++ b/tests/test_reference_match.py
@@ -317,14 +317,12 @@ class TestSequenceModelExtensions:
             reference_source_id="src-ref",
             dimension_weights={"brightness": 0.8, "color": 0.5},
             allow_repeats=True,
-            match_reference_timing=False,
         )
         data = seq.to_dict()
         assert data["algorithm"] == "reference_guided"
         assert data["reference_source_id"] == "src-ref"
         assert data["dimension_weights"] == {"brightness": 0.8, "color": 0.5}
         assert data["allow_repeats"] is True
-        assert "match_reference_timing" not in data  # False is default, not written
 
     def test_from_dict_round_trip(self):
         seq = Sequence(
@@ -332,7 +330,6 @@ class TestSequenceModelExtensions:
             reference_source_id="src-ref",
             dimension_weights={"brightness": 0.8},
             allow_repeats=True,
-            match_reference_timing=True,
         )
         data = seq.to_dict()
         restored = Sequence.from_dict(data)
@@ -341,7 +338,6 @@ class TestSequenceModelExtensions:
         assert restored.reference_source_id == "src-ref"
         assert restored.dimension_weights == {"brightness": 0.8}
         assert restored.allow_repeats is True
-        assert restored.match_reference_timing is True
 
     def test_from_dict_backward_compatible(self):
         """Old project files without reference fields should load fine."""
@@ -357,7 +353,6 @@ class TestSequenceModelExtensions:
         assert seq.reference_source_id is None
         assert seq.dimension_weights is None
         assert seq.allow_repeats is False
-        assert seq.match_reference_timing is False
 
 
 # --- Active Dimensions Detection ---

--- a/todos/011-complete-p2-replace-any-typing-reference-match.md
+++ b/todos/011-complete-p2-replace-any-typing-reference-match.md
@@ -1,0 +1,100 @@
+---
+status: complete
+priority: p2
+issue_id: "011"
+tags: [code-review, type-safety, quality]
+dependencies: []
+---
+
+# Replace `Any` Typing in reference_match.py
+
+## Problem Statement
+
+Heavy use of `Any` typing in `core/remix/reference_match.py` defeats type safety. Every function that accepts a `Clip` or `Source` object uses `Any` instead of the actual types, making it impossible for type checkers (mypy, pyright) to catch attribute access errors. For example, `clip.cinematography.shot_size` is accessed without any static guarantee that `clip` has a `cinematography` attribute.
+
+## Findings
+
+**Location:** `core/remix/reference_match.py`
+
+The following functions all use `Any` where `Clip` or `Source` types should be used:
+
+- **Line 9**: `from typing import Any, Optional` - `Any` imported for use throughout
+- **Line 56**: `def _get_proximity_score(clip: Any) -> float:` - should be `Clip`
+- **Lines 68-72**: `def extract_feature_vector(clip: Any, source: Any, ...) -> dict[str, Any]:` - `clip` should be `Clip`, `source` should be `Source`
+- **Lines 115-117**: `def compute_normalizers(all_vectors: list[dict[str, Any]], ...) -> dict[str, tuple[float, float]]:` - return dict values are `Any` but are always numeric
+- **Lines 210-216**: `def reference_guided_match(reference_clips: list[tuple[Any, Any]], user_clips: list[tuple[Any, Any]], ...) -> list[tuple[Any, Any]]:` - all `Any` should be `Clip` and `Source`
+- **Line 262**: `result: list[tuple[Any, Any]] = []` - should be `list[tuple[Clip, Source]]`
+- **Lines 298-300**: `def get_active_dimensions_for_clips(clips: list[Any]) -> list[str]:` - should be `list[Clip]`
+
+The `Any` typing also bleeds into the return types, so callers of `reference_guided_match` lose type information on the returned tuples.
+
+**Impact:** A typo like `clip.cinematograhpy` (misspelling) would not be caught by static analysis. Same for accessing non-existent attributes after a model refactor.
+
+## Proposed Solutions
+
+### Option A: TYPE_CHECKING Guard with Proper Annotations (Recommended)
+**Pros:** Full type safety, no circular import risk, zero runtime cost
+**Cons:** Slightly more boilerplate at top of file
+**Effort:** Small
+**Risk:** None
+
+```python
+from __future__ import annotations
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from models.clip import Clip, Source
+
+def _get_proximity_score(clip: Clip) -> float: ...
+def extract_feature_vector(clip: Clip, source: Source, ...) -> dict[str, float | list[float] | str]: ...
+def reference_guided_match(
+    reference_clips: list[tuple[Clip, Source]],
+    user_clips: list[tuple[Clip, Source]],
+    ...
+) -> list[tuple[Clip, Source]]: ...
+```
+
+### Option B: Direct Imports
+**Pros:** Simplest approach
+**Cons:** May introduce circular import if models ever import from remix
+**Effort:** Small
+**Risk:** Low (no current circular dependency, but fragile)
+
+### Option C: Protocol-Based Typing
+**Pros:** Decouples from concrete model classes
+**Cons:** Over-engineered for this use case, more code to maintain
+**Effort:** Medium
+**Risk:** Low
+
+## Recommended Action
+
+Option A - Use `TYPE_CHECKING` guard with `from __future__ import annotations` for zero-cost type safety.
+
+## Technical Details
+
+**Affected Files:**
+- `core/remix/reference_match.py` - Replace all `Any` with proper `Clip`/`Source` types
+
+**Verification:**
+1. Run `mypy core/remix/reference_match.py` or `pyright` - should pass with no errors
+2. Intentionally misspell an attribute access - type checker should flag it
+3. Run `pytest tests/test_reference_match.py` - all tests still pass
+
+## Acceptance Criteria
+
+- [ ] No `Any` type annotations remain in `reference_match.py` (except for truly dynamic values)
+- [ ] `Clip` and `Source` types used for all clip/source parameters and return types
+- [ ] `TYPE_CHECKING` guard prevents any runtime import overhead
+- [ ] All existing tests pass without modification
+- [ ] Type checker (mypy/pyright) reports no new errors
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | `Any` typing should be replaced with proper types using TYPE_CHECKING guard to maintain type safety without runtime cost |
+
+## Resources
+
+- PR #58: Reference-Guided Remixing
+- Python typing docs: https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING

--- a/todos/012-complete-p2-extract-apply-sequence-method.md
+++ b/todos/012-complete-p2-extract-apply-sequence-method.md
@@ -1,0 +1,195 @@
+---
+status: complete
+priority: p2
+issue_id: "012"
+tags: [code-review, duplication, architecture]
+dependencies: []
+---
+
+# Extract Shared `_apply_matched_sequence()` Method in sequence_tab.py
+
+## Problem Statement
+
+Three nearly-identical `_apply_*_sequence` methods in `ui/tabs/sequence_tab.py` share approximately 80% of their code. The Exquisite Corpus, Storyteller, and Reference Guide apply methods all perform the same steps: clear timeline, set FPS, load video, add clips in order, update preview, update dropdown, set algorithm name, persist on sequence, and transition state. Additionally, the agent path `generate_reference_guided` duplicates this same logic a fourth time. This creates a maintenance risk where a fix applied to one path (e.g., a timeline update bug) may not be applied to the others.
+
+## Findings
+
+**Location:** `ui/tabs/sequence_tab.py`
+
+### `_apply_exquisite_corpus_sequence` (lines 586-638)
+
+```python
+def _apply_exquisite_corpus_sequence(self, sequence_clips: list):
+    # Clear and populate timeline
+    self.timeline.clear_timeline()
+    first_clip, first_source = sequence_clips[0]
+    self.timeline.set_fps(first_source.fps)
+    self.video_player.load_video(first_source.file_path)
+    current_frame = 0
+    for clip, source in sequence_clips:
+        self.timeline.add_clip(clip, source, track_index=0, start_frame=current_frame)
+        current_frame += clip.duration_frames
+        self.clip_added.emit(clip, source)
+    self.timeline_preview.set_clips(sequence_clips, self._sources)
+    self.timeline._on_zoom_fit()
+    # ... dropdown update, algorithm set, state transition
+```
+
+### `_apply_storyteller_sequence` (lines 727-778)
+
+```python
+def _apply_storyteller_sequence(self, sequence_clips: list):
+    # Identical structure: clear, fps, load, add clips, preview, zoom, dropdown, state
+```
+
+### `_apply_reference_guide_sequence` (lines 799-852)
+
+```python
+def _apply_reference_guide_sequence(self, sequence_clips: list):
+    # Same pattern plus: storing dialog config on sequence
+```
+
+### `generate_reference_guided` (lines 1260-1369) - Agent path
+
+```python
+def generate_reference_guided(self, ...):
+    # Lines 1320-1349: Same timeline population pattern duplicated again
+```
+
+**Shared steps across all four paths:**
+1. `self.timeline.clear_timeline()`
+2. Set FPS from first source
+3. Load video into player
+4. Iterate clips: `add_clip()` + emit `clip_added`
+5. `self.timeline_preview.set_clips()`
+6. `self.timeline._on_zoom_fit()`
+7. Update algorithm dropdown (add item if missing, set current text)
+8. Set `self._current_algorithm`
+9. Set `sequence.algorithm`
+10. `self._set_state(self.STATE_TIMELINE)`
+
+**Differences:**
+- Dropdown label text varies ("Exquisite Corpus", "Storyteller", "Reference Guide")
+- Reference Guide stores extra metadata on sequence (`reference_source_id`, `dimension_weights`, etc.)
+- Agent path returns a dict instead of being void
+
+## Proposed Solutions
+
+### Option A: Extract `_apply_matched_sequence()` Helper (Recommended)
+**Pros:** Eliminates ~120 lines of duplication, single place for timeline population logic, easy to extend
+**Cons:** Need to handle the metadata attachment for Reference Guide as a post-hook
+**Effort:** Medium
+**Risk:** Low
+
+```python
+def _apply_matched_sequence(
+    self,
+    sequence_clips: list,
+    algorithm_key: str,
+    algorithm_label: str,
+    sequence_metadata: dict = None,
+):
+    """Apply a dialog-generated sequence to the timeline.
+
+    Shared by Exquisite Corpus, Storyteller, Reference Guide, and agent paths.
+    """
+    if not sequence_clips:
+        return
+
+    self.timeline.clear_timeline()
+
+    first_clip, first_source = sequence_clips[0]
+    self.timeline.set_fps(first_source.fps)
+    self.video_player.load_video(first_source.file_path)
+
+    current_frame = 0
+    for clip, source in sequence_clips:
+        self.timeline.add_clip(clip, source, track_index=0, start_frame=current_frame)
+        current_frame += clip.duration_frames
+        self.clip_added.emit(clip, source)
+
+    self.timeline_preview.set_clips(sequence_clips, self._sources)
+    self.timeline._on_zoom_fit()
+
+    self.algorithm_dropdown.blockSignals(True)
+    if self.algorithm_dropdown.findText(algorithm_label) == -1:
+        self.algorithm_dropdown.addItem(algorithm_label)
+    self.algorithm_dropdown.setCurrentText(algorithm_label)
+    self.algorithm_dropdown.blockSignals(False)
+
+    self._current_algorithm = algorithm_key
+
+    sequence = self.timeline.get_sequence()
+    sequence.algorithm = algorithm_key
+    if sequence_metadata:
+        for key, value in sequence_metadata.items():
+            setattr(sequence, key, value)
+
+    self._set_state(self.STATE_TIMELINE)
+```
+
+Then each apply method becomes a thin wrapper:
+```python
+def _apply_exquisite_corpus_sequence(self, sequence_clips):
+    self._apply_matched_sequence(sequence_clips, "exquisite_corpus", "Exquisite Corpus")
+
+def _apply_reference_guide_sequence(self, sequence_clips):
+    metadata = {}
+    dialog = self.sender()
+    if dialog and hasattr(dialog, '_last_ref_source_id'):
+        metadata = {
+            "reference_source_id": dialog._last_ref_source_id,
+            "dimension_weights": dialog._last_weights,
+            ...
+        }
+    self._apply_matched_sequence(sequence_clips, "reference_guided", "Reference Guide", metadata)
+```
+
+### Option B: Template Method Pattern
+**Pros:** More OOP, allows overriding specific steps
+**Cons:** Overkill for 3-4 callers, adds class complexity
+**Effort:** Medium
+**Risk:** Medium (harder to reason about)
+
+### Option C: Leave As-Is with Documentation
+**Pros:** No code changes, explicit per-algorithm code
+**Cons:** Duplication remains, maintenance risk persists
+**Effort:** None
+**Risk:** Bug divergence between paths over time
+
+## Recommended Action
+
+Option A - Extract a shared `_apply_matched_sequence()` method with a `sequence_metadata` dict for algorithm-specific extras.
+
+## Technical Details
+
+**Affected Files:**
+- `ui/tabs/sequence_tab.py` - Extract shared method, refactor 4 callers
+
+**Verification:**
+1. Run existing tests: `pytest tests/`
+2. Manually test each algorithm path: Exquisite Corpus, Storyteller, Reference Guide
+3. Test agent tool: `generate_reference_guided` via chat
+4. Verify sequence metadata is correctly persisted for Reference Guide
+
+## Acceptance Criteria
+
+- [ ] Single `_apply_matched_sequence()` method handles all timeline population
+- [ ] `_apply_exquisite_corpus_sequence` delegates to shared method
+- [ ] `_apply_storyteller_sequence` delegates to shared method
+- [ ] `_apply_reference_guide_sequence` delegates to shared method (with metadata)
+- [ ] `generate_reference_guided` agent path delegates to shared method
+- [ ] Reference Guide sequence metadata (source_id, weights, etc.) still persisted
+- [ ] All existing tests pass
+- [ ] No functional behavior change
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | Dialog-based algorithms accumulate near-identical apply methods; extract shared logic before a fourth copy appears |
+
+## Resources
+
+- PR #58: Reference-Guided Remixing
+- DRY principle: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself

--- a/todos/013-complete-p2-remove-match-reference-timing.md
+++ b/todos/013-complete-p2-remove-match-reference-timing.md
@@ -1,0 +1,120 @@
+---
+status: complete
+priority: p2
+issue_id: "013"
+tags: [code-review, yagni, simplicity]
+dependencies: []
+---
+
+# Remove Unimplemented `match_reference_timing` Parameter
+
+## Problem Statement
+
+The `match_reference_timing` parameter is accepted, stored, serialized, and tested throughout the entire stack but **never actually implemented**. The algorithm function `reference_guided_match()` accepts it as a parameter but performs no timing adjustment based on it. This is a classic YAGNI violation: plumbing for a feature that does not exist yet, adding complexity to every layer of the codebase.
+
+## Findings
+
+**The parameter is threaded through 7 files but has zero implementation logic:**
+
+### Algorithm layer
+- **`core/remix/reference_match.py` line 215**: `match_reference_timing: bool = False` - accepted but never read in the function body (lines 236-295 contain no reference to it)
+
+### Dialog layer
+- **`ui/dialogs/reference_guide_dialog.py` line 96**: Passed to `ReferenceMatchWorker.__init__()`
+- **`ui/dialogs/reference_guide_dialog.py` line 104**: Stored as `self.match_reference_timing`
+- **`ui/dialogs/reference_guide_dialog.py` line 118**: Passed through to `reference_guided_match()`
+- **`ui/dialogs/reference_guide_dialog.py` line 452**: Read from `self.match_timing_check.isChecked()`
+
+### Tab layer
+- **`ui/tabs/sequence_tab.py` line 844**: `sequence.match_reference_timing = dialog._last_match_timing`
+- **`ui/tabs/sequence_tab.py` line 1265**: `match_reference_timing: bool = False` parameter on `generate_reference_guided()`
+- **`ui/tabs/sequence_tab.py` line 1310**: Passed to `reference_guided_match()`
+- **`ui/tabs/sequence_tab.py` line 1347**: `sequence.match_reference_timing = match_reference_timing`
+
+### Agent tool layer
+- **`core/chat_tools.py` line 3958**: `match_reference_timing: bool = False` parameter on agent tool
+- **`core/chat_tools.py` line 3968**: Docstring describes the parameter
+- **`core/chat_tools.py` line 4005**: Passed to `sequence_tab.generate_reference_guided()`
+
+### Model layer
+- **`models/sequence.py` line 145**: `match_reference_timing: bool = False` field on `Sequence`
+- **`models/sequence.py` lines 204-205**: Serialized to JSON when True
+- **`models/sequence.py` line 224**: Deserialized from JSON
+
+### Test layer
+- **`tests/test_reference_match.py` lines 320, 327, 335, 344, 360**: Tested for persistence round-trip despite no functional behavior
+
+**Total: ~20 lines of plumbing across 7 files for zero functionality.**
+
+## Proposed Solutions
+
+### Option A: Remove Entirely (Recommended)
+**Pros:** Eliminates dead parameter from all layers, simplifies every function signature, removes misleading test coverage, follows YAGNI
+**Cons:** If/when timing matching is needed, it must be re-added
+**Effort:** Small (30 min - mostly deleting code)
+**Risk:** None (parameter has no effect)
+
+Steps:
+1. Remove parameter from `reference_guided_match()` signature
+2. Remove from `ReferenceMatchWorker`
+3. Remove from `ReferenceGuideDialog` (remove checkbox widget)
+4. Remove from `SequenceTab.generate_reference_guided()` and `_apply_reference_guide_sequence()`
+5. Remove from `generate_reference_guided` agent tool
+6. Remove from `Sequence` model
+7. Remove/update tests
+8. Add a comment in `reference_match.py`: `# Future: match_reference_timing could trim output clips to reference durations`
+
+### Option B: Keep but Mark as NotImplemented
+**Pros:** Preserves the API for future use
+**Cons:** Still clutters 7 files, checkbox misleads users into thinking it works
+**Effort:** Small (just add a `raise NotImplementedError` or `logger.warning`)
+**Risk:** Low, but still carries dead code weight
+
+### Option C: Implement It Now
+**Pros:** Feature is actually useful - trim clips to match reference durations
+**Cons:** Scope creep, not requested, adds complexity to the matching algorithm
+**Effort:** Medium-Large (requires changes to clip in/out point handling)
+**Risk:** Medium (new behavior to test)
+
+## Recommended Action
+
+Option A - Remove the parameter entirely. When the feature is actually needed, add it back with a proper implementation. The parameter currently misleads users via the dialog checkbox and inflates test surface area.
+
+## Technical Details
+
+**Affected Files:**
+- `core/remix/reference_match.py` - Remove parameter from `reference_guided_match()`
+- `ui/dialogs/reference_guide_dialog.py` - Remove from worker, remove checkbox
+- `ui/tabs/sequence_tab.py` - Remove from `generate_reference_guided()` and apply method
+- `core/chat_tools.py` - Remove from agent tool
+- `models/sequence.py` - Remove field, update serialization
+- `tests/test_reference_match.py` - Remove timing-related test assertions
+
+**Verification:**
+1. Run `pytest tests/test_reference_match.py` - all tests pass
+2. Run `pytest tests/` - full suite passes
+3. Verify dialog no longer shows non-functional checkbox
+4. Verify saved projects without `match_reference_timing` still load correctly
+
+## Acceptance Criteria
+
+- [ ] `match_reference_timing` parameter removed from `reference_guided_match()` function
+- [ ] Parameter removed from `ReferenceMatchWorker` and dialog
+- [ ] Parameter removed from `SequenceTab.generate_reference_guided()`
+- [ ] Parameter removed from `generate_reference_guided` agent tool
+- [ ] Field removed from `Sequence` model (with backward-compatible deserialization)
+- [ ] Dialog checkbox removed
+- [ ] Tests updated to not reference the parameter
+- [ ] All existing tests pass
+- [ ] Comment added noting future timing-match feature possibility
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | Parameters should not be threaded through the stack until they have actual implementation; follow YAGNI principle |
+
+## Resources
+
+- PR #58: Reference-Guided Remixing
+- YAGNI: https://martinfowler.com/bliki/Yagni.html

--- a/todos/014-complete-p2-use-cancellable-worker-base.md
+++ b/todos/014-complete-p2-use-cancellable-worker-base.md
@@ -1,0 +1,163 @@
+---
+status: complete
+priority: p2
+issue_id: "014"
+tags: [code-review, conventions, threading]
+dependencies: []
+---
+
+# Use CancellableWorker Base Class for ReferenceMatchWorker
+
+## Problem Statement
+
+`ReferenceMatchWorker` inherits from `QThread` directly instead of `CancellableWorker` as specified in CLAUDE.md project conventions. The worker uses a bare `self._cancelled = False` boolean flag for cancellation, which is not thread-safe (no memory barrier). Additionally, the algorithm function `reference_guided_match()` has no cancellation check in its inner loop, meaning a cancel request has no effect until the entire matching computation finishes.
+
+## Findings
+
+**Location:** `ui/dialogs/reference_guide_dialog.py` lines 83-131
+
+```python
+class ReferenceMatchWorker(QThread):  # Should be CancellableWorker
+    """Background worker for reference-guided matching."""
+
+    progress = Signal(str)
+    match_ready = Signal(list)
+    error = Signal(str)
+
+    def __init__(self, reference_clips, user_clips, weights,
+                 allow_repeats, match_reference_timing, parent=None):
+        super().__init__(parent)
+        # ...
+        self._cancelled = False  # Not thread-safe!
+
+    def run(self):
+        try:
+            matched = reference_guided_match(...)
+            if not self._cancelled:
+                self.match_ready.emit(matched)
+        except Exception as e:
+            if not self._cancelled:
+                self.error.emit(str(e))
+
+    def cancel(self):
+        self._cancelled = True  # Race condition: no threading.Event
+```
+
+**Convention reference:** `ui/workers/base.py` lines 14-24
+
+```python
+class CancellableWorker(QThread):
+    """Base class for workers that support cancellation.
+
+    Uses threading.Event for thread-safe cancellation, which is essential
+    when workers use ThreadPoolExecutor or other multi-threaded patterns.
+
+    Provides:
+    - Thread-safe cancellation via threading.Event
+    - cancel() method with logging
+    - Common logging patterns for worker lifecycle
+    """
+```
+
+**Algorithm inner loop has no cancellation check:** `core/remix/reference_match.py` lines 264-286
+
+```python
+for ref_idx, ref_vec in enumerate(ref_vectors):  # Could be 100s of iterations
+    best_distance = float("inf")
+    best_user_idx = None
+
+    for user_idx, user_vec in enumerate(user_vectors):  # Nested loop: R*U iterations
+        if not allow_repeats and user_idx in used_indices:
+            continue
+        dist = weighted_distance(...)  # No cancellation check anywhere
+        if dist < best_distance:
+            best_distance = dist
+            best_user_idx = user_idx
+    # ...
+```
+
+With 200 reference clips and 500 user clips, this is 100,000 distance computations with no opportunity to bail out.
+
+## Proposed Solutions
+
+### Option A: Inherit CancellableWorker + Pass Cancellation Check to Algorithm (Recommended)
+**Pros:** Follows conventions, thread-safe cancellation, responsive cancel during long matches
+**Cons:** Requires adding a `cancelled_check` parameter to `reference_guided_match()`
+**Effort:** Small
+**Risk:** Low
+
+```python
+# Worker:
+class ReferenceMatchWorker(CancellableWorker):
+    def run(self):
+        try:
+            matched = reference_guided_match(
+                ...,
+                cancelled_check=self._cancel_event.is_set,
+            )
+            if not self._cancel_event.is_set():
+                self.match_ready.emit(matched)
+        except CancelledError:
+            pass
+
+# Algorithm:
+def reference_guided_match(
+    ...,
+    cancelled_check: Callable[[], bool] | None = None,
+) -> list[tuple[Clip, Source]]:
+    for ref_idx, ref_vec in enumerate(ref_vectors):
+        if cancelled_check and cancelled_check():
+            return result  # Return partial results or empty
+        # ... matching logic
+```
+
+### Option B: Inherit CancellableWorker Only (No Algorithm Change)
+**Pros:** Follows conventions for the worker class, simpler change
+**Cons:** Cancel still waits for full algorithm completion
+**Effort:** Small
+**Risk:** Low (but misses the real benefit of cancellation)
+
+### Option C: Keep QThread but Add threading.Event
+**Pros:** Thread-safe cancellation without changing base class
+**Cons:** Doesn't follow project conventions, reinvents CancellableWorker
+**Effort:** Small
+**Risk:** Low
+
+## Recommended Action
+
+Option A - Inherit from `CancellableWorker` and pass a cancellation check into the algorithm's inner loop. This follows project conventions and provides responsive cancellation.
+
+## Technical Details
+
+**Affected Files:**
+- `ui/dialogs/reference_guide_dialog.py` - Change `ReferenceMatchWorker` to inherit `CancellableWorker`
+- `core/remix/reference_match.py` - Add optional `cancelled_check` parameter to `reference_guided_match()`
+
+**Verification:**
+1. Start a reference-guided match with many clips
+2. Click cancel during matching
+3. Verify the operation stops promptly (within ~100ms)
+4. Verify no signals emitted after cancellation
+5. Run `pytest tests/test_reference_match.py` - all tests pass
+
+## Acceptance Criteria
+
+- [ ] `ReferenceMatchWorker` inherits from `CancellableWorker` instead of `QThread`
+- [ ] `self._cancelled` boolean replaced with `self._cancel_event` from base class
+- [ ] `reference_guided_match()` accepts optional `cancelled_check` callable
+- [ ] Inner matching loop checks cancellation at each reference clip iteration
+- [ ] Cancellation during matching returns partial/empty results gracefully
+- [ ] All existing tests pass without modification
+- [ ] Manual test: cancel mid-match works responsively
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | New workers should always inherit from CancellableWorker; algorithm functions with O(n*m) loops should accept cancellation callbacks |
+
+## Resources
+
+- PR #58: Reference-Guided Remixing
+- `ui/workers/base.py` - CancellableWorker base class
+- CLAUDE.md: "All workers inherit from CancellableWorker (ui/workers/base.py)"

--- a/todos/015-complete-p2-vectorize-cosine-distance.md
+++ b/todos/015-complete-p2-vectorize-cosine-distance.md
@@ -1,0 +1,167 @@
+---
+status: complete
+priority: p2
+issue_id: "015"
+tags: [code-review, performance, algorithm]
+dependencies: []
+---
+
+# Vectorize Cosine Distance Computation in reference_match.py
+
+## Problem Statement
+
+`_cosine_distance()` in `core/remix/reference_match.py` allocates two new numpy arrays per call by converting Python lists to `np.array`. With 768-dimensional CLIP embeddings and R reference clips * U user clips pairs, this creates massive garbage collection pressure at scale. For example, 200 reference clips and 500 user clips means 100,000 calls to `_cosine_distance()`, each allocating two 768-element float32 arrays (6 KB per call = ~600 MB of short-lived allocations).
+
+The codebase already has the correct vectorized pattern in `core/remix/similarity_chain.py` and `core/remix/match_cut.py`, where embeddings are pre-converted to numpy matrices and batch dot products are used.
+
+## Findings
+
+**Location:** `core/remix/reference_match.py` lines 148-162
+
+```python
+def _cosine_distance(a: list[float], b: list[float]) -> float:
+    """Compute cosine distance between two vectors, normalized to [0, 1]."""
+    a_arr = np.array(a, dtype=np.float32)  # Allocation per call
+    b_arr = np.array(b, dtype=np.float32)  # Allocation per call
+
+    norm_a = np.linalg.norm(a_arr)
+    norm_b = np.linalg.norm(b_arr)
+
+    if norm_a == 0 or norm_b == 0:
+        return 1.0
+
+    similarity = np.dot(a_arr, b_arr) / (norm_a * norm_b)
+    similarity = float(np.clip(similarity, -1.0, 1.0))
+    return (1.0 - similarity) / 2.0
+```
+
+**Called from:** `weighted_distance()` line 190, which is called inside the nested matching loop at lines 264-272:
+
+```python
+for ref_idx, ref_vec in enumerate(ref_vectors):       # R iterations
+    for user_idx, user_vec in enumerate(user_vectors): # U iterations
+        dist = weighted_distance(...)                   # Calls _cosine_distance()
+```
+
+**Existing vectorized pattern:** `core/remix/similarity_chain.py` lines 16-28
+
+```python
+def _cosine_distance_matrix(embeddings: np.ndarray) -> np.ndarray:
+    """Compute pairwise cosine distance matrix."""
+    # Embeddings are already L2-normalized, so dot product = cosine similarity
+    similarity = embeddings @ embeddings.T  # Single matrix multiply
+    np.clip(similarity, -1.0, 1.0, out=similarity)
+    return 1.0 - similarity
+```
+
+**Same pattern in:** `core/remix/match_cut.py` lines 66-70
+
+```python
+similarity = last_embeddings @ first_embeddings.T  # Vectorized
+np.clip(similarity, -1.0, 1.0, out=similarity)
+cost_matrix = 1.0 - similarity
+```
+
+## Proposed Solutions
+
+### Option A: Pre-build Embedding Matrices and Vectorized Distance (Recommended)
+**Pros:** Eliminates all per-call allocations, 10-100x faster for large clip sets, follows existing codebase pattern
+**Cons:** Slightly more complex matching loop, requires splitting embedding distance from the weighted_distance function
+**Effort:** Medium
+**Risk:** Low (well-tested pattern already in codebase)
+
+```python
+def _precompute_embedding_distances(
+    ref_vectors: list[dict],
+    user_vectors: list[dict],
+) -> np.ndarray | None:
+    """Pre-compute R x U embedding cosine distance matrix.
+
+    Returns None if no embeddings are available.
+    """
+    ref_embeddings = []
+    user_embeddings = []
+    for v in ref_vectors:
+        if "embedding" in v:
+            ref_embeddings.append(v["embedding"])
+    for v in user_vectors:
+        if "embedding" in v:
+            user_embeddings.append(v["embedding"])
+
+    if not ref_embeddings or not user_embeddings:
+        return None
+
+    ref_matrix = np.array(ref_embeddings, dtype=np.float32)  # R x D
+    user_matrix = np.array(user_embeddings, dtype=np.float32)  # U x D
+
+    # L2 normalize
+    ref_norms = np.linalg.norm(ref_matrix, axis=1, keepdims=True)
+    user_norms = np.linalg.norm(user_matrix, axis=1, keepdims=True)
+    ref_norms[ref_norms == 0] = 1.0
+    user_norms[user_norms == 0] = 1.0
+    ref_matrix /= ref_norms
+    user_matrix /= user_norms
+
+    # Single matrix multiply: R x U similarity matrix
+    similarity = ref_matrix @ user_matrix.T
+    np.clip(similarity, -1.0, 1.0, out=similarity)
+    return (1.0 - similarity) / 2.0  # R x U distance matrix
+```
+
+Then in `reference_guided_match()`:
+```python
+embedding_distances = _precompute_embedding_distances(ref_vectors, user_vectors)
+# In inner loop: look up embedding_distances[ref_idx, user_idx] instead of calling _cosine_distance()
+```
+
+### Option B: Cache numpy Arrays in Feature Vectors
+**Pros:** Simpler change - store embeddings as numpy arrays in extract_feature_vector
+**Cons:** Still O(R*U) individual dot products, just avoids the list->array conversion
+**Effort:** Small
+**Risk:** None
+
+### Option C: Use scipy.spatial.distance.cdist
+**Pros:** One-liner, battle-tested implementation
+**Cons:** Adds scipy dependency (heavy), overkill for this single use
+**Effort:** Small
+**Risk:** Low but adds dependency
+
+## Recommended Action
+
+Option A - Pre-compute the full R x U embedding distance matrix with a single matrix multiply, matching the vectorized pattern already used in `similarity_chain.py` and `match_cut.py`.
+
+## Technical Details
+
+**Affected Files:**
+- `core/remix/reference_match.py` - Add `_precompute_embedding_distances()`, modify `reference_guided_match()` to use it, potentially simplify or remove `_cosine_distance()`
+
+**Performance Impact (estimated):**
+- 200 ref clips x 500 user clips x 768-dim embeddings:
+  - Current: ~100,000 `np.array()` allocations + individual dot products = ~2-5 seconds
+  - After: One matrix multiply (200 x 768) @ (768 x 500) = ~5-20 ms
+
+**Verification:**
+1. Run `pytest tests/test_reference_match.py` - all tests pass with identical results
+2. Add a benchmark test with 200 x 500 clips to verify speedup
+3. Verify matching results are numerically identical (within float32 tolerance)
+
+## Acceptance Criteria
+
+- [ ] Embedding distances computed via single matrix multiply, not per-pair `np.array()` calls
+- [ ] `_cosine_distance()` either removed or only used as fallback for edge cases
+- [ ] Matching results numerically identical to current implementation
+- [ ] All existing tests pass without modification
+- [ ] Performance improvement measurable for clip sets > 50 (no regression for small sets)
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | Per-call numpy array allocation from Python lists is a common performance anti-pattern; pre-build matrices and use vectorized operations (pattern already in similarity_chain.py and match_cut.py) |
+
+## Resources
+
+- PR #58: Reference-Guided Remixing
+- `core/remix/similarity_chain.py` lines 16-28: Vectorized cosine distance matrix pattern
+- `core/remix/match_cut.py` lines 66-70: Same vectorized pattern
+- NumPy broadcasting docs: https://numpy.org/doc/stable/user/basics.broadcasting.html

--- a/todos/016-complete-p3-replace-sender-private-attr-sniffing.md
+++ b/todos/016-complete-p3-replace-sender-private-attr-sniffing.md
@@ -1,0 +1,81 @@
+---
+status: complete
+priority: p3
+issue_id: "016"
+tags: [code-review, quality, signals]
+dependencies: []
+---
+
+# Replace sender() Private Attribute Sniffing in _apply_reference_guide_sequence
+
+## Problem Statement
+
+`_apply_reference_guide_sequence` uses `self.sender()` to reach back into the dialog and read underscore-prefixed private attributes (`_last_ref_source_id`, `_last_weights`, `_last_allow_repeats`, `_last_match_timing`) to persist metadata on the sequence. This is fragile: if the signal connection changes (e.g., queued connection, intermediary slot, or lambda wrapper), `self.sender()` may return `None` or the wrong object, silently dropping metadata.
+
+## Findings
+
+**Location:** `ui/tabs/sequence_tab.py` lines 839-844
+
+```python
+# Store dialog config if available (for save/load round-trip)
+dialog = self.sender()
+if dialog and hasattr(dialog, '_last_ref_source_id'):
+    sequence.reference_source_id = dialog._last_ref_source_id
+    sequence.dimension_weights = dialog._last_weights
+    sequence.allow_repeats = dialog._last_allow_repeats
+    sequence.match_reference_timing = dialog._last_match_timing
+```
+
+The slot is connected at line 795:
+
+```python
+dialog.sequence_ready.connect(self._apply_reference_guide_sequence)
+```
+
+The `sequence_ready` signal currently only carries `list` (line 140 of `ui/dialogs/reference_guide_dialog.py`), so the slot has no way to receive metadata except through this `sender()` back-channel.
+
+## Proposed Solutions
+
+### Option A: Emit Richer Signal with Metadata Dict (Recommended)
+Change `sequence_ready` to emit both the clip list and a metadata dict:
+
+```python
+# In ReferenceGuideDialog
+sequence_ready = Signal(list, dict)  # clips, metadata
+
+# When emitting:
+metadata = {
+    "reference_source_id": self._last_ref_source_id,
+    "dimension_weights": self._last_weights,
+    "allow_repeats": self._last_allow_repeats,
+    "match_reference_timing": self._last_match_timing,
+}
+self.sequence_ready.emit(matched_clips, metadata)
+```
+
+Then the slot receives metadata as a parameter instead of sniffing the sender.
+
+**Pros:** Clean signal contract, no coupling to dialog internals, survives connection type changes
+**Cons:** Minor API change to signal signature
+**Effort:** Small
+
+### Option B: Pass Config as Named Signal Arguments via Dataclass
+Create a small `ReferenceGuideConfig` dataclass and emit it alongside clips.
+
+**Pros:** Strongly typed, extensible
+**Cons:** More boilerplate for a small payload
+**Effort:** Small
+
+## Acceptance Criteria
+
+- [ ] `_apply_reference_guide_sequence` no longer calls `self.sender()`
+- [ ] `_apply_reference_guide_sequence` no longer reads underscore-prefixed private attributes from the dialog
+- [ ] Metadata (reference_source_id, weights, allow_repeats, match_reference_timing) is still persisted on the sequence
+- [ ] Save/load round-trip for reference_guided sequences still works
+- [ ] Existing tests pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | sender() + private attribute access is a fragile anti-pattern in Qt signal/slot wiring |

--- a/todos/017-complete-p3-add-agent-clip-added-signal.md
+++ b/todos/017-complete-p3-add-agent-clip-added-signal.md
@@ -1,0 +1,80 @@
+---
+status: complete
+priority: p3
+issue_id: "017"
+tags: [code-review, agent-native, signals]
+dependencies: []
+---
+
+# Add clip_added Signal Emission in Agent generate_reference_guided Path
+
+## Problem Statement
+
+The agent path `generate_reference_guided()` does NOT emit `clip_added` signals when adding clips to the timeline, while every other clip-adding code path in SequenceTab does. Any observers listening to `clip_added` (e.g., for live preview updates, analytics, or future undo/redo tracking) will not be notified when the agent builds a reference-guided sequence.
+
+## Findings
+
+**Location:** `ui/tabs/sequence_tab.py` lines 1326-1328
+
+The agent method's clip loop:
+
+```python
+current_frame = 0
+for clip, source in matched:
+    self.timeline.add_clip(clip, source, track_index=0, start_frame=current_frame)
+    current_frame += clip.duration_frames
+```
+
+Compare with the dialog path at lines 817-820, which correctly emits:
+
+```python
+for clip, source in sequence_clips:
+    self.timeline.add_clip(clip, source, track_index=0, start_frame=current_frame)
+    current_frame += clip.duration_frames
+    self.clip_added.emit(clip, source)
+```
+
+Other code paths that correctly emit `clip_added`:
+- `_apply_sorted_sequence` (line 517)
+- `_apply_exquisite_corpus_sequence` (line 609)
+- `_apply_storyteller_sequence` (line 750)
+- `_apply_reference_guide_sequence` (line 820)
+- `_rebuild_with_params` (line 1434)
+- `add_clip` (line 1071)
+
+The agent path at line 1326 is the only one missing the signal emission.
+
+## Proposed Solutions
+
+### Option A: Add Signal Emission in Agent Loop (Recommended)
+
+```python
+current_frame = 0
+for clip, source in matched:
+    self.timeline.add_clip(clip, source, track_index=0, start_frame=current_frame)
+    current_frame += clip.duration_frames
+    self.clip_added.emit(clip, source)  # <-- add this
+```
+
+**Pros:** One-line fix, matches all other code paths
+**Cons:** None
+**Effort:** Small
+
+### Option B: Extract Common Clip-Adding Helper
+Refactor all 7+ clip-adding loops into a single `_apply_clips_to_timeline(clips)` method that always emits the signal. This would prevent the pattern from diverging again.
+
+**Pros:** DRY, prevents future omissions
+**Cons:** Larger refactor, may warrant its own issue
+**Effort:** Medium
+
+## Acceptance Criteria
+
+- [ ] `generate_reference_guided()` emits `clip_added(clip, source)` for each clip added
+- [ ] Signal behavior matches the dialog path (`_apply_reference_guide_sequence`)
+- [ ] Existing tests pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | Agent code paths must mirror dialog paths for signal emission parity |

--- a/todos/018-complete-p3-add-dimension-discovery-agent-tool.md
+++ b/todos/018-complete-p3-add-dimension-discovery-agent-tool.md
@@ -1,0 +1,85 @@
+---
+status: complete
+priority: p3
+issue_id: "018"
+tags: [code-review, agent-native, discovery]
+dependencies: []
+---
+
+# Add Dimension Discovery for Agent Before Reference-Guided Remixing
+
+## Problem Statement
+
+The agent has no way to discover which dimensions have data before calling `generate_reference_guided`. The dialog UI checks via `get_active_dimensions_for_clips()` and auto-disables checkboxes for unavailable dimensions, but no agent tool exposes this information. Without it, the agent must guess which weight keys are valid, and will get opaque errors or silent zero-matches if it specifies dimensions that have no analysis data.
+
+## Findings
+
+**Dialog path:** `ui/dialogs/reference_guide_dialog.py` lines 164-166
+
+```python
+from core.remix.reference_match import get_active_dimensions_for_clips
+all_clip_objects = [clip for clip, _ in clips]
+self._available_dimensions = get_active_dimensions_for_clips(all_clip_objects)
+```
+
+This result drives which checkboxes are enabled (line 309-311):
+
+```python
+is_available = dim_key in self._available_dimensions
+checkbox.setEnabled(is_available)
+checkbox.setChecked(is_available)
+```
+
+**Agent path:** `core/chat_tools.py` lines 3984-3989
+
+The agent tool validates weight keys against a hardcoded set of valid dimensions:
+
+```python
+valid_dims = {"color", "brightness", "shot_scale", "audio", "embedding", "movement", "duration"}
+invalid = set(weights.keys()) - valid_dims
+```
+
+But it does not check whether those dimensions actually have data for the current clips. The agent has no tool to call `get_active_dimensions_for_clips()` before generating.
+
+## Proposed Solutions
+
+### Option A: Add a `get_available_dimensions` Agent Tool (Recommended)
+Create a new tool that calls `get_active_dimensions_for_clips()` and returns the set of dimensions with data:
+
+```python
+@register_tool(
+    name="get_available_dimensions",
+    description="Check which analysis dimensions have data for the current clips",
+    requires_project=True,
+)
+def get_available_dimensions(project, main_window):
+    clips = main_window.sequence_tab._available_clips
+    clip_objects = [clip for clip, _ in clips]
+    from core.remix.reference_match import get_active_dimensions_for_clips
+    available = get_active_dimensions_for_clips(clip_objects)
+    return {"success": True, "available_dimensions": sorted(available)}
+```
+
+**Pros:** Clean separation, agent can check before generating
+**Cons:** Requires extra tool call
+**Effort:** Small
+
+### Option B: Include Dimension Availability in `get_project_state`
+Add an `available_dimensions` field to the project state response so the agent always has this info.
+
+**Pros:** No extra tool call needed, always up-to-date
+**Cons:** Adds complexity to a general-purpose tool; dimension check only matters for reference-guided remixing
+**Effort:** Small
+
+## Acceptance Criteria
+
+- [ ] Agent can discover which dimensions have analysis data before calling `generate_reference_guided`
+- [ ] The discovery mechanism uses the same logic as the dialog (`get_active_dimensions_for_clips`)
+- [ ] Agent tool description guides the LLM to check dimensions before generating
+- [ ] Existing tests pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | Agent tools need discovery parity with dialog UIs for guided workflows |

--- a/todos/019-complete-p3-validate-weight-values-agent-tool.md
+++ b/todos/019-complete-p3-validate-weight-values-agent-tool.md
@@ -1,0 +1,81 @@
+---
+status: complete
+priority: p3
+issue_id: "019"
+tags: [code-review, security, validation]
+dependencies: []
+---
+
+# Validate Weight Values in generate_reference_guided Agent Tool
+
+## Problem Statement
+
+The `generate_reference_guided` agent tool validates weight **keys** (ensuring they are valid dimension names) but does not validate weight **values**. Negative weights would silently invert distance semantics (making the algorithm prefer the *least* similar clip instead of the most similar). Non-numeric values (e.g., strings) would cause a `TypeError` deep in the matching algorithm with no helpful error message for the agent.
+
+## Findings
+
+**Location:** `core/chat_tools.py` lines 3983-3989
+
+Current validation only checks keys:
+
+```python
+# Validate weights
+valid_dims = {"color", "brightness", "shot_scale", "audio", "embedding", "movement", "duration"}
+invalid = set(weights.keys()) - valid_dims
+if invalid:
+    return {
+        "success": False,
+        "error": f"Invalid dimensions: {invalid}. Valid: {sorted(valid_dims)}"
+    }
+```
+
+No validation of weight values follows. The `weights` dict is passed directly to `reference_guided_match()` which uses the values as multipliers in distance calculations.
+
+**Impact scenarios:**
+- `{"color": -1.0}` -- inverts color matching, selects most dissimilar clips
+- `{"color": "high"}` -- `TypeError` when multiplying float by string in distance computation
+- `{"color": 999.0}` -- technically works but overwhelms all other dimensions
+
+## Proposed Solutions
+
+### Option A: Add isinstance Check and 0.0-1.0 Range Validation (Recommended)
+
+```python
+# Validate weight values
+for dim, value in weights.items():
+    if not isinstance(value, (int, float)):
+        return {
+            "success": False,
+            "error": f"Weight for '{dim}' must be a number, got {type(value).__name__}"
+        }
+    if value < 0.0 or value > 1.0:
+        return {
+            "success": False,
+            "error": f"Weight for '{dim}' must be between 0.0 and 1.0, got {value}"
+        }
+```
+
+**Pros:** Clear error messages, matches dialog UI slider range (0-100 mapped to 0.0-1.0), prevents semantic inversion
+**Cons:** Slightly more restrictive than necessary (values >1.0 could be intentional power-user behavior)
+**Effort:** Small
+
+### Option B: Validate Type Only, Warn on Out-of-Range
+Check `isinstance` but allow any non-negative float, logging a warning for values outside 0.0-1.0.
+
+**Pros:** More permissive for advanced use cases
+**Cons:** Still allows semantic inversion with negative values
+**Effort:** Small
+
+## Acceptance Criteria
+
+- [ ] Non-numeric weight values produce a clear error message
+- [ ] Negative weight values are rejected (or warned)
+- [ ] Weight values outside 0.0-1.0 are handled (rejected or clamped)
+- [ ] Error messages guide the agent to correct the input
+- [ ] Existing tests pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | Agent tool parameter validation should cover both keys and values |

--- a/todos/020-complete-p3-debounce-cost-estimation-refresh.md
+++ b/todos/020-complete-p3-debounce-cost-estimation-refresh.md
@@ -1,0 +1,76 @@
+---
+status: complete
+priority: p3
+issue_id: "020"
+tags: [code-review, performance, ui]
+dependencies: []
+---
+
+# Debounce Cost Estimation Refresh in ReferenceGuideDialog
+
+## Problem Statement
+
+Cost estimation (`_refresh_cost_estimates`) fires on every checkbox toggle in the Reference Guide dialog. During initialization, each of the 7 dimension rows calls `checkbox.setChecked(is_available)` which triggers `toggled` -> `_refresh_cost_estimates()`. With all 7 dimensions available, this means 7 redundant cost recomputations during dialog init. Additionally, rapid user toggling of checkboxes fires one recomputation per toggle with no debouncing.
+
+## Findings
+
+**Location:** `ui/dialogs/reference_guide_dialog.py`
+
+Each dimension row connects checkbox toggle to cost refresh at line 331:
+
+```python
+checkbox.toggled.connect(lambda *_: self._refresh_cost_estimates())
+```
+
+The checkbox is set during row creation at line 311:
+
+```python
+checkbox.setChecked(is_available)
+```
+
+There are 7 dimensions defined in `DIMENSION_INFO` (lines 37-80): color, brightness, shot_scale, audio, embedding, movement, duration. Each `setChecked()` call emits `toggled` which triggers `_refresh_cost_estimates()`.
+
+The `_refresh_cost_estimates` method (line 365) calls `estimate_sequence_cost()` which builds cost estimates from active dimensions -- not expensive individually, but 7 redundant calls during init is wasteful and could become noticeable if the estimation logic grows more complex.
+
+The `_update_clip_counts` method (called on source combo change at line 363) also calls `_refresh_cost_estimates()`, adding another trigger path.
+
+## Proposed Solutions
+
+### Option A: QTimer Debounce (Recommended)
+Add an 80ms single-shot `QTimer` so rapid toggles produce a single recomputation:
+
+```python
+def __init__(self, ...):
+    ...
+    self._cost_debounce = QTimer(self)
+    self._cost_debounce.setSingleShot(True)
+    self._cost_debounce.setInterval(80)
+    self._cost_debounce.timeout.connect(self._refresh_cost_estimates)
+
+# Replace direct connection:
+checkbox.toggled.connect(lambda *_: self._cost_debounce.start())
+```
+
+**Pros:** Clean pattern, eliminates all redundant calls (init and user interaction), minimal code
+**Cons:** 80ms delay before estimates update (imperceptible to user)
+**Effort:** Small
+
+### Option B: Block Signals During Init
+Use `blockSignals(True)` on checkboxes during the dimension row creation loop, then unblock after all rows are created, followed by a single `_refresh_cost_estimates()` call.
+
+**Pros:** No timer overhead, init fires exactly once
+**Cons:** Does not help with rapid user toggling after init; signal blocking is error-prone
+**Effort:** Small
+
+## Acceptance Criteria
+
+- [ ] Dialog initialization triggers `_refresh_cost_estimates` at most once (not 7 times)
+- [ ] Rapid checkbox toggling produces at most one recomputation per debounce window
+- [ ] Cost estimates still update correctly after user interaction settles
+- [ ] Existing tests pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | QTimer debounce is standard Qt pattern for coalescing rapid signal bursts |

--- a/todos/021-complete-p3-remove-unused-project-param-dialog.md
+++ b/todos/021-complete-p3-remove-unused-project-param-dialog.md
@@ -1,0 +1,80 @@
+---
+status: complete
+priority: p3
+issue_id: "021"
+tags: [code-review, dead-code, simplicity]
+dependencies: []
+---
+
+# Remove Unused project Parameter from ReferenceGuideDialog
+
+## Problem Statement
+
+The `project` parameter in `ReferenceGuideDialog.__init__` is always passed as `None` and never meaningfully used. It is stored as `self.project` but no method in the dialog reads it. This is dead code that misleads readers into thinking the dialog depends on the project object.
+
+## Findings
+
+**Location:** `ui/dialogs/reference_guide_dialog.py` lines 142-160
+
+The constructor accepts `project`:
+
+```python
+def __init__(
+    self,
+    clips: list,
+    sources_by_id: dict,
+    project: Any,
+    parent=None,
+):
+```
+
+It is stored at line 160:
+
+```python
+self.project = project
+```
+
+But `self.project` is never referenced anywhere else in the file. A grep for `self.project` in the dialog file returns only the assignment at line 160.
+
+**Caller:** `ui/tabs/sequence_tab.py` lines 788-792
+
+The dialog is always instantiated with `project=None`:
+
+```python
+dialog = ReferenceGuideDialog(
+    clips=clips,
+    sources_by_id=sources_by_id,
+    project=None,
+    parent=self,
+)
+```
+
+## Proposed Solutions
+
+### Option A: Remove the Parameter (Recommended)
+Delete `project: Any` from the constructor signature, remove `self.project = project`, and remove `project=None` from the caller.
+
+**Pros:** Eliminates dead code, removes misleading `Any` import dependency
+**Cons:** Breaking change if any external code passes `project` (none found)
+**Effort:** Small
+
+### Option B: Keep as Reserved for Future Use
+Add a comment explaining it is reserved.
+
+**Pros:** No API change
+**Cons:** Dead code remains, YAGNI violation
+**Effort:** None
+
+## Acceptance Criteria
+
+- [ ] `project` parameter removed from `ReferenceGuideDialog.__init__`
+- [ ] `self.project` assignment removed
+- [ ] Caller in `sequence_tab.py` no longer passes `project=None`
+- [ ] `Any` import removed from dialog if no longer needed
+- [ ] Existing tests pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 code review | Remove unused parameters early to prevent misleading API surfaces |

--- a/todos/022-complete-p2-add-reference-guided-to-dialog-algorithms.md
+++ b/todos/022-complete-p2-add-reference-guided-to-dialog-algorithms.md
@@ -1,0 +1,55 @@
+---
+status: complete
+priority: p2
+issue_id: "022"
+tags: [code-review, agent-native, bug]
+dependencies: []
+---
+
+# Add reference_guided to dialog_algorithms Tuple
+
+## Problem Statement
+
+The `dialog_algorithms` tuple in `set_sorting_algorithm()` at `sequence_tab.py:1127` does not include `"reference_guided"`. When the agent calls `set_sorting_algorithm("reference_guided")` while in timeline state, the code falls into the dropdown-based regeneration path instead of re-opening the dialog. Since `reference_guided` is not in the header dropdown, this silently fails or produces unexpected behavior.
+
+## Findings
+
+**Location:** `ui/tabs/sequence_tab.py` line 1127
+
+```python
+dialog_algorithms = ("exquisite_corpus", "storyteller")
+```
+
+Should be:
+
+```python
+dialog_algorithms = ("exquisite_corpus", "storyteller", "reference_guided")
+```
+
+All three algorithms bypass the `generate_sequence()` dispatcher and use their own configuration dialogs.
+
+## Proposed Solutions
+
+### Option A: Add to Tuple (Recommended)
+
+One-line fix:
+
+```python
+dialog_algorithms = ("exquisite_corpus", "storyteller", "reference_guided")
+```
+
+**Pros:** Trivial fix, correct behavior
+**Cons:** None
+**Effort:** Small
+**Risk:** None
+
+## Acceptance Criteria
+
+- [ ] `set_sorting_algorithm("reference_guided")` re-opens the dialog instead of using dropdown
+- [ ] Existing tests pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 architecture review | Dialog-based algorithms must be registered in both `ALGORITHM_CONFIG` and the `dialog_algorithms` tuple |

--- a/todos/023-complete-p2-add-video-player-load-in-agent-path.md
+++ b/todos/023-complete-p2-add-video-player-load-in-agent-path.md
@@ -1,0 +1,56 @@
+---
+status: complete
+priority: p2
+issue_id: "023"
+tags: [code-review, agent-native, bug]
+dependencies: []
+---
+
+# Add video_player.load_video Call in Agent generate_reference_guided Path
+
+## Problem Statement
+
+The agent path `generate_reference_guided()` in `sequence_tab.py` does not call `self.video_player.load_video(first_source.file_path)` after setting up the timeline. The dialog path (`_apply_reference_guide_sequence` at line 814) does. Without this call, after the agent generates a reference-guided sequence, the video player will not have the correct source loaded -- playback and scrubbing will be broken or show the wrong video.
+
+## Findings
+
+**Location:** `ui/tabs/sequence_tab.py` lines 1320-1324
+
+Agent path (missing load_video):
+```python
+first_clip, first_source = matched[0]
+self.timeline.set_fps(first_source.fps)
+# Missing: self.video_player.load_video(first_source.file_path)
+```
+
+Dialog path (correct, line 813-814):
+```python
+self.timeline.set_fps(first_source.fps)
+self.video_player.load_video(first_source.file_path)
+```
+
+## Proposed Solutions
+
+### Option A: Add the Call (Recommended)
+
+```python
+first_clip, first_source = matched[0]
+self.timeline.set_fps(first_source.fps)
+self.video_player.load_video(first_source.file_path)  # Add this
+```
+
+**Pros:** One-line fix, matches dialog path
+**Cons:** None
+**Effort:** Small
+
+## Acceptance Criteria
+
+- [ ] Video player loads correct source after agent generates reference-guided sequence
+- [ ] Playback and scrubbing work after agent-generated sequence
+- [ ] Existing tests pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 agent-native review | Agent code paths must replicate all UI setup steps, not just timeline population |

--- a/todos/024-complete-p3-add-reference-guided-to-agent-discovery.md
+++ b/todos/024-complete-p3-add-reference-guided-to-agent-discovery.md
@@ -1,0 +1,54 @@
+---
+status: complete
+priority: p3
+issue_id: "024"
+tags: [code-review, agent-native, discovery]
+dependencies: []
+---
+
+# Add Reference-Guided to Agent Discovery (System Prompt + list_sorting_algorithms)
+
+## Problem Statement
+
+The system prompt in `chat_worker.py` tells the agent to use `generate_remix` for sequence generation and `list_sorting_algorithms` for discovery. Neither mentions `generate_reference_guided`. The agent has no way to discover this tool exists unless the user explicitly asks for reference-guided matching by name.
+
+## Findings
+
+**System prompt:** `ui/chat_worker.py` line 724 says:
+> "Use the generate_remix tool to create sequences with any of the 13 sorting algorithms. Use list_sorting_algorithms first to check which algorithms are available."
+
+No mention of `generate_reference_guided`.
+
+**list_sorting_algorithms:** `core/chat_tools.py` lines 3734-3855 returns algorithm descriptions but does not include reference_guided or mention the separate tool.
+
+## Proposed Solutions
+
+### Option A: Add Note to list_sorting_algorithms Output (Recommended)
+
+Add a `reference_guided_note` field to the response:
+```python
+return {
+    "success": True,
+    "algorithms": [...],
+    "reference_guided_available": True,
+    "reference_guided_note": "For matching clips to a reference video's structure, use the generate_reference_guided tool instead of generate_remix."
+}
+```
+
+Also add a line to the system prompt mentioning the tool.
+
+**Pros:** Agent can discover the feature through normal discovery flow
+**Cons:** Minor system prompt change
+**Effort:** Small
+
+## Acceptance Criteria
+
+- [ ] Agent can discover reference-guided capability via list_sorting_algorithms
+- [ ] System prompt mentions generate_reference_guided for reference-based matching
+- [ ] Existing tests pass
+
+## Work Log
+
+| Date | Action | Learnings |
+|------|--------|-----------|
+| 2026-02-24 | Created from PR #58 agent-native review | New agent tools must be added to discovery paths (system prompt, listing tools) |

--- a/ui/chat_worker.py
+++ b/ui/chat_worker.py
@@ -721,7 +721,7 @@ When creating plans, follow these tool dependency rules:
 2. If the user wants to search multiple topics, create a plan that interleaves
    search and download steps for each topic.
 
-3. SEQUENCE GENERATION: Use the generate_remix tool to create sequences with any of the 13 sorting algorithms. Use list_sorting_algorithms first to check which algorithms are available based on clip analysis state.
+3. SEQUENCE GENERATION: Use the generate_remix tool to create sequences with any of the 13 sorting algorithms. Use list_sorting_algorithms first to check which algorithms are available based on clip analysis state. For matching clips to a reference video's structure, use the generate_reference_guided tool instead.
 """
 
         # For Ollama, include tool schemas in the prompt since we don't pass them via API


### PR DESCRIPTION
## Summary

Addresses all 14 code review findings from PR #58 (Reference-Guided Remixing). Zero P1 issues — all P2 and P3 cleanup/hardening.

### P2 Fixes (7):
- **011** — Replace `Any` typing with `Clip`/`Source` via `TYPE_CHECKING` guard in `reference_match.py`
- **012** — Extract shared `_apply_dialog_sequence()` from 3 near-identical handlers (Exquisite Corpus, Storyteller, Reference Guide), removing ~120 lines of duplication
- **013** — Remove unimplemented `match_reference_timing` from all 7 files (YAGNI)
- **014** — Migrate `ReferenceMatchWorker` to `CancellableWorker` base class with `threading.Event`-based cancellation
- **015** — Vectorize cosine distance with pre-computed R×U embedding matrix (eliminates per-pair numpy allocations)
- **022** — Add `"reference_guided"` to `dialog_algorithms` tuple so agent `set_sorting_algorithm` routes correctly
- **023** — Add missing `video_player.load_video()` in agent reference-guided path (parity with dialog path)

### P3 Fixes (7):
- **016** — Replace `self.sender()` + private attr sniffing with `Signal(list, dict)` metadata
- **017** — Add `clip_added.emit(clip, source)` in agent reference-guided loop
- **018** — Add `get_available_dimensions` agent tool for dimension discovery before matching
- **019** — Validate weight values (type check + 0.0–1.0 range) in agent tool
- **020** — Add QTimer debounce (80ms) for cost estimation refresh in dialog
- **021** — Remove unused `project` parameter from `ReferenceGuideDialog.__init__`
- **024** — Add reference-guided to system prompt and `list_sorting_algorithms` output

## Test plan
- [x] All 748 tests pass (including 33 reference-match specific tests)
- [x] `match_reference_timing` fully removed — `grep` confirms only in todo docs and plan files
- [x] Net code reduction: -9 lines despite adding new agent tool + vectorized distance function

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: all changes are internal refactoring with no runtime behavior change beyond bug fixes.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)