### PR TITLE
fix: auto-detect Homebrew libmpv path on macOS

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,6 +56,19 @@ logger = logging.getLogger(__name__)
 if is_frozen():
     _setup_frozen_environment()
 
+import platform
+if platform.system() == "Darwin":
+    # Homebrew on Apple Silicon / Intel puts libs in different locations.
+    # python-mpv needs libmpv.dylib on the loader path.
+    for lib_dir in ("/opt/homebrew/lib", "/usr/local/lib"):
+        if os.path.isdir(lib_dir):
+            existing = os.environ.get("DYLD_LIBRARY_PATH", "")
+            if lib_dir not in existing:
+                os.environ["DYLD_LIBRARY_PATH"] = (
+                    f"{lib_dir}:{existing}" if existing else lib_dir
+                )
+            break
+
 from PySide6.QtWidgets import QApplication, QMessageBox
 from ui.main_window import MainWindow
 from ui.theme import theme


### PR DESCRIPTION
## Summary

- `python-mpv` uses `ctypes.util.find_library('mpv')` which returns `None` on macOS when `DYLD_LIBRARY_PATH` isn't set
- Homebrew installs libmpv to `/opt/homebrew/lib` (Apple Silicon) or `/usr/local/lib` (Intel) but neither is in the default library search path
- Now `main.py` detects macOS and adds the Homebrew lib directory to `DYLD_LIBRARY_PATH` **before** any `import mpv` occurs
- This means the app starts without needing `DYLD_LIBRARY_PATH=/opt/homebrew/lib python main.py`

## Test plan

- [x] All 795 tests pass
- [x] Verified: without `DYLD_LIBRARY_PATH`, mpv imports successfully after the fix
- [x] Verified: `ctypes.util.find_library('mpv')` finds libmpv with the env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)