### PR TITLE
feat: Add user documentation and Help menu

### DIFF
--- a/docs/brainstorms/2026-03-14-user-documentation-brainstorm.md
+++ b/docs/brainstorms/2026-03-14-user-documentation-brainstorm.md
@@ -1,0 +1,83 @@
+# User Documentation for Scene Ripper
+
+**Date:** 2026-03-14
+**Status:** Brainstorm
+
+## What We're Building
+
+A user-facing documentation section (`docs/user-guide/`) with markdown files hosted on GitHub. The app's menu bar gets a new **Help** menu with items that open specific doc pages in the user's default browser.
+
+### Initial doc set:
+1. **Sequencer Guide** - One page covering all 15 sequencer algorithms
+2. **API Keys Guide** - How API keys work in Scene Ripper, plus detailed per-provider walkthroughs for obtaining keys
+
+## Why This Approach
+
+- **Markdown in repo** - Zero infrastructure, version-controlled alongside code, renders well on GitHub. No build step or hosting to maintain.
+- **Browser-based help** - Adding `Help > Sequencer Guide` and `Help > API Keys` menu items that call `QDesktopServices.openUrl()` is trivial to implement and keeps the app simple.
+- **Practical & concise tone** - Users want to understand what each sequencer does and when to use it, not read a textbook. Brief descriptions, required analysis, direction options, one-sentence "when to use."
+- **Detailed API key walkthroughs** - Getting API keys from different providers is a real friction point for non-technical users. Step-by-step instructions per provider reduce support burden.
+
+## Key Decisions
+
+1. **Docs location**: `docs/user-guide/` in the repo (new directory)
+2. **Format**: Markdown, rendered on GitHub
+3. **App integration**: New `Help` menu in menu bar with items that open GitHub URLs in browser
+4. **Sequencer doc structure**: Practical & concise - what it does, when to use it, required analysis, direction options
+5. **API key doc structure**: Detailed per-provider walkthroughs with account creation steps, dashboard navigation, key generation
+6. **Scope exclusion**: Local/Ollama setup is out of scope for now - only cloud API providers (Anthropic, OpenAI, Gemini, OpenRouter, Replicate, YouTube)
+
+## Sequencer Algorithms to Document
+
+| Algorithm | Display Name | Required Analysis | Has Dialog |
+|-----------|-------------|-------------------|------------|
+| color | Chromatics | colors | No |
+| duration | Tempo Shift | none | No |
+| brightness | Into the Dark | brightness | No |
+| volume | Crescendo | volume | No |
+| shuffle | Hatchet Job | none | Yes |
+| sequential | Time Capsule | none | No |
+| shot_type | Focal Ladder | shots | No |
+| proximity | Up Close and Personal | shots | No |
+| similarity_chain | Human Centipede | embeddings | No |
+| match_cut | Match Cut | boundary_embeddings | No |
+| exquisite_corpus | Exquisite Corpus | extract_text | Yes |
+| storyteller | Storyteller | describe | Yes |
+| reference_guided | Reference Guide | dynamic | Yes |
+| signature_style | Signature Style | colors | Yes |
+| rose_hobart | Rose Hobart | none (face detection) | Yes |
+
+## API Providers to Document
+
+| Provider | Env Var | Used For |
+|----------|---------|----------|
+| Anthropic | `ANTHROPIC_API_KEY` | Chat agent, Storyteller, descriptions |
+| OpenAI | `OPENAI_API_KEY` | Chat agent, descriptions, VLM |
+| Gemini | `GEMINI_API_KEY` | Chat agent, VLM, descriptions |
+| OpenRouter | `OPENROUTER_API_KEY` | Multi-model access |
+| Replicate | `REPLICATE_API_TOKEN` | (model hosting) |
+| YouTube | `YOUTUBE_API_KEY` | Video search and metadata |
+
+Each provider section needs: account creation, navigating to API key page, generating the key, free tier / pricing notes, where to paste it in Scene Ripper settings.
+
+## Doc File Structure
+
+```
+docs/user-guide/
+├── sequencers.md          # All 15 algorithms
+└── api-keys.md            # API key setup for all providers
+```
+
+## Menu Structure
+
+```
+Help
+├── Sequencer Guide        → opens docs/user-guide/sequencers.md on GitHub
+├── API Keys Guide         → opens docs/user-guide/api-keys.md on GitHub
+└── ─────────────
+    About Scene Ripper     → (existing or new about dialog)
+```
+
+## Open Questions
+
+None - all key decisions resolved during brainstorm.

