### PR TITLE
fix: guard mpv import for Windows CI

### DIFF
--- a/ui/video_player.py
+++ b/ui/video_player.py
@@ -1,5 +1,7 @@
 """Video player component using MPV (libmpv) via python-mpv."""
 
+from __future__ import annotations
+
 import locale
 import logging
 import threading
@@ -19,7 +21,10 @@ from PySide6.QtWidgets import (
 from ui.widgets.styled_slider import StyledSlider
 from PySide6.QtCore import Qt, Slot, Signal, QObject
 
-import mpv
+try:
+    import mpv
+except OSError:
+    mpv = None  # libmpv not available (e.g. Windows CI without DLL)
 
 from core.constants import PLAYBACK_SPEEDS, DEFAULT_SPEED_INDEX
 from ui.theme import theme, TypeScale, Spacing, UISizes
@@ -305,6 +310,10 @@ class VideoPlayer(QWidget):
 
     def _setup_player(self):
         """Set up MPV player instance."""
+        if mpv is None:
+            raise RuntimeError(
+                "libmpv is not available. Install mpv/libmpv for your platform."
+            )
         wid = str(int(self.video_widget.winId()))
         self._mpv = mpv.MPV(
             wid=wid,


### PR DESCRIPTION
## Summary

- Windows CI fails because `import mpv` raises `OSError` when `libmpv` DLL isn't installed
- The import chain `test_analysis_pipeline → MainWindow → SequenceTab → VideoPlayer → import mpv` crashes all test collection
- Wraps `import mpv` in `try/except OSError` so the module loads without libmpv
- Adds `from __future__ import annotations` to defer `mpv.MPV` type annotation evaluation
- `_setup_player()` raises `RuntimeError` if mpv is unavailable at instantiation time

## Test plan

- [x] All 795 tests pass locally
- [ ] Windows CI should now pass (no libmpv DLL needed for test collection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)