--- a/docs/plans/2026-03-14-001-feat-user-documentation-help-menu-plan.md
+++ b/docs/plans/2026-03-14-001-feat-user-documentation-help-menu-plan.md
@@ -1,0 +1,168 @@
+---
+title: "feat: Add user documentation and Help menu"
+type: feat
+status: completed
+date: 2026-03-14
+origin: docs/brainstorms/2026-03-14-user-documentation-brainstorm.md
+---
+
+# feat: Add User Documentation and Help Menu
+
+## Overview
+
+Add user-facing documentation to Scene Ripper with two initial guides (sequencer algorithms, API keys) and a Help menu in the app that opens them on GitHub in the user's browser.
+
+## Problem Statement / Motivation
+
+Scene Ripper has no user-facing documentation. Users encountering the 15 sequencer algorithms have no way to learn what each one does, what analysis it requires, or what the direction options mean. Getting API keys from different providers is a friction point for non-technical users. A Help menu provides discoverability within the app.
+
+## Proposed Solution
+
+1. Create `docs/user-guide/sequencers.md` - practical, concise guide to all 15 sequencer algorithms
+2. Create `docs/user-guide/api-keys.md` - detailed per-provider API key walkthroughs
+3. Add a `Help` menu to the menu bar with items that open these docs on GitHub
+
+(see brainstorm: docs/brainstorms/2026-03-14-user-documentation-brainstorm.md)
+
+## Technical Considerations
+
+### URL Construction
+
+Reuse `_GITHUB_OWNER` and `_GITHUB_REPO` from `core/update_checker.py` to construct GitHub URLs. Promote these to a shared location or import directly. URLs target the `main` branch:
+
+```
+https://github.com/{owner}/{repo}/blob/main/docs/user-guide/sequencers.md
+```
+
+Since docs and Help menu ship in the same PR/merge, links resolve immediately.
+
+### Menu Implementation
+
+All imports already exist in `ui/main_window.py` (line 27): `QDesktopServices`, `QUrl`, `QAction`. Insert Help menu after the View menu in `_create_menu_bar()` (after line 1275).
+
+**macOS note**: Do NOT set `QAction.AboutRole` on any Help menu items — that relocates them to the app menu. Keep both items as plain actions in the Help menu. An About dialog is **out of scope** for this plan.
+
+### Algorithm Config as Source of Truth
+
+Algorithm names, descriptions, and required analysis come from `ui/algorithm_config.py` (`ALGORITHM_CONFIG`). Direction options come from `ui/tabs/sequence_tab.py` (`_DIRECTION_OPTIONS`). The docs should match these exactly.
+
+### Cross-Referencing
+
+The sequencer doc should link to the API keys doc when mentioning features that require cloud APIs. The API keys doc should include a "Which keys do I need?" table mapping features to providers.
+
+## Acceptance Criteria
+
+- [x] `docs/user-guide/sequencers.md` exists with documentation for all 15 algorithms
+- [x] Each algorithm section includes: display name, what it does, required analysis, direction options (if any), dialog workflow (if applicable), auto-compute note (if applicable)
+- [x] `docs/user-guide/api-keys.md` exists with detailed walkthroughs for all 6 providers
+- [x] API keys doc includes "Which keys do I need?" quick-reference table at the top
+- [x] Each provider section includes: account creation steps, navigating to API key page, generating the key, free tier/pricing notes, where to enter it in Scene Ripper (Settings UI primary, env var secondary)
+- [x] Replicate section explicitly notes the env var is `REPLICATE_API_TOKEN` (not `_API_KEY`)
+- [x] Help menu appears in the menu bar after View menu
+- [x] Help > Sequencer Guide opens `sequencers.md` on GitHub in the default browser
+- [x] Help > API Keys Guide opens `api-keys.md` on GitHub in the default browser
+- [x] GitHub URLs are constructed from shared constants (not hardcoded strings)
+- [x] Help menu items have brief tooltips
+
+## Implementation Phases
+
+### Phase 1: Documentation Files
+
+Create both markdown files in `docs/user-guide/`.
+
+#### `docs/user-guide/sequencers.md`
+
+Structure per algorithm:
+- **Heading**: Display name (e.g., "Chromatics")
+- **One-liner**: What it does
+- **Required analysis**: What analysis must be run first (or "None")
+- **Direction options**: Table/list if applicable (5 algorithms have these)
+- **Dialog workflow**: Brief 3-5 sentence walkthrough for dialog-based algorithms (6 algorithms)
+- **Auto-compute note**: For algorithms that auto-compute missing analysis (brightness, volume, similarity_chain, match_cut)
+- **Tips**: One practical tip per algorithm (optional)
+
+Group algorithms by category for readability:
+1. **Sorting algorithms** (Chromatics, Tempo Shift, Into the Dark, Crescendo, Focal Ladder, Up Close and Personal)
+2. **Relationship algorithms** (Human Centipede, Match Cut)
+3. **Randomization** (Hatchet Job, Time Capsule)
+4. **AI-powered** (Exquisite Corpus, Storyteller, Reference Guide, Signature Style, Rose Hobart)
+
+Cross-link to API keys doc for AI-powered algorithms.
+
+#### `docs/user-guide/api-keys.md`
+
+Structure:
+1. **Introduction**: Brief explanation of how API keys work in Scene Ripper (keyring storage, env var override)
+2. **Which keys do I need?** Quick-reference table:
+
+| Feature | Required Provider |
+|---------|------------------|
+| Chat agent | Any LLM provider (Anthropic, OpenAI, Gemini, or OpenRouter) |
+| Describe clips | Any VLM provider (Gemini, OpenAI, or Anthropic) |
+| Storyteller sequencer | Any LLM provider |
+| Exquisite Corpus | Any VLM provider (for text extraction) |
+| Signature Style | Any VLM provider |
+| YouTube search/download | YouTube Data API |
+| Replicate models | Replicate |
+
+3. **Per-provider sections** (one per provider, detailed walkthrough):
+   - Anthropic
+   - OpenAI
+   - Google Gemini
+   - OpenRouter
+   - Replicate
+   - YouTube Data API (most complex — requires Google Cloud project setup)
+
+Each provider section:
+- **Create an account**: Step-by-step
+- **Generate an API key**: Navigate dashboard, create key
+- **Enter in Scene Ripper**: Settings > API Keys tab instructions
+- **Environment variable alternative**: `export PROVIDER_KEY=sk-...`
+- **Pricing notes**: Free tier info, link to pricing page (avoid specific dollar amounts — they change)
+
+### Phase 2: Help Menu
+
+Add to `ui/main_window.py`:
+
+1. Import `_GITHUB_OWNER`, `_GITHUB_REPO` from `core/update_checker.py`
+2. Construct base URL: `f"https://github.com/{_GITHUB_OWNER}/{_GITHUB_REPO}/blob/main"`
+3. Add `_create_help_menu()` method or extend `_create_menu_bar()`
+4. Two actions:
+   - "Sequencer Guide" → opens `{base}/docs/user-guide/sequencers.md`
+   - "API Keys Guide" → opens `{base}/docs/user-guide/api-keys.md`
+5. Add tooltips: "Opens sequencer documentation on GitHub"
+
+#### Key files to modify
+
+| File | Change |
+|------|--------|
+| `docs/user-guide/sequencers.md` | **New file** |
+| `docs/user-guide/api-keys.md` | **New file** |
+| `ui/main_window.py` | Add Help menu after View menu in `_create_menu_bar()` |
+
+## Dependencies & Risks
+
+| Risk | Mitigation |
+|------|------------|
+| API key walkthrough steps become outdated as providers change their UIs | Link to provider pricing/docs pages rather than quoting specific prices. Keep step descriptions generic enough to survive minor UI changes. |
+| Rose Hobart algorithm only exists on current branch | Already merged to main as of PR #68 — verified. |
+| Offline users see browser error | Low frequency, acceptable tradeoff. No in-app fallback needed for v1. |
+| Repo rename breaks Help URLs | URLs constructed from `_GITHUB_OWNER`/`_GITHUB_REPO` constants — update in one place. |
+
+## Sources & References
+
+### Origin
+
+- **Brainstorm document:** [docs/brainstorms/2026-03-14-user-documentation-brainstorm.md](docs/brainstorms/2026-03-14-user-documentation-brainstorm.md) — Key decisions carried forward: markdown in `docs/user-guide/`, Help menu opens GitHub in browser, practical tone for sequencers, detailed walkthroughs for API keys, Ollama excluded.
+
+### Internal References
+
+- Algorithm config: `ui/algorithm_config.py` (all 15 algorithms)
+- Direction options: `ui/tabs/sequence_tab.py:1053` (`_DIRECTION_OPTIONS`)
+- Menu bar: `ui/main_window.py:1155` (`_create_menu_bar()`)
+- GitHub constants: `core/update_checker.py:18-19` (`_GITHUB_OWNER`, `_GITHUB_REPO`)
+- API key settings: `ui/settings_dialog.py:800` (`_create_api_keys_tab()`)
+- API key env vars: `core/settings.py` (all `ENV_*` constants)
+- LLM providers: `core/llm_client.py:16-65` (providers, models)
+- Existing `QDesktopServices.openUrl()` usage: `ui/main_window.py:1078`
+- Learnings: `docs/solutions/logic-errors/circular-import-config-consolidation.md` (import from `algorithm_config.py`, not `sequence_tab.py`)

--- a/docs/user-guide/api-keys.md
+++ b/docs/user-guide/api-keys.md
@@ -1,0 +1,253 @@
+# API Keys
+
+Scene Ripper uses cloud APIs for AI-powered features like clip descriptions, narrative generation, and text extraction. This guide walks you through getting an API key from each supported provider and entering it in the app.
+
+## How API Keys Work in Scene Ripper
+
+API keys are stored securely in your system's keyring (macOS Keychain, Windows Credential Manager, or Linux Secret Service). You enter them once in **Settings > API Keys** and they persist across sessions.
+
+Environment variables take priority over stored keys. If you set `ANTHROPIC_API_KEY` in your shell, Scene Ripper will use that instead of whatever is saved in settings.
+
+## Which Keys Do I Need?
+
+You don't need all of these. Most users need just one or two.
+
+| Feature | What You Need |
+|---------|--------------|
+| Chat agent | Any LLM provider: Anthropic, OpenAI, Gemini, or OpenRouter |
+| Describe clips | Any VLM provider: Gemini, OpenAI, or Anthropic |
+| Classify shots | Any VLM provider |
+| Extract on-screen text | Any VLM provider |
+| Storyteller sequencer | Any LLM provider |
+| Exquisite Corpus sequencer | Any VLM provider |
+| Signature Style sequencer (VLM mode) | Any VLM provider |
+| YouTube search and download | YouTube Data API |
+| Replicate models | Replicate |
+
+**Recommendation:** A Gemini key is the most versatile starting point. It works as both an LLM and VLM provider, and Google offers a generous free tier.
+
+---
+
+## Anthropic
+
+Anthropic makes the Claude family of models. Claude is particularly strong at narrative and creative writing tasks like the Storyteller sequencer.
+
+### Create an Account
+
+1. Go to [console.anthropic.com](https://console.anthropic.com/)
+2. Click **Sign Up** and create an account with your email or Google account
+3. Verify your email address
+
+### Generate an API Key
+
+1. Once logged in, go to [console.anthropic.com/settings/keys](https://console.anthropic.com/settings/keys)
+2. Click **Create Key**
+3. Give the key a name (e.g., "Scene Ripper")
+4. Copy the key immediately. It starts with `sk-ant-` and won't be shown again
+
+### Enter in Scene Ripper
+
+1. Open **Settings** (Cmd+, on macOS, or File > Settings)
+2. Go to the **API Keys** tab
+3. Paste your key in the **Anthropic** field
+4. Click **Save**
+
+### Environment Variable Alternative
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-your-key-here
+```
+
+### Pricing
+
+Anthropic offers a pay-as-you-go model. New accounts receive a small amount of free credits. See [anthropic.com/pricing](https://www.anthropic.com/pricing) for current rates.
+
+---
+
+## OpenAI
+
+OpenAI makes the GPT family of models. GPT models work well for both text and vision tasks in Scene Ripper.
+
+### Create an Account
+
+1. Go to [platform.openai.com](https://platform.openai.com/)
+2. Click **Sign Up** and create an account
+3. Verify your email and phone number
+
+### Generate an API Key
+
+1. Once logged in, go to [platform.openai.com/api-keys](https://platform.openai.com/api-keys)
+2. Click **Create new secret key**
+3. Give it a name (e.g., "Scene Ripper")
+4. Copy the key immediately. It starts with `sk-` and won't be shown again
+
+### Enter in Scene Ripper
+
+1. Open **Settings** (Cmd+, on macOS, or File > Settings)
+2. Go to the **API Keys** tab
+3. Paste your key in the **OpenAI** field
+4. Click **Save**
+
+### Environment Variable Alternative
+
+```bash
+export OPENAI_API_KEY=sk-your-key-here
+```
+
+### Pricing
+
+OpenAI uses pay-as-you-go pricing. New accounts may receive free credits. See [openai.com/pricing](https://openai.com/api/pricing/) for current rates.
+
+---
+
+## Google Gemini
+
+Google's Gemini models are strong at vision tasks (describing clips, classifying shots, extracting text) and offer a generous free tier.
+
+### Create an Account
+
+1. Go to [aistudio.google.com](https://aistudio.google.com/)
+2. Sign in with your Google account
+3. Accept the terms of service
+
+### Generate an API Key
+
+1. Once signed in, go to [aistudio.google.com/apikey](https://aistudio.google.com/apikey)
+2. Click **Create API Key**
+3. Select a Google Cloud project (or create a new one if prompted)
+4. Copy the key. It starts with `AIza`
+
+### Enter in Scene Ripper
+
+1. Open **Settings** (Cmd+, on macOS, or File > Settings)
+2. Go to the **API Keys** tab
+3. Paste your key in the **Gemini** field
+4. Click **Save**
+
+### Environment Variable Alternative
+
+```bash
+export GEMINI_API_KEY=AIza-your-key-here
+```
+
+### Pricing
+
+Gemini offers a free tier with generous rate limits for most models. Paid usage is billed through Google Cloud. See [ai.google.dev/pricing](https://ai.google.dev/pricing) for current details.
+
+---
+
+## OpenRouter
+
+OpenRouter is a unified API that gives you access to models from multiple providers (Anthropic, OpenAI, Google, Meta, and others) through a single key. Useful if you want to try different models without managing separate accounts.
+
+### Create an Account
+
+1. Go to [openrouter.ai](https://openrouter.ai/)
+2. Click **Sign Up** and create an account
+3. Add credits to your account (OpenRouter is prepaid)
+
+### Generate an API Key
+
+1. Once logged in, go to [openrouter.ai/keys](https://openrouter.ai/keys)
+2. Click **Create Key**
+3. Give it a name (e.g., "Scene Ripper")
+4. Copy the key. It starts with `sk-or-`
+
+### Enter in Scene Ripper
+
+1. Open **Settings** (Cmd+, on macOS, or File > Settings)
+2. Go to the **API Keys** tab
+3. Paste your key in the **OpenRouter** field
+4. Click **Save**
+
+### Environment Variable Alternative
+
+```bash
+export OPENROUTER_API_KEY=sk-or-your-key-here
+```
+
+### Pricing
+
+OpenRouter charges per-token based on the underlying model's pricing, plus a small markup. See [openrouter.ai/models](https://openrouter.ai/models) for per-model pricing.
+
+---
+
+## Replicate
+
+Replicate hosts open-source models as cloud APIs. Used for specific model-based features in Scene Ripper.
+
+### Create an Account
+
+1. Go to [replicate.com](https://replicate.com/)
+2. Click **Sign In** and create an account with GitHub or Google
+3. Add a payment method (required for API access beyond the free tier)
+
+### Generate an API Key
+
+1. Once logged in, go to [replicate.com/account/api-tokens](https://replicate.com/account/api-tokens)
+2. Click **Create Token**
+3. Copy the token. It starts with `r8_`
+
+### Enter in Scene Ripper
+
+1. Open **Settings** (Cmd+, on macOS, or File > Settings)
+2. Go to the **API Keys** tab
+3. Paste your token in the **Replicate** field
+4. Click **Save**
+
+### Environment Variable Alternative
+
+> **Note:** The Replicate environment variable is `REPLICATE_API_TOKEN` (not `REPLICATE_API_KEY`). This follows Replicate's own naming convention.
+
+```bash
+export REPLICATE_API_TOKEN=r8_your-token-here
+```
+
+### Pricing
+
+Replicate offers a small free tier for new accounts. After that, pricing varies by model and is billed per second of compute time. See [replicate.com/pricing](https://replicate.com/pricing) for details.
+
+---
+
+## YouTube Data API
+
+The YouTube API key enables searching for videos and fetching metadata directly in Scene Ripper's Collect tab. This setup is more involved than the other providers because it goes through Google Cloud Console.
+
+### Create a Google Cloud Project
+
+1. Go to [console.cloud.google.com](https://console.cloud.google.com/)
+2. Sign in with your Google account
+3. Click the project dropdown at the top of the page and select **New Project**
+4. Name it something like "Scene Ripper" and click **Create**
+5. Wait a moment for the project to be created, then select it from the project dropdown
+
+### Enable the YouTube Data API
+
+1. In the left sidebar, go to **APIs & Services > Library**
+2. Search for **YouTube Data API v3**
+3. Click on it and then click **Enable**
+
+### Generate an API Key
+
+1. In the left sidebar, go to **APIs & Services > Credentials**
+2. Click **Create Credentials** at the top and select **API key**
+3. A dialog will show your new key. Copy it immediately
+4. (Optional but recommended) Click **Restrict Key** to limit it to only the YouTube Data API v3
+
+### Enter in Scene Ripper
+
+1. Open **Settings** (Cmd+, on macOS, or File > Settings)
+2. Go to the **API Keys** tab
+3. Scroll down to the **YouTube Data API** section
+4. Paste your key in the API key field
+5. Click **Save**
+
+### Environment Variable Alternative
+
+```bash
+export YOUTUBE_API_KEY=your-key-here
+```
+
+### Pricing
+
+The YouTube Data API v3 includes a daily quota of 10,000 units per project at no cost. Each search request costs about 100 units, so you get roughly 100 searches per day for free. This is sufficient for most Scene Ripper workflows. See [Google's quota documentation](https://developers.google.com/youtube/v3/getting-started#quota) for details.

--- a/docs/user-guide/sequencers.md
+++ b/docs/user-guide/sequencers.md
@@ -1,0 +1,207 @@
+# Sequencer Algorithms
+
+Scene Ripper includes 15 sequencer algorithms that arrange your clips into a sequence. Each algorithm uses a different creative logic to determine the order.
+
+To use a sequencer, go to the **Sequence** tab, select an algorithm from the dropdown, and click **Generate**. Some algorithms require that you run specific analysis on your clips first (in the **Analyze** tab). Others open a dialog where you configure additional options before generating.
+
+> Some algorithms (like Storyteller and Exquisite Corpus) require a cloud API key. See the [API Keys Guide](api-keys.md) for setup instructions.
+
+---
+
+## Sorting Algorithms
+
+These algorithms arrange clips based on a measurable property. Most support a **direction** option that controls the sort order.
+
+### Chromatics
+
+Arrange clips along a color gradient or cycle through the spectrum.
+
+**Required analysis:** Colors
+
+**Direction options:**
+
+| Direction | Description |
+|-----------|-------------|
+| Rainbow | Cycle through the full color spectrum (red, orange, yellow, green, blue, violet) |
+| Warm to Cool | Start with warm tones (reds, oranges) and end with cool tones (blues, greens) |
+| Cool to Warm | The reverse: cool tones first, warm tones last |
+| Complementary | Alternate between complementary colors for maximum contrast |
+
+Clips without color data can be appended to the end, excluded, or sorted inline depending on your settings.
+
+### Tempo Shift
+
+Order clips from shortest to longest (or reverse).
+
+**Required analysis:** None
+
+**Direction options:**
+
+| Direction | Description |
+|-----------|-------------|
+| Shortest First | Start with the quickest cuts and build to longer takes |
+| Longest First | Start with longer takes and accelerate toward shorter clips |
+
+### Into the Dark
+
+Arrange clips from light to shadow, or shadow to light.
+
+**Required analysis:** Brightness
+
+If clips haven't been analyzed for brightness yet, this algorithm will automatically compute it when you generate. This may take a moment for large clip sets.
+
+**Direction options:**
+
+| Direction | Description |
+|-----------|-------------|
+| Bright to Dark | Start with the brightest clips and descend into darkness |
+| Dark to Bright | Emerge from shadow into light |
+
+### Crescendo
+
+Build from silence to thunder, or thunder to silence.
+
+**Required analysis:** Volume
+
+If clips haven't been analyzed for volume yet, this algorithm will automatically compute it when you generate. This uses FFmpeg to measure audio levels and may take a moment.
+
+**Direction options:**
+
+| Direction | Description |
+|-----------|-------------|
+| Quiet to Loud | Start with the quietest clips and build to the loudest |
+| Loud to Quiet | Start loud and fade to quiet |
+
+### Focal Ladder
+
+Arrange clips by camera shot scale, from wide establishing shots to tight close-ups (or reverse).
+
+**Required analysis:** Shots (shot type classification)
+
+### Up Close and Personal
+
+Glide from distant vistas to intimate close-ups.
+
+**Required analysis:** Shots (shot type classification)
+
+**Direction options:**
+
+| Direction | Description |
+|-----------|-------------|
+| Far to Close | Start with wide/establishing shots and move to close-ups |
+| Close to Far | Start with close-ups and pull back to wide shots |
+
+---
+
+## Relationship Algorithms
+
+These algorithms find connections between clips based on visual similarity.
+
+### Human Centipede
+
+Chain clips together by visual similarity. Each clip is placed next to the one it most closely resembles, creating a continuous visual flow.
+
+**Required analysis:** Embeddings (visual feature extraction via DINOv2)
+
+If clips haven't been analyzed for embeddings yet, this algorithm will automatically compute them when you generate. Embedding extraction can take a while for large clip sets.
+
+### Match Cut
+
+Find hidden connections between clips at cut points. Analyzes the last frame of each clip and the first frame of the next to find the most visually similar transitions.
+
+**Required analysis:** Boundary embeddings
+
+If clips lack boundary embeddings, this algorithm will automatically compute them. This analyzes the first and last frames of each clip.
+
+---
+
+## Randomization
+
+### Hatchet Job
+
+Randomly shuffle clips into a new order. Opens a dialog where you can optionally apply random transforms to each clip.
+
+**Required analysis:** None
+
+**Dialog options:**
+- **Random H-Flip:** Randomly mirror some clips horizontally
+- **Random V-Flip:** Randomly flip some clips vertically
+- **Random Reverse:** Randomly play some clips in reverse
+
+When transforms are enabled, the dialog pre-renders each affected clip via FFmpeg before assembling the sequence. A progress bar shows rendering status.
+
+### Time Capsule
+
+Keep clips in their original order. This is the simplest algorithm: clips appear in the sequence exactly as they were detected, preserving the source video's timeline.
+
+**Required analysis:** None
+
+---
+
+## AI-Powered Algorithms
+
+These algorithms use language models or vision models to make creative decisions. They require a cloud API key — see the [API Keys Guide](api-keys.md).
+
+### Exquisite Corpus
+
+Generate a poem from on-screen text. Opens a multi-step dialog.
+
+**Required analysis:** Text extraction (OCR/VLM)
+
+**Dialog workflow:**
+1. Enter a mood or vibe prompt (e.g., "melancholic and introspective") and select a poem length (Short, Medium, or Long)
+2. The dialog extracts on-screen text from your clips using OCR or a vision-language model, showing a progress bar
+3. An LLM arranges the extracted text into a poem, displayed as a drag-reorderable list where each line maps to a clip
+4. You can **Regenerate** for a different poem or manually reorder lines before clicking **Create Sequence**
+
+### Storyteller
+
+Create a narrative from clip descriptions. Opens a multi-step dialog.
+
+**Required analysis:** Describe (AI-generated clip descriptions)
+
+All clips must have descriptions before using this algorithm. If some clips lack descriptions, the dialog will offer to exclude them or redirect you to the Analyze tab.
+
+**Dialog workflow:**
+1. Optionally enter a thematic focus and choose a narrative structure (Three-Act, Chronological, Thematic, or Auto)
+2. Set a target duration (10 minutes to 90 minutes, or use all clips)
+3. The LLM arranges clips into a narrative, assigning roles like "setup," "climax," and "resolution"
+4. Review the narrative as a drag-reorderable list and adjust the order before confirming
+
+### Reference Guide
+
+Match your clips to a reference video's structure. Opens a dialog.
+
+**Required analysis:** Varies by selected dimensions
+
+**Dialog workflow:**
+1. Select a source video as the "reference" — its clips become the template structure
+2. All clips from other sources become the matching pool
+3. Adjust seven dimension sliders to control matching weights: Color, Brightness, Shot Scale, Audio Energy, Visual Match (DINOv2), Movement, and Duration. Dimensions without analysis data are grayed out
+4. Optionally allow repeated clips with the "Allow Repeats" checkbox
+5. Click **Generate** to find the best-matching clip for each position in the reference
+
+### Signature Style
+
+Interpret a drawing as an editing guide. Opens a large canvas-based dialog.
+
+**Required analysis:** Colors
+
+**Dialog workflow:**
+1. Draw on the canvas (or import an image). The Y-axis maps to pacing (spiky = fast cuts, smooth = slow) and color maps to color matching against your clips
+2. Set a target duration and FPS
+3. Choose between **Parametric** mode (pixel-level analysis with a granularity slider) or **VLM** mode (a vision model interprets the drawing's meaning)
+4. Click **Generate** to match your drawing to clips and assemble a timed sequence
+
+### Rose Hobart
+
+Isolate clips featuring a specific person. Named after Joseph Cornell's 1936 found-footage film. Opens a dialog.
+
+**Required analysis:** None (face detection runs in the dialog)
+
+**Dialog workflow:**
+1. Upload 1-3 reference photos of the person you want to find. Each image is analyzed for faces, and a green bounding box highlights the detected face
+2. Configure matching sensitivity (Strict, Balanced, or Loose)
+3. Choose how to order matched clips: Original, Duration, Color, Brightness, Confidence, or Random
+4. Set a frame sample interval (how often to check for faces within each clip)
+5. Click **Generate** to scan all clips for the matching face and build a sequence from the results

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1274,6 +1274,26 @@ class MainWindow(QMainWindow):
         # Store reference to view menu for chat panel toggle
         self._view_menu = view_menu
 
+        # Help menu
+        help_menu = menu_bar.addMenu("&Help")
+
+        from core.update_checker import _GITHUB_OWNER, _GITHUB_REPO
+        _docs_base = f"https://github.com/{_GITHUB_OWNER}/{_GITHUB_REPO}/blob/main/docs/user-guide"
+
+        sequencer_guide_action = QAction("&Sequencer Guide", self)
+        sequencer_guide_action.setToolTip("Opens sequencer algorithm documentation on GitHub")
+        sequencer_guide_action.triggered.connect(
+            lambda: QDesktopServices.openUrl(QUrl(f"{_docs_base}/sequencers.md"))
+        )
+        help_menu.addAction(sequencer_guide_action)
+
+        api_keys_action = QAction("&API Keys Guide", self)
+        api_keys_action.setToolTip("Opens API key setup documentation on GitHub")
+        api_keys_action.triggered.connect(
+            lambda: QDesktopServices.openUrl(QUrl(f"{_docs_base}/api-keys.md"))
+        )
+        help_menu.addAction(api_keys_action)
+
     def _is_any_worker_running(self) -> bool:
         """Check if any background worker is currently running."""
         workers = [


### PR DESCRIPTION
## Summary

- **Sequencer Guide** (`docs/user-guide/sequencers.md`): Covers all 15 algorithms grouped by category (sorting, relationship, randomization, AI-powered). Each section includes what it does, required analysis, direction options, dialog workflow descriptions, and auto-compute notes.
- **API Keys Guide** (`docs/user-guide/api-keys.md`): Detailed per-provider walkthroughs for Anthropic, OpenAI, Gemini, OpenRouter, Replicate, and YouTube Data API. Includes a "Which keys do I need?" quick-reference table, account creation steps, key generation, pricing notes, and env var alternatives.
- **Help menu**: New menu in the app menu bar (after View) with "Sequencer Guide" and "API Keys Guide" items that open the docs on GitHub via `QDesktopServices.openUrl()`. URLs constructed from shared `_GITHUB_OWNER`/`_GITHUB_REPO` constants.

## Test plan

- [x] All 1122 tests pass
- [x] `MainWindow` imports cleanly with Help menu code
- [ ] Manual: Help > Sequencer Guide opens correct GitHub URL in browser
- [ ] Manual: Help > API Keys Guide opens correct GitHub URL in browser
- [ ] Manual: Help menu appears after View menu on macOS

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: documentation files and a menu that opens URLs have no runtime impact.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)