### PR TITLE
feat: Free Association sequencer — LLM-powered step-by-step clip selection

### DIFF
--- a/core/remix/free_association.py
+++ b/core/remix/free_association.py
@@ -1,0 +1,465 @@
+"""Free Association: LLM-powered iterative sequencer.
+
+The user selects a first clip, then the LLM proposes each next clip based on
+clip metadata, providing a rationale for each transition. Accept/reject
+interaction with rejection memory per position.
+
+Key design (see docs/plans/2026-04-12-001-feat-free-association-sequencer-plan.md):
+
+Tiered metadata keeps per-step prompt cost bounded (~800 tokens) regardless
+of total clip count:
+  - Current clip: full metadata block
+  - Candidate pool: 12 clips pre-filtered by cosine similarity, each as a
+    compact pipe-delimited digest (~20-30 tokens)
+  - Sequence history: last 3-5 accepted rationale entries
+
+Local embedding shortlisting absorbs scaling — the LLM only ever sees ~12
+candidates regardless of how many clips exist.
+"""
+
+import json
+import logging
+import random
+from typing import Any, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SHORTLIST_SIZE = 12
+DEFAULT_RECENT_RATIONALES = 4  # middle of the 3-5 window
+
+
+def format_clip_digest(clip: Any) -> str:
+    """Format a clip as a compact pipe-delimited digest for LLM prompts.
+
+    Produces a short string (~20-30 tokens) summarizing structured clip fields.
+    Missing fields are omitted gracefully — never raises on partial metadata.
+
+    Example output: "CU | warm tones | bright | 2 people | outdoor | dialogue"
+
+    Args:
+        clip: A Clip object with optional metadata fields.
+
+    Returns:
+        Pipe-delimited string of available structured metadata. Falls back to
+        description (truncated) or clip name if no structured fields are set.
+    """
+    parts: list[str] = []
+
+    if clip.shot_type:
+        parts.append(clip.shot_type)
+
+    color_desc = _describe_colors(clip.dominant_colors)
+    if color_desc:
+        parts.append(color_desc)
+
+    brightness_desc = _describe_brightness(clip.average_brightness)
+    if brightness_desc:
+        parts.append(brightness_desc)
+
+    if clip.person_count:
+        noun = "person" if clip.person_count == 1 else "people"
+        parts.append(f"{clip.person_count} {noun}")
+
+    if clip.object_labels:
+        top_objects = [label for label in clip.object_labels[:3] if label]
+        if top_objects:
+            parts.append(", ".join(top_objects))
+
+    transcript_excerpt = _transcript_snippet(clip.transcript)
+    if transcript_excerpt:
+        parts.append(f'"{transcript_excerpt}"')
+
+    motion_desc = _describe_motion(clip.cinematography)
+    if motion_desc:
+        parts.append(motion_desc)
+
+    if parts:
+        return " | ".join(parts)
+
+    # Fallback: use description or name when structured fields are empty
+    if clip.description:
+        return clip.description[:80]
+    if clip.name:
+        return clip.name
+    return "no metadata available"
+
+
+def format_clip_full_metadata(clip: Any) -> str:
+    """Format a clip's full metadata as a richer text block for LLM prompts.
+
+    Used for the current clip only — gives the LLM deep context on "where we
+    are" in the sequence. Candidate clips use the compact digest instead.
+
+    Args:
+        clip: A Clip object.
+
+    Returns:
+        Multi-line text block with all available metadata fields.
+    """
+    lines: list[str] = []
+
+    if clip.description:
+        lines.append(f"Description: {clip.description}")
+    if clip.shot_type:
+        lines.append(f"Shot type: {clip.shot_type}")
+
+    color_desc = _describe_colors(clip.dominant_colors)
+    if color_desc:
+        lines.append(f"Colors: {color_desc}")
+
+    brightness_desc = _describe_brightness(clip.average_brightness)
+    if brightness_desc:
+        lines.append(f"Brightness: {brightness_desc}")
+
+    if clip.rms_volume is not None:
+        volume_desc = _describe_volume(clip.rms_volume)
+        lines.append(f"Audio: {volume_desc}")
+
+    if clip.person_count is not None and clip.person_count > 0:
+        noun = "person" if clip.person_count == 1 else "people"
+        lines.append(f"People: {clip.person_count} {noun}")
+
+    if clip.object_labels:
+        top = ", ".join(clip.object_labels[:5])
+        lines.append(f"Objects: {top}")
+
+    if clip.gaze_category:
+        lines.append(f"Gaze: {clip.gaze_category}")
+
+    transcript_excerpt = _transcript_snippet(clip.transcript, max_chars=200)
+    if transcript_excerpt:
+        lines.append(f'Transcript: "{transcript_excerpt}"')
+
+    if clip.extracted_texts:
+        texts = [t.text for t in clip.extracted_texts[:3] if getattr(t, "text", "")]
+        if texts:
+            lines.append(f"On-screen text: {', '.join(texts)}")
+
+    motion_desc = _describe_motion(clip.cinematography)
+    if motion_desc:
+        lines.append(f"Camera: {motion_desc}")
+
+    if clip.tags:
+        lines.append(f"Tags: {', '.join(clip.tags)}")
+
+    return "\n".join(lines) if lines else "(no metadata)"
+
+
+def shortlist_candidates(
+    current_clip: Any,
+    pool: list[tuple[Any, Any]],
+    k: int = DEFAULT_SHORTLIST_SIZE,
+) -> list[tuple[Any, Any]]:
+    """Pick the top-k most similar candidates from the pool by cosine similarity.
+
+    Uses existing CLIP/DINOv2 embeddings. Falls back to random sampling when
+    the current clip or the pool has no embeddings — the LLM can still make
+    useful choices from structured metadata alone.
+
+    Args:
+        current_clip: The Clip just accepted (or user-selected first clip).
+        pool: Remaining (Clip, Source) tuples available for proposal.
+        k: Maximum number of candidates to return.
+
+    Returns:
+        Up to k (Clip, Source) tuples ordered by similarity to current_clip
+        (most similar first). Returns all of pool if len(pool) <= k.
+    """
+    if len(pool) <= k:
+        return list(pool)
+
+    # Fallback: random sample when embedding comparison isn't possible
+    if current_clip.embedding is None:
+        logger.info("Current clip has no embedding; shortlisting by random sample")
+        return random.sample(pool, k)
+
+    with_emb: list[tuple[int, Any, Any]] = []
+    without_emb: list[tuple[Any, Any]] = []
+    for i, (clip, source) in enumerate(pool):
+        if clip.embedding is not None:
+            with_emb.append((i, clip, source))
+        else:
+            without_emb.append((clip, source))
+
+    if not with_emb:
+        logger.info("No pool clips have embeddings; shortlisting by random sample")
+        return random.sample(pool, k)
+
+    # Cosine similarity: dot product of L2-normalized vectors
+    current_vec = np.array(current_clip.embedding, dtype=np.float32)
+    pool_matrix = np.array(
+        [clip.embedding for _, clip, _ in with_emb], dtype=np.float32
+    )
+    similarities = pool_matrix @ current_vec
+
+    # Top-k by similarity (highest first)
+    top_indices = np.argsort(-similarities)[:k]
+    result = [(with_emb[idx][1], with_emb[idx][2]) for idx in top_indices]
+
+    # If we didn't fill k from embedding-equipped clips, pad with random
+    # selections from clips without embeddings
+    if len(result) < k and without_emb:
+        remaining = k - len(result)
+        result.extend(random.sample(without_emb, min(remaining, len(without_emb))))
+
+    return result
+
+
+def build_id_mapping(
+    candidates: list[tuple[Any, Any]],
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Build bidirectional short-ID <-> UUID mapping for LLM communication.
+
+    LLMs tend to truncate long UUIDs, so we map each candidate to c1, c2, ...
+    for the prompt and map back on response parsing.
+
+    Args:
+        candidates: List of (Clip, Source) tuples to assign short IDs to.
+
+    Returns:
+        (short_to_full, full_to_short) dict pair.
+    """
+    short_to_full: dict[str, str] = {}
+    full_to_short: dict[str, str] = {}
+    for i, (clip, _) in enumerate(candidates, start=1):
+        short_id = f"c{i}"
+        short_to_full[short_id] = clip.id
+        full_to_short[clip.id] = short_id
+    return short_to_full, full_to_short
+
+
+def propose_next_clip(
+    current_clip_metadata: str,
+    candidate_digests: list[tuple[str, str]],
+    recent_rationales: list[str],
+    rejected_short_ids: list[str],
+    model: Optional[str] = None,
+    temperature: Optional[float] = None,
+) -> tuple[str, str]:
+    """Ask the LLM to pick the next clip from the candidate shortlist.
+
+    Args:
+        current_clip_metadata: Full metadata text block for the current clip.
+        candidate_digests: List of (short_id, digest) tuples for shortlisted
+            candidates.
+        recent_rationales: Last 3-5 rationale strings from the sequence (empty
+            list for the first proposal).
+        rejected_short_ids: Short IDs the user rejected for this position.
+            The LLM must avoid these.
+        model: LLM model name (defaults to settings).
+        temperature: Sampling temperature (defaults to settings).
+
+    Returns:
+        (clip_short_id, rationale) tuple. The short_id must be validated by
+        the caller against the candidate set (handled in the worker).
+
+    Raises:
+        ValueError: If the LLM returns no content, malformed JSON, or an ID
+            not in the candidate set.
+    """
+    import litellm
+    from core.settings import get_llm_api_key, load_settings
+
+    settings = load_settings()
+    model = model or settings.exquisite_corpus_model or "gemini-3-flash-preview"
+    if temperature is None:
+        temperature = settings.exquisite_corpus_temperature
+
+    # Normalize model name for LiteLLM (same convention as storyteller)
+    if "gemini" in model.lower() and not any(
+        model.startswith(p) for p in ["gemini/", "vertex_ai/"]
+    ):
+        model = f"gemini/{model}"
+    elif "claude" in model.lower() and not any(
+        model.startswith(p) for p in ["anthropic/", "bedrock/"]
+    ):
+        model = f"anthropic/{model}"
+
+    api_key = get_llm_api_key()
+
+    candidate_ids = {short_id for short_id, _ in candidate_digests}
+    available_ids = sorted(candidate_ids - set(rejected_short_ids))
+
+    system_prompt = """You are a film editor building a sequence one clip at a time through \
+free association. You see the current clip's full metadata, compact digests for a shortlist \
+of candidate clips, and the rationales for recent transitions.
+
+Pick ONE clip from the candidate shortlist that has the strongest metadata-grounded \
+connection to the current clip. Your rationale must reference ACTUAL metadata values \
+(shot type, colors, objects, people, motion, etc.) — no abstract or poetic language.
+
+AVOID: candidates already rejected for this position (listed separately).
+AVOID: repeating motifs already heavy in recent transitions.
+
+Return ONLY a JSON object with this shape:
+{"clip_id": "c3", "rationale": "Both clips share close-up framing with warm tones \
+and a single person; the motion rhymes — left-pan to left-pan."}
+
+Keep the rationale to 1-2 sentences. Reference 2-4 concrete metadata dimensions."""
+
+    candidate_block = "\n".join(
+        f"  {sid}: {digest}" for sid, digest in candidate_digests
+    )
+
+    history_block = ""
+    if recent_rationales:
+        recent = "\n".join(f"  - {r}" for r in recent_rationales)
+        history_block = f"\n\nRECENT TRANSITIONS:\n{recent}"
+
+    rejected_block = ""
+    if rejected_short_ids:
+        rejected_block = f"\n\nREJECTED AT THIS POSITION (avoid): {', '.join(sorted(rejected_short_ids))}"
+
+    available_block = f"\n\nAVAILABLE TO CHOOSE FROM: {', '.join(available_ids)}"
+
+    user_prompt = f"""CURRENT CLIP:
+{current_clip_metadata}
+
+CANDIDATE SHORTLIST:
+{candidate_block}{history_block}{rejected_block}{available_block}
+
+Pick one from the available candidates and explain the metadata-grounded connection."""
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+    logger.debug("Free Association LLM call: model=%s, temp=%s", model, temperature)
+    response = litellm.completion(
+        model=model,
+        messages=messages,
+        api_key=api_key,
+        temperature=temperature,
+    )
+
+    # None-safe response extraction (drawing_vlm.py pattern — NOT
+    # storyteller.py, which has a latent AttributeError on None content).
+    content = response.choices[0].message.content
+    if content is None or not str(content).strip():
+        raise ValueError("LLM returned no content (possible content filter or rate limit)")
+    response_text = str(content).strip()
+    logger.debug("LLM response: %s", response_text[:300])
+
+    clip_id, rationale = _parse_proposal_response(response_text)
+
+    if clip_id not in candidate_ids:
+        raise ValueError(
+            f"LLM returned clip_id '{clip_id}' not in candidate set {sorted(candidate_ids)}"
+        )
+    if clip_id in rejected_short_ids:
+        raise ValueError(
+            f"LLM returned clip_id '{clip_id}' which is in the rejected set — retry"
+        )
+
+    return clip_id, rationale
+
+
+def _parse_proposal_response(response_text: str) -> tuple[str, str]:
+    """Extract clip_id and rationale from the LLM response JSON.
+
+    Handles markdown code fences and extra surrounding text. Raises ValueError
+    on malformed JSON or missing fields.
+    """
+    text = response_text
+    # Strip markdown fences
+    if text.startswith("```"):
+        lines = text.split("\n")
+        text = "\n".join(line for line in lines if not line.startswith("```")).strip()
+
+    # Find JSON object boundaries (LLMs sometimes add explanatory prose)
+    start_idx = text.find("{")
+    end_idx = text.rfind("}")
+    if start_idx == -1 or end_idx == -1:
+        raise ValueError(f"No JSON object found in LLM response: {response_text[:200]}")
+    text = text[start_idx : end_idx + 1]
+
+    try:
+        result = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"LLM returned malformed JSON: {exc}") from exc
+
+    if not isinstance(result, dict):
+        raise ValueError(f"LLM response is not a JSON object: {type(result).__name__}")
+
+    clip_id = result.get("clip_id")
+    rationale = result.get("rationale")
+    if not clip_id or not isinstance(clip_id, str):
+        raise ValueError(f"LLM response missing 'clip_id' field: {result}")
+    if not rationale or not isinstance(rationale, str):
+        raise ValueError(f"LLM response missing 'rationale' field: {result}")
+
+    return clip_id, rationale
+
+
+# ---------------------------------------------------------------------------
+# Private helpers: metadata descriptors
+# ---------------------------------------------------------------------------
+
+
+def _describe_colors(dominant_colors: Optional[list[tuple[int, int, int]]]) -> str:
+    """Map dominant RGB tuples to a short color descriptor."""
+    if not dominant_colors:
+        return ""
+    r, g, b = dominant_colors[0]
+    # Warmth from red/blue balance
+    if r > b + 30:
+        warmth = "warm"
+    elif b > r + 30:
+        warmth = "cool"
+    else:
+        warmth = "neutral"
+    # Saturation vs grayscale
+    max_c, min_c = max(r, g, b), min(r, g, b)
+    if max_c - min_c < 25:
+        return f"{warmth} grayscale"
+    return f"{warmth} tones"
+
+
+def _describe_brightness(brightness: Optional[float]) -> str:
+    if brightness is None:
+        return ""
+    if brightness < 0.3:
+        return "dark"
+    if brightness < 0.6:
+        return "mid-tone"
+    return "bright"
+
+
+def _describe_volume(rms_volume: float) -> str:
+    """Describe RMS volume in dB."""
+    if rms_volume < -40:
+        return "quiet / near-silent"
+    if rms_volume < -20:
+        return "moderate"
+    return "loud"
+
+
+def _transcript_snippet(transcript: Any, max_chars: int = 60) -> str:
+    """Extract a short excerpt from a clip's transcript, if any."""
+    if not transcript:
+        return ""
+    try:
+        text = " ".join(seg.text for seg in transcript if getattr(seg, "text", "")).strip()
+    except Exception:
+        return ""
+    if not text:
+        return ""
+    if len(text) > max_chars:
+        text = text[: max_chars - 1].rstrip() + "…"
+    return text
+
+
+def _describe_motion(cinematography: Any) -> str:
+    """Describe camera motion from cinematography analysis, if present."""
+    if cinematography is None:
+        return ""
+    # Look for common motion-related attributes without hard-coding the
+    # full CinematographyAnalysis schema. Graceful on missing fields.
+    for attr in ("camera_motion", "movement", "motion"):
+        value = getattr(cinematography, attr, None)
+        if value:
+            return str(value)
+    return ""

--- a/docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md
+++ b/docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md
@@ -1,0 +1,72 @@
+---
+date: 2026-04-12
+topic: free-association-sequencer
+---
+
+# Free Association Sequencer
+
+## Problem Frame
+
+Scene Ripper's existing sequencers operate on fixed axes — similarity chains use embeddings, storyteller follows narrative arcs, shuffle is random. None let the user leverage the full breadth of clip metadata through an LLM that makes practical, grounded associative decisions one clip at a time. Editors want a sequencer that acts like a knowledgeable collaborator: it sees everything about each clip and proposes connections the editor can accept, reject, or re-roll.
+
+## Requirements
+
+**Core Sequencing**
+- R1. The sequencer accepts a user-selected first clip and iteratively builds a sequence by proposing one next clip at a time.
+- R2. Each proposal is informed by a tiered metadata strategy to keep per-step token cost bounded (~800 tokens input):
+  - **Current clip**: full metadata (description, shot type, dominant colors, brightness, volume, objects, faces, transcript, cinematography, gaze, extracted text).
+  - **Candidate pool**: a shortlist of ~10-15 clips pre-filtered locally using embedding similarity, each represented as a compact metadata digest (~20-30 tokens per clip, e.g., "CU | warm tones | bright | 2 people | outdoor | dialogue | slow pan"). The shortlist is built from structured fields with no LLM cost.
+  - **Sequence history**: a rolling theme summary (~50-100 tokens) updated after each acceptance, not the full metadata of every placed clip.
+- R3. The rolling sequence summary captures motifs, patterns, and variety so the LLM avoids repetitive transitions without needing the full history of every placed clip.
+
+**Rationale**
+- R4. Each proposed clip includes a rationale explaining the metadata-driven connection (e.g., "Both clips share close-up framing with warm dominant colors and similar motion energy").
+- R5. Rationales are displayed in a scrollable side panel log that accumulates as the sequence is built, showing each transition decision.
+
+**Accept / Reject Interaction**
+- R6. The user can accept the proposed clip (it's added to the sequence, LLM proposes the next one) or reject it.
+- R7. On rejection, the LLM proposes a different clip, knowing which clips have been rejected for this position. The user can re-roll as many times as needed.
+- R8. Rejected clips return to the available pool for future positions — they're only excluded from the current position's proposals.
+
+**Completion**
+- R9. Sequencing ends when all clips are placed or the user explicitly stops early.
+- R10. The accumulated rationale log persists with the sequence so it can be reviewed after the dialog is closed.
+
+## Success Criteria
+
+- User can build a full sequence one clip at a time with meaningful, metadata-grounded rationales for each transition.
+- Reject/re-roll produces a different clip with a different rationale.
+- Rationale log is readable and useful as editorial notes.
+
+## Scope Boundaries
+
+- No abstract/poetic mode — rationales are grounded in actual metadata values.
+- No multi-candidate selection (showing ranked alternatives). Single proposal with re-roll.
+- No "regenerate from midpoint" — this is a step-by-step sequencer, not batch-with-rewind.
+- No new metadata fields or analysis types — uses whatever metadata already exists on clips. The compact digest and rolling summary are ephemeral prompt artifacts, not persisted data.
+
+## Key Decisions
+
+- **Step-by-step over one-shot**: Gives the editor creative control at each transition rather than reviewing a fait accompli. More engaging and educational (you learn what metadata connections exist).
+- **Single re-roll over ranked alternatives**: Keeps the UI simple. Showing 3 candidates with rationales would be noisy and slow (3x LLM output per step).
+- **Side panel log over inline card annotations**: Keeps the sequence grid clean while providing full transparency. The log reads like editor's notes.
+- **Tiered metadata over full dump**: The current clip gets full detail, candidates get compact digests, and history is a rolling summary. This keeps per-step cost at ~800 tokens regardless of total clip count — local embedding similarity absorbs the scaling, not the LLM context. The LLM still sees all metadata dimensions for the current clip and can weight what matters per transition.
+- **Local pre-filtering over LLM pool scanning**: Using existing embeddings to shortlist ~10-15 candidates keeps the LLM focused on making a good choice from strong options rather than scanning 100+ clips. This also bounds latency and cost per step.
+
+## Dependencies / Assumptions
+
+- Clips must have at least `description` populated for meaningful associations. Other metadata fields enrich the output but aren't strictly required.
+- Existing LLM infrastructure (`core/llm_client.py`, LiteLLM) handles the model calls. Each LLM response must be validated for None/empty content before parsing — this is a documented codebase bug pattern (existing sequencers don't guard against it). A failed call mid-sequence must not discard the user's accepted clips.
+- Dialog-based sequencer pattern (QDialog + QThread worker) is established by Storyteller and Exquisite Corpus. However, the iterative accept/reject loop is a novel interaction pattern — existing dialogs run to completion in one go. Planning must design a new worker lifecycle (e.g., single-step worker invoked per proposal, not a long-running worker).
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R5, R10][Technical] Whether the rationale log should be a new field on SequenceClip or a separate data structure on the sequence, and its serialization format for project save/load.
+- [Affects R2][Technical] Exact format of the compact metadata digest — which fields to include, field ordering, and how to handle missing metadata gracefully.
+- [Affects R2][Technical] Shortlist size tuning — 10-15 is the starting target, but the right number may depend on how diverse the candidate pool is.
+- [Affects R1][Technical] Worker lifecycle design for the iterative accept/reject loop — single-step worker per proposal vs. long-lived worker with inter-thread signaling.
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-12-001-feat-free-association-sequencer-plan.md
+++ b/docs/plans/2026-04-12-001-feat-free-association-sequencer-plan.md
@@ -1,0 +1,394 @@
+---
+title: "feat: Add Free Association sequencer"
+type: feat
+status: active
+date: 2026-04-12
+deepened: 2026-04-13
+origin: docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md
+---
+
+# feat: Add Free Association sequencer
+
+## Overview
+
+Add a new LLM-powered sequencer algorithm called "Free Association" that builds a clip sequence one transition at a time through an interactive accept/reject dialog. The user selects a first clip, and the LLM proposes each subsequent clip based on clip metadata, providing a rationale for each transition. This is the first iterative, human-in-the-loop sequencer in the app.
+
+## Problem Frame
+
+Scene Ripper has 16 sequencer algorithms, including two LLM-powered ones (Storyteller, Exquisite Corpus), but all operate in batch mode — the user configures and generates a complete sequence at once. Free Association fills a gap: a step-by-step sequencer where the editor collaborates with the LLM one transition at a time, reviewing metadata-grounded rationales for each choice. (see origin: `docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md`)
+
+## Requirements Trace
+
+- R1. User-selected first clip with iterative one-at-a-time proposal
+- R2. Tiered metadata strategy (total ~800 tokens/step): full metadata for current clip, compact digests for 12 shortlisted candidates, last 3-5 rationale entries for sequence context
+- R3. Last 3-5 rationale entries serve as sequence context so the LLM avoids repetitive transitions
+- R4. Each proposal includes a metadata-grounded rationale
+- R5. Scrollable side panel log displaying rationale entries
+- R6. Accept adds clip to sequence and triggers next proposal
+- R7. Reject proposes a different clip with rejection memory per position
+- R8. Rejected clips return to pool for future positions
+- R9. Ends when all clips placed or user stops early
+- R10. Rationale log persists with the sequence via `SequenceClip.rationale` field
+
+## Scope Boundaries
+
+- No abstract/poetic mode — rationales reference actual metadata values
+- No multi-candidate selection — single proposal with re-roll
+- No regenerate-from-midpoint — step-by-step only
+- No new analysis types (the `SequenceClip.rationale` field is added, but no new clip-level metadata)
+- The compact digest and recent-rationales prompt window are ephemeral generation artifacts. The final rationale text for each accepted clip **is** persisted on `SequenceClip.rationale` (see R10).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `core/remix/storyteller.py` — LLM sequencer pattern: `litellm.completion()`, short ID mapping (c1/c2/...), JSON response parsing, markdown fence stripping
+- `core/remix/exquisite_corpus.py` — Alternative LLM sequencer with same call pattern
+- `core/remix/similarity_chain.py` — `_cosine_distance_matrix()` for embedding similarity, L2-normalized vectors
+- `ui/dialogs/storyteller_dialog.py` — Dialog + QThread worker pattern: `QStackedWidget` pages, `sequence_ready` signal, preview with reorder
+- `ui/algorithm_config.py` — Algorithm registration with `is_dialog: True`, zero-dependency module
+- `ui/tabs/sequence_tab.py` — Dialog routing at `_on_card_clicked()`, `_apply_dialog_sequence()` for applying results
+- `models/sequence.py` — `Sequence` and `SequenceClip` dataclasses with `to_dict`/`from_dict`
+- `ui/workers/base.py` — `CancellableWorker` base class
+- `core/settings.py` — Model/temperature settings pattern (see `exquisite_corpus_model`)
+
+### Institutional Learnings
+
+- **QThread finished signal duplication** (`docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`): Qt `finished` signal can fire twice. Use guard flags + `Qt.UniqueConnection`. Critical for iterative worker pattern.
+- **Sequence overwrite** (`docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md`): Dialog output must write to the same Sequence object the UI reads from. Use `_apply_dialog_sequence()` path.
+- **Algorithm config location** (`docs/solutions/logic-errors/circular-import-config-consolidation.md`): Register in `ui/algorithm_config.py` only, never inline.
+- **Worker ID sync** (`docs/solutions/ui-bugs/pyside6-thumbnail-source-id-mismatch.md`): Worker-created objects must reference existing UI-state IDs.
+- **LLM None responses** (CLAUDE.md): `litellm.completion()` can return None content without exception. Always validate before `.strip()`.
+
+## Key Technical Decisions
+
+- **Single-step worker per proposal over long-lived worker**: Each accept/reject spawns a fresh `QThread` worker for the next LLM call. The dialog maintains all state (sequence, pool, rejections). This avoids inter-thread signaling complexity and follows the guard flag pattern from institutional learnings. Old workers are cleaned up via `worker.finished.connect(worker.deleteLater)`.
+- **Rationale stored on SequenceClip**: Add `rationale: Optional[str] = None` to `SequenceClip`. Co-located with clip data, serializes through existing `to_dict`/`from_dict` pipeline. First clip gets `None` (user-selected).
+- **Recent rationales as sequence context**: Instead of a separate rolling summary, include the last 3-5 rationale entries in each prompt. These already describe transitions and metadata connections. Keeps history at ~150-200 tokens without an extra LLM call.
+- **Local shortlisting via cosine similarity**: Use existing `_cosine_distance_matrix()` pattern from `similarity_chain.py` to pre-filter to 12 candidates closest to the current clip. Caps prompt cost regardless of total clip count.
+- **Short ID mapping**: Map clip UUIDs to `c1, c2, ...` for LLM communication (following Storyteller pattern). Map back on parse.
+- **Pipe-delimited compact digest**: Format each candidate as `"c3: CU | warm tones | bright | 2 people | outdoor | dialogue | slow pan"` — structured fields, no LLM cost to generate, ~20-30 tokens each.
+- **No worker.wait() on early stop**: Cancel sets flag, dialog closes immediately with partial sequence. Worker cleans up via `deleteLater`. Avoids 120s UI freeze from blocking HTTP calls.
+- **New apply method instead of reusing `_apply_dialog_sequence()`**: The existing dialog apply path reconstructs SequenceClip objects internally with no mechanism to carry a rationale field. A new `_apply_free_association_sequence()` method preserves rationale by setting it on the SequenceClip immediately after the timeline creates it. The dialog emits `list[tuple[Clip, Source, Optional[str]]]` (the third element being rationale) to make this explicit in the signal contract.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Rationale storage location**: `SequenceClip.rationale` field — co-located, serializes naturally, no separate data structure needed
+- **Worker lifecycle**: Single-step worker per proposal, dialog owns all state
+- **Token budget strategy**: Tiered metadata (~800 tokens/step) with local shortlisting — scales to any clip count
+- **Sequence history representation**: Last 3-5 rationale entries — no extra LLM call, natural context window
+- **Pool exhaustion**: When every clip in the shortlist for the current position has been rejected (and no other candidates remain in the pool), enter `POOL_EXHAUSTED` state. The dialog shows a page offering "End sequence with clips placed so far" or "Back to previous proposal" (which resurrects the most recently rejected clip and treats it as if proposed again, letting the user reconsider). No "Skip position" — a gap in the sequence has no meaning in this sequencer.
+- **LLM error recovery**: Retry button for current step; sequence built so far is preserved; cancel closes with partial sequence
+- **Stop flow (user-initiated early stop)**: Confirmation dialog if 3+ clips have been accepted ("End sequence with N clips?"). On confirm, transition directly to COMPLETE with partial sequence preserved. Skip confirmation if 0-2 clips accepted (low-cost to start over).
+- **Rationale log behavior**: Only accepted transitions appear in the log. Rejected proposals never enter the log — the log is the record of the final sequence, not the exploration path. Log is not cleared when the dialog errors and recovers.
+- **Rationale preservation through apply pipeline**: `_apply_dialog_sequence()` does not propagate custom SequenceClip fields (it reconstructs clips). Free Association uses a new apply method that sets `rationale` on each created SequenceClip after the timeline creates it (see Unit 5).
+- **Rejection history in prompt**: Include rejected short IDs with instruction to avoid them
+
+### Deferred to Implementation
+
+- **Exact prompt wording**: System prompt and user prompt templates will be tuned during implementation based on LLM output quality
+- **Shortlist size tuning**: Starting at 12, may adjust based on diversity of proposals
+- **Compact digest field ordering**: Which fields to prioritize when not all metadata is available
+- **Model/temperature defaults**: Will match existing sequencer settings pattern but specific defaults TBD
+- **Rationale-lookup mechanism in `_apply_free_association_sequence()`**: Prefer extending `timeline_widget.add_clip()` to return the created `SequenceClip` (cleaner). Fall back to matching by `source_clip_id` on `sequence.get_all_clips()` if the timeline API change is invasive. Decide when touching the code.
+- **Shortlisting diversity vs similarity**: Pure cosine similarity may pre-filter too narrowly for true "free association." If early testing shows homogeneous proposals, consider a hybrid shortlist (e.g., 6 most similar + 6 random from remaining pool). Start pure, adjust after validation.
+- **Cross-position rejection cooldown**: The current design only remembers rejections within the current position. If testing shows rejected clips cycling back immediately at the next position and annoying users, add a short cooldown (last 2-3 positions).
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Dialog
+    participant Worker
+    participant LLM
+    participant Pool as Candidate Pool
+
+    User->>Dialog: Select first clip
+    Dialog->>Dialog: Add to sequence, update pool
+
+    loop For each position
+        Dialog->>Pool: Shortlist 12 candidates (cosine similarity)
+        Dialog->>Worker: Spawn single-step worker
+        Worker->>LLM: Send prompt (current clip + digests + recent rationales + rejected IDs)
+        LLM-->>Worker: Response (clip_id + rationale)
+        Worker-->>Dialog: proposal_ready signal
+
+        alt User accepts
+            Dialog->>Dialog: Add clip to sequence, log rationale
+        else User rejects
+            Dialog->>Dialog: Add to rejection set for this position
+            Note over Dialog: Spawn new worker with updated rejection list
+        else Pool exhausted for position
+            Dialog->>User: Skip position / End sequence
+        end
+    end
+
+    Dialog->>Dialog: Emit sequence_ready with SequenceClips (rationales attached)
+```
+
+**State machine for the dialog:**
+- `FIRST_CLIP_SELECT` → user picks first clip + clicks Start → `LOADING`
+- `LOADING` → worker emits `proposal_ready` → `PROPOSAL` / worker emits `error` → `ERROR` / user clicks Stop → `COMPLETE` (partial)
+- `PROPOSAL` → Accept → `LOADING` (next position) / Reject → `LOADING` (same position, new candidate) / Stop → confirmation if ≥3 clips → `COMPLETE` (partial)
+- `LOADING` (after reject when shortlist-minus-rejected is empty) → `POOL_EXHAUSTED`
+- `POOL_EXHAUSTED` → End sequence → `COMPLETE` / Reconsider last rejected → `PROPOSAL` (with resurrected clip)
+- `ERROR` → Retry → `LOADING` (same position) / Cancel → `COMPLETE` (partial, clips so far preserved)
+- `COMPLETE` → Apply → emit `sequence_ready`, dialog closes / Close → discard (confirmation if ≥3 clips)
+
+**COMPLETE vs POOL_EXHAUSTED distinction:**
+- `COMPLETE` is a terminal state entered deliberately: all clips placed (pool empty via acceptance), user chose to stop early, or error recovery cancel.
+- `POOL_EXHAUSTED` is a transient state entered when no unrejected candidates remain at the current position; the user resolves it (end or reconsider) and the flow continues.
+
+## Implementation Units
+
+- [ ] **Unit 1: Data model and algorithm registration**
+
+  **Goal:** Add `SequenceClip.rationale` field (new persistent field, the first generic metadata string on SequenceClip) and register Free Association in `ALGORITHM_CONFIG`.
+
+  **Requirements:** R10 (persistence)
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `models/sequence.py` — add `rationale` field to `SequenceClip`
+  - Modify: `ui/algorithm_config.py` — add `free_association` entry
+  - Test: `tests/test_sequence_model.py` — field persistence + project round-trip
+
+  **Approach:**
+  - **Data model change (explicit call-out)**: Add `rationale: Optional[str] = None` to the `SequenceClip` dataclass. This is the first SequenceClip field intended for free-form human/LLM text, so ensure it does not break existing equality, hashing, or repr expectations in tests.
+  - Update `to_dict()` to include `rationale` when non-None (skip when None to keep serialized size small and backward-compatible).
+  - Update `from_dict()` to read `rationale` with `None` default (old projects without the key load cleanly).
+  - Verify the field survives through the full save/load chain: `SequenceClip` → `Track.to_dict()` → `Sequence.to_dict()` → `Project` save → load back. No intermediate layer should cherry-pick fields.
+  - Add `"free_association"` entry to `ALGORITHM_CONFIG` with `is_dialog: True`, appropriate icon, label, description, `categories`, and `required_analysis: ["describe"]` (embeddings are *not* required — the core module falls back to random sampling when embeddings are missing, so gating on embeddings would contradict the graceful degradation design in Unit 2).
+
+  **Patterns to follow:**
+  - Existing optional fields on `SequenceClip` (e.g., `prerendered_path`)
+  - Existing dialog algorithm entries in `ALGORITHM_CONFIG` (Storyteller, Exquisite Corpus)
+
+  **Test scenarios:**
+  - Happy path: SequenceClip with rationale serializes to dict and deserializes back with rationale preserved
+  - Happy path: SequenceClip without rationale serializes without rationale key (backward-compatible)
+  - Edge case: `from_dict` on old data (no rationale key) returns SequenceClip with `rationale=None`
+  - Integration: Full project round-trip — create a Sequence with a SequenceClip carrying a rationale, save project to disk, load back, verify rationale text survives intact. Catches any serialization layer that drops unknown fields.
+  - Happy path: `get_algorithm_config("free_association")` returns valid config with `is_dialog: True` and `required_analysis: ["describe"]`
+
+  **Verification:**
+  - Existing project save/load tests still pass (backward compatibility)
+  - New algorithm appears in `ALGORITHM_CONFIG` and returns correct config
+  - Rationale text survives a full project save/load round-trip
+
+- [ ] **Unit 2: Core algorithm module**
+
+  **Goal:** Implement metadata formatting, candidate shortlisting, and LLM proposal logic.
+
+  **Requirements:** R2, R3, R4, R7
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `core/remix/free_association.py`
+  - Test: `tests/test_free_association.py`
+
+  **Approach:**
+  - `format_clip_digest(clip: Clip) -> str` — Pipe-delimited compact summary from structured fields (shot_type, color descriptor from dominant_colors, brightness descriptor, person_count, object labels, transcript keywords, camera motion from cinematography). Omit missing fields gracefully.
+  - `format_clip_full_metadata(clip: Clip) -> str` — Richer text block for the current clip: description, shot type, colors, brightness, volume, objects, faces, transcript excerpt, cinematography, gaze, extracted text.
+  - `shortlist_candidates(current_clip: Clip, pool: list[tuple[Clip, Source]], k: int = 12) -> list[tuple[Clip, Source]]` — Compute cosine similarity using the same L2-normalized dot-product pattern from `similarity_chain.py`. Return top-k most similar candidates. Fall back to random sample if embeddings are missing.
+  - `propose_next_clip(current_clip_metadata: str, candidate_digests: list[tuple[str, str]], recent_rationales: list[str], rejected_ids: list[str], model: str, temperature: float) -> tuple[str, str]` — Build prompt, call `litellm.completion()`, parse JSON response for `(clip_short_id, rationale)`. **Critical: do NOT follow `storyteller.py`'s response extraction pattern** — it calls `response.choices[0].message.content.strip()` without a None check, which crashes with `AttributeError` when the LLM returns None content (a documented codebase bug pattern). Instead follow `core/remix/drawing_vlm.py`: extract content first, validate for None/empty, then strip. Raise `ValueError("LLM returned no content")` on None. Use short ID mapping (c1, c2, ...) following Storyteller's ID pattern. Strip markdown fences before JSON parse. Validate returned short ID is in the candidate set (reject hallucinated IDs).
+  - `build_id_mapping(candidates: list[tuple[Clip, Source]]) -> tuple[dict[str, str], dict[str, str]]` — Map between UUIDs and short IDs.
+
+  **Patterns to follow:**
+  - `core/remix/storyteller.py` — `litellm.completion()` call setup, short ID mapping, JSON parsing, model prefix normalization. **Do NOT copy its response extraction** (missing None guard).
+  - `core/remix/drawing_vlm.py` — Correct response extraction pattern: extract `.content`, None-check, then process.
+  - `core/remix/similarity_chain.py` — cosine similarity computation (L2-normalized dot product)
+
+  **Test scenarios:**
+  - Happy path: `format_clip_digest` with fully populated clip produces pipe-delimited string with all fields
+  - Edge case: `format_clip_digest` with clip missing most metadata produces short but valid string (only description)
+  - Edge case: `format_clip_digest` with clip having no metadata at all returns minimal placeholder
+  - Happy path: `shortlist_candidates` with 50 clips and valid embeddings returns top 12 by similarity
+  - Edge case: `shortlist_candidates` with clips missing embeddings falls back to random sample of k
+  - Edge case: `shortlist_candidates` with fewer clips than k returns all clips
+  - Happy path: `propose_next_clip` with mocked `litellm.completion` returning valid JSON extracts clip ID and rationale
+  - Error path: `propose_next_clip` with mocked `litellm.completion` returning None content raises ValueError with clear message
+  - Error path: `propose_next_clip` with mocked `litellm.completion` returning malformed JSON raises ValueError
+  - Happy path: `build_id_mapping` creates bidirectional short ID ↔ UUID mapping
+  - Happy path: short ID mapping round-trips — UUID → short ID → UUID
+
+  **Verification:**
+  - All formatting functions handle missing metadata without crashing
+  - Shortlisting respects k parameter and embedding similarity ordering
+  - LLM call uses short IDs and maps back correctly
+  - None/malformed response raises clear errors
+
+- [ ] **Unit 3: Single-step worker**
+
+  **Goal:** Create a QThread worker that executes one LLM proposal call per invocation.
+
+  **Requirements:** R1, R6, R7
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Create: `ui/workers/free_association_worker.py`
+  - Test: `tests/test_free_association_worker.py`
+
+  **Approach:**
+  - Extend `CancellableWorker` from `ui/workers/base.py`
+  - Constructor receives: current clip metadata (str), candidate digests (list), recent rationales (list), rejected IDs (list), model, temperature
+  - `run()` calls `propose_next_clip()` from the core module
+  - Emits `proposal_ready(str, str)` signal with (clip_short_id, rationale) on success
+  - Emits `error(str)` signal with message on failure (catches ValueError from None/malformed response, litellm exceptions)
+  - Uses `_cancelled` flag from base class — checks after LLM call returns
+  - Each instance is single-use: created, started, emits one result, then cleaned up via `deleteLater`
+
+  **Patterns to follow:**
+  - `ui/workers/base.py` — `CancellableWorker` interface (provides thread-safe cancellation via `threading.Event`)
+  - `ui/dialogs/storyteller_dialog.py` — Worker signal connection pattern with `Qt.UniqueConnection`. Note: `StorytellerWorker` extends `QThread` directly with a bare `_cancelled` flag — this worker should extend `CancellableWorker` instead, which is the correct base class for new workers.
+
+  **Test scenarios:**
+  - Happy path: Worker with mocked `propose_next_clip` emits `proposal_ready` with correct clip ID and rationale
+  - Error path: Worker with `propose_next_clip` raising ValueError emits `error` signal with message
+  - Error path: Worker with `propose_next_clip` raising network exception emits `error` signal
+  - Edge case: Worker cancelled before LLM call completes does not emit `proposal_ready`
+
+  **Verification:**
+  - Worker never crashes — all exceptions caught and routed to `error` signal
+  - Single-use lifecycle: one invocation, one signal, then cleanup
+
+- [ ] **Unit 4: Dialog UI**
+
+  **Goal:** Build the interactive dialog with first-clip selection, proposal display, accept/reject controls, and rationale log panel.
+
+  **Requirements:** R1, R5, R6, R7, R8, R9, R10
+
+  **Dependencies:** Unit 1, Unit 2, Unit 3
+
+  **Files:**
+  - Create: `ui/dialogs/free_association_dialog.py`
+  - Test: `tests/test_free_association_dialog.py`
+
+  **Approach:**
+  - `QDialog` subclass with `sequence_ready = Signal(list)` emitting `list[tuple[Clip, Source]]`
+  - Constructor: `(clips, sources_by_id, project, parent=None)`
+  - **Layout**: Two-column — left side has the main interaction area (stacked widget), right side has the scrollable rationale log panel. Minimum dialog width: wide enough for two columns (~900px). The log panel takes ~30% of width.
+  - **Pages** via `QStackedWidget`:
+    - `FIRST_CLIP_SELECT`: Fixed grid view of available clips with thumbnails (no list/grid toggle — keep it simple). User single-clicks to select (visual highlight), then clicks a **Start** button to confirm. No double-click-to-start (too easy to trigger accidentally). If the clip pool is empty at dialog open time, show a message "No clips available — add clips in the Cut tab first" with a Close button (no Start).
+    - `LOADING`: Spinner + status label below: "Finding clip for position N of the sequence…" (position number makes progress legible). A **Stop** button is visible (same behavior as stopping from PROPOSAL). No position total is shown — this is an open-ended sequence.
+    - `PROPOSAL`: Shows proposed clip (thumbnail, name, key metadata from digest) with rationale text. **Accept** and **Reject** buttons enabled. **Stop** button also visible to end the sequence early.
+    - `ERROR`: Error message with **Retry** and **Cancel** buttons. Sequence built so far is preserved on either action. Cancel routes to COMPLETE with partial sequence.
+    - `POOL_EXHAUSTED`: Message "All remaining candidates for this position have been rejected." Two buttons: **End sequence** (routes to COMPLETE with partial sequence) and **Reconsider last rejected** (resurrects the most recently rejected clip and re-enters PROPOSAL with it). No "Skip position" — gaps have no meaning here.
+    - `COMPLETE`: Summary content: count of accepted clips, total approximate duration (sum of clip durations), and a scrollable list of accepted clip names in sequence order. **Apply** button commits the sequence (emits `sequence_ready`). **Close** discards the session without applying — confirmation required if 3+ clips were accepted ("Discard sequence with N clips?").
+  - **Rationale log panel**: `QListWidget` (read-only) on the right side. Each entry: position number + clip name + rationale text (multiline, word-wrapped). Auto-scrolls to latest on new entry. **Only accepted transitions appear in the log** — rejected proposals never enter the log. The log is the record of the final sequence, not the exploration path. The log is not cleared during ERROR/recovery. During FIRST_CLIP_SELECT the panel shows a placeholder "Proposals and rationales will appear here."
+  - **Dialog state** (owned by dialog, not worker):
+    - `sequence_built: list[tuple[Clip, Source]]` — accepted clips in order
+    - `rationales: list[str]` — parallel list of rationale strings
+    - `available_pool: list[tuple[Clip, Source]]` — remaining candidates
+    - `rejected_for_position: set[str]` — clip IDs rejected for current position, cleared on accept or skip
+  - **Accept flow**: Add proposed clip to `sequence_built`, add rationale to `rationales`, remove clip from `available_pool`, clear `rejected_for_position`, shortlist from updated pool, append entry to rationale log, spawn new worker.
+  - **Reject flow**: Add proposed clip ID to `rejected_for_position`, **do not touch the rationale log** (rejected proposals never enter it), re-shortlist excluding rejected IDs, spawn new worker with updated rejection list.
+  - **Pool exhaustion**: When shortlisting returns zero unrejected candidates for the current position, transition to POOL_EXHAUSTED page. The most recently rejected clip ID is stashed so "Reconsider last rejected" can resurrect it.
+  - **Early stop flow**: "Stop" button visible during LOADING and PROPOSAL pages. On click, if `len(sequence_built) >= 3`, show a confirmation dialog "End sequence with N clips?". On confirm (or if fewer than 3 clips), call `worker.cancel()` (no `worker.wait()`), transition to COMPLETE with partial sequence. Worker cleans up via `deleteLater`.
+  - **Finish / Apply**: When the user clicks Apply on COMPLETE, emit `sequence_ready` with a payload of `list[tuple[Clip, Source, Optional[str]]]` — the third tuple element is the rationale for that clip (None for the first/user-selected clip). This three-tuple signature allows the sequence tab to set `rationale` on each SequenceClip after the timeline creates it (see Unit 5 for the apply mechanism). Do not emit pre-built SequenceClip objects — the existing timeline pipeline reconstructs clips internally, and sending pre-built ones would be confusing.
+  - **Worker lifecycle**: Guard flag (`_proposal_handled = False`) on `_on_proposal_ready`, reset before spawning new worker. Connect with `Qt.UniqueConnection`. **IMPORTANT: Do not follow `storyteller_dialog.py`'s `_on_cancel`/`closeEvent` pattern of calling `worker.wait()`** — that blocks the UI thread for the duration of the in-flight HTTP call (up to 120s). Instead, call `worker.cancel()` and use `worker.finished.connect(worker.deleteLater)` for cleanup. Close the dialog immediately with the partial sequence.
+
+  **Patterns to follow:**
+  - `ui/dialogs/storyteller_dialog.py` — Dialog structure, signal emission, worker management, `QStackedWidget` pages
+  - `ui/dialogs/exquisite_corpus_dialog.py` — Alternative dialog pattern
+
+  **Test scenarios:**
+  - Happy path: Dialog initializes with clips, shows FIRST_CLIP_SELECT page
+  - Happy path: Selecting first clip + clicking Start transitions to LOADING, then PROPOSAL when worker completes
+  - Edge case: Empty clip pool at dialog open shows empty-state message with Close button, no Start button
+  - Happy path: Accepting proposal adds clip to sequence, appends rationale entry to log, transitions to LOADING for next
+  - Happy path: Rejecting proposal adds clip to rejection set, does NOT append to log, spawns new worker for same position
+  - Happy path: Completing full sequence (pool empty via acceptance) transitions to COMPLETE; Apply emits `sequence_ready` with correct three-tuple payload including rationales
+  - Happy path: First clip in emitted payload has `rationale=None` (user-selected)
+  - Edge case: Early stop with 1-2 clips accepted skips confirmation, goes directly to COMPLETE
+  - Edge case: Early stop with 3+ clips accepted shows confirmation dialog; cancel keeps session, confirm goes to COMPLETE
+  - Edge case: Pool exhaustion (all shortlisted rejected) transitions to POOL_EXHAUSTED page; End sequence → COMPLETE; Reconsider last rejected → PROPOSAL with resurrected clip
+  - Error path: Worker emits `error`, transitions to ERROR page; Retry spawns new worker; Cancel routes to COMPLETE with clips so far preserved
+  - Edge case: Multiple rapid rejects during LOADING don't create duplicate workers (guard flag + button disabled during LOADING)
+  - Edge case: Dialog Close on COMPLETE with 3+ accepted clips shows "Discard sequence?" confirmation
+  - Integration: Rationale log accumulates only accepted transitions in order, scrolls to latest
+  - Integration: Log is preserved across ERROR → Retry cycle (not cleared)
+
+  **Verification:**
+  - Dialog never discards accepted clips on error — partial sequence is always recoverable
+  - Accept/Reject buttons disabled during LOADING — no race conditions
+  - Rationale log shows all transitions in order
+  - SequenceClips emitted have `rationale` field populated
+
+- [ ] **Unit 5: Sequence tab integration with rationale-preserving apply path**
+
+  **Goal:** Wire the Free Association dialog into the sequence tab's algorithm routing and implement a new apply method that preserves per-clip rationales (which the existing `_apply_dialog_sequence()` cannot do).
+
+  **Requirements:** R1, R9, R10
+
+  **Dependencies:** Unit 4
+
+  **Files:**
+  - Modify: `ui/tabs/sequence_tab.py` — routing, new apply method, card availability mapping
+  - Test: `tests/test_sequence_tab.py`
+
+  **Approach:**
+  - **Why a new apply method is needed (critical design constraint)**: `_apply_dialog_sequence()` iterates over `(Clip, Source)` tuples and calls `self.timeline.add_clip(clip, source, ...)`. That path internally constructs a fresh `SequenceClip` inside `timeline_scene.add_clip_to_track()` with only the fields it knows about (source_clip_id, source_id, track_index, start_frame, in_point, out_point). It has no mechanism to thread a `rationale` parameter through, so any SequenceClip built by the dialog would be discarded in favor of a freshly-reconstructed one without rationale. R10 would silently fail.
+  - **Apply mechanism**: Add `_apply_free_association_sequence(payload: list[tuple[Clip, Source, Optional[str]]])`. For each entry, call `self.timeline.add_clip(clip, source, ...)` as the existing path does, then **look up the just-created `SequenceClip` in the Sequence and set `rationale`**. Options for the lookup:
+    - (a) If `timeline_scene.add_clip_to_track()` returns the created `SequenceClip`, extend `timeline_widget.add_clip()` to return it as well, then set `.rationale` on the returned object.
+    - (b) After `add_clip`, iterate `sequence.get_all_clips()` to find the newest entry matching `source_clip_id` and set `.rationale`.
+    - Prefer (a) — cleaner, single object reference. Fall back to (b) if (a) requires invasive changes to the timeline widget API. Document the choice at implementation time under `Deferred to Implementation`.
+  - After applying all clips, set `sequence.algorithm = "free_association"` so the sequence is tracked.
+  - **Routing in `_on_card_clicked()`**: Add `free_association` to the `is_dialog` branch. Open dialog, connect `sequence_ready` to `_apply_free_association_sequence()`.
+  - **Routing in `_on_confirm_generate()`**: `sequence_tab.py` has a second dialog-routing if-chain around line 502. Dialog-based algorithms with `is_dialog: True` bypass the cost confirmation gate via the early return in `_on_card_clicked` (line 639), so `_on_confirm_generate` is not reached for Free Association. Verify this assumption by tracing the control flow during implementation; if it is reachable, add routing there as well.
+  - **Card availability mapping**: `sequence_tab.py` has a hand-maintained availability dict in `_update_card_availability()` (around line 1587) that does NOT auto-derive from `ALGORITHM_CONFIG`. Add a `free_association` entry following the Storyteller pattern (dialog handles its own prerequisite checks, so the card can be unconditionally available when there are clips available). Without this entry the card will not appear or will be silently disabled.
+
+  **Patterns to follow:**
+  - `ui/tabs/sequence_tab.py` — Existing `_show_storyteller_dialog()` routing pattern, existing `_update_card_availability()` availability dict pattern
+  - Existing `_apply_dialog_sequence()` for the iteration shape (but not the full logic — the new method must preserve rationale)
+
+  **Test scenarios:**
+  - Happy path: Clicking Free Association card in sequence tab opens the dialog
+  - Happy path: Dialog `sequence_ready` signal applies clips to the timeline with each SequenceClip's `rationale` populated from the payload
+  - Integration: Sequence object has `algorithm="free_association"` after dialog completes
+  - Integration: After apply + project save + reload, rationales survive on each SequenceClip (this is the end-to-end R10 verification)
+  - Happy path: First clip in the applied sequence has `rationale=None` (user-selected, no LLM rationale)
+  - Edge case: Dialog cancelled (no `sequence_ready` emitted) leaves sequence tab unchanged
+  - Edge case: Partial sequence (user stopped early) applies the accepted N clips with correct rationales
+  - Happy path: Free Association card appears in the algorithm grid with correct availability state
+
+  **Verification:**
+  - Free Association appears in the sequence tab algorithm grid
+  - Completing the dialog populates the timeline with clips in the expected order and rationales attached to each SequenceClip
+  - Rationale text appears on the SequenceClip objects both in memory and after save/reload
+  - Sequence overwrite pattern is avoided — the new apply method still writes to the correct (single-source-of-truth) Sequence object
+
+## System-Wide Impact
+
+- **Interaction graph:** Dialog emits `sequence_ready` → sequence tab applies via `_apply_dialog_sequence()` → timeline widget updates. Same path as Storyteller/Exquisite Corpus. No new callbacks or middleware.
+- **Error propagation:** LLM errors caught in worker, routed to dialog via `error` signal. Dialog shows retry UI. No error reaches sequence tab or main window.
+- **State lifecycle risks:** Single-step worker pattern avoids long-lived thread state. Dialog owns all mutable state. Worker is stateless and single-use. Guard flags prevent duplicate signal delivery.
+- **API surface parity:** No CLI or MCP server changes needed — this is a UI-only sequencer. Agent tool integration (adding "free_association" to `generate_sequence` tool) is out of scope for this plan.
+- **Unchanged invariants:** Existing sequencers unaffected. `SequenceClip.rationale` defaults to `None` — no change to existing serialization. `_apply_dialog_sequence()` interface unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| LLM proposes clip not in candidate list (hallucinated ID) | Validate proposed short ID against the candidates sent. Treat as error and auto-retry once before showing error UI. |
+| LLM re-proposes rejected clip despite instructions | Validate proposed ID against `rejected_for_position` set. Auto-retry with stronger prompt emphasis. |
+| Latency per step feels slow (3-10s) | Loading state with progress indicator. Compact prompt (~800 tokens) keeps call fast. Can tune model choice for speed. |
+| Cost accumulation over many steps | `required_analysis` gate ensures clips have metadata before starting. LLM call cost is bounded by tiered prompt. Consider adding step count display (e.g., "Step 12 of 47"). |
+| Embedding quality varies (CLIP vs DINOv2) | `shortlist_candidates` falls back to random sample when embeddings are missing. Digests still give LLM enough to make reasonable choices. |
+| Cosine similarity pre-filter narrows "free association" creatively | Start pure; if early use shows homogeneous proposals, switch to hybrid (6 similar + 6 random). Tracked as deferred implementation decision. |
+| LLM hallucinates clip ID not in candidate set | Validate short ID against sent candidates; auto-retry once with stronger prompt; show error UI if two attempts fail. |
+| Rationale silently dropped at apply time | New `_apply_free_association_sequence()` sets rationale on each SequenceClip immediately after timeline creation. Integration test verifies end-to-end R10 via save/reload. |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md](docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md)
+- Related code: `core/remix/storyteller.py`, `core/remix/similarity_chain.py`, `ui/dialogs/storyteller_dialog.py`
+- Institutional learnings: `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`, `docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md`, `docs/solutions/logic-errors/circular-import-config-consolidation.md`

--- a/models/sequence.py
+++ b/models/sequence.py
@@ -30,6 +30,7 @@ class SequenceClip:
     vflip: bool = False  # Random vertical flip
     reverse: bool = False  # Random reverse playback
     prerendered_path: Optional[str] = None  # Path to pre-rendered clip with baked transforms
+    rationale: Optional[str] = None  # LLM-generated rationale for why this clip follows the previous (Free Association sequencer)
 
     @property
     def is_frame_entry(self) -> bool:
@@ -89,6 +90,8 @@ class SequenceClip:
                     data["prerendered_path"] = self.prerendered_path
             else:
                 data["prerendered_path"] = self.prerendered_path
+        if self.rationale is not None:
+            data["rationale"] = self.rationale
         return data
 
     @classmethod
@@ -120,6 +123,7 @@ class SequenceClip:
             vflip=data.get("vflip", False),
             reverse=data.get("reverse", False),
             prerendered_path=prerendered,
+            rationale=data.get("rationale"),
         )
 
 

--- a/tests/test_algorithm_config.py
+++ b/tests/test_algorithm_config.py
@@ -35,4 +35,4 @@ def test_multi_tagged_algorithms():
 
 
 def test_algorithm_count():
-    assert len(ALGORITHM_CONFIG) == 19
+    assert len(ALGORITHM_CONFIG) == 20

--- a/tests/test_free_association.py
+++ b/tests/test_free_association.py
@@ -1,0 +1,399 @@
+"""Unit tests for the Free Association core algorithm module."""
+
+import json
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+
+from core.remix.free_association import (
+    DEFAULT_SHORTLIST_SIZE,
+    _parse_proposal_response,
+    build_id_mapping,
+    format_clip_digest,
+    format_clip_full_metadata,
+    propose_next_clip,
+    shortlist_candidates,
+)
+from models.clip import Clip, Source
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_UNSET = object()
+
+
+def _make_clip(
+    clip_id: str = "c-test",
+    description=_UNSET,
+    shot_type=_UNSET,
+    dominant_colors=_UNSET,
+    average_brightness=_UNSET,
+    person_count=_UNSET,
+    object_labels=_UNSET,
+    embedding=None,
+    **extra,
+) -> Clip:
+    kwargs = dict(
+        id=clip_id,
+        source_id="src-1",
+        start_frame=0,
+        end_frame=30,
+        description="A person walking" if description is _UNSET else description,
+        shot_type="close-up" if shot_type is _UNSET else shot_type,
+        dominant_colors=[(220, 150, 100)] if dominant_colors is _UNSET else dominant_colors,
+        average_brightness=0.7 if average_brightness is _UNSET else average_brightness,
+        person_count=1 if person_count is _UNSET else person_count,
+        object_labels=["person"] if object_labels is _UNSET else object_labels,
+        embedding=embedding,
+    )
+    kwargs.update(extra)
+    return Clip(**kwargs)
+
+
+def _source(source_id: str = "src-1") -> Source:
+    return Source(
+        id=source_id,
+        file_path="/test/video.mp4",
+        duration_seconds=60.0,
+        fps=30.0,
+        width=1920,
+        height=1080,
+    )
+
+
+# ---------------------------------------------------------------------------
+# format_clip_digest
+# ---------------------------------------------------------------------------
+
+
+class TestFormatClipDigest:
+    def test_fully_populated_clip(self):
+        clip = _make_clip(
+            shot_type="CU",
+            dominant_colors=[(220, 150, 100)],  # warm
+            average_brightness=0.8,
+            person_count=2,
+            object_labels=["person", "chair"],
+        )
+        digest = format_clip_digest(clip)
+        assert "CU" in digest
+        assert "warm" in digest
+        assert "bright" in digest
+        assert "2 people" in digest
+        assert "person" in digest
+        assert " | " in digest
+
+    def test_missing_most_metadata_falls_back_to_description(self):
+        clip = _make_clip(
+            shot_type=None,
+            dominant_colors=None,
+            average_brightness=None,
+            person_count=None,
+            object_labels=None,
+            description="A person walking down a sunlit street",
+        )
+        digest = format_clip_digest(clip)
+        assert digest == "A person walking down a sunlit street"
+
+    def test_no_metadata_at_all_returns_placeholder(self):
+        clip = _make_clip(
+            description=None,
+            shot_type=None,
+            dominant_colors=None,
+            average_brightness=None,
+            person_count=None,
+            object_labels=None,
+        )
+        clip.name = ""
+        digest = format_clip_digest(clip)
+        assert digest == "no metadata available"
+
+    def test_falls_back_to_name_when_no_description(self):
+        clip = _make_clip(
+            description=None,
+            shot_type=None,
+            dominant_colors=None,
+            average_brightness=None,
+            person_count=None,
+            object_labels=None,
+        )
+        clip.name = "My clip"
+        assert format_clip_digest(clip) == "My clip"
+
+    def test_single_person_grammar(self):
+        clip = _make_clip(person_count=1)
+        assert "1 person" in format_clip_digest(clip)
+        assert "1 people" not in format_clip_digest(clip)
+
+
+# ---------------------------------------------------------------------------
+# format_clip_full_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestFormatClipFullMetadata:
+    def test_includes_description_and_structured_fields(self):
+        clip = _make_clip(description="A close-up of hands")
+        text = format_clip_full_metadata(clip)
+        assert "Description: A close-up of hands" in text
+        assert "Shot type: close-up" in text
+        assert "People:" in text
+
+    def test_handles_empty_clip(self):
+        clip = _make_clip(
+            description=None,
+            shot_type=None,
+            dominant_colors=None,
+            average_brightness=None,
+            person_count=None,
+            object_labels=None,
+        )
+        text = format_clip_full_metadata(clip)
+        assert text == "(no metadata)"
+
+
+# ---------------------------------------------------------------------------
+# shortlist_candidates
+# ---------------------------------------------------------------------------
+
+
+class TestShortlistCandidates:
+    def test_returns_top_k_by_similarity(self):
+        current = _make_clip("current", embedding=_normalize([1.0, 0.0]))
+        # Pool: first 3 are highly similar, last 2 are dissimilar
+        pool_clips = [
+            (_make_clip(f"c{i}", embedding=_normalize([1.0, 0.1 * i])), _source())
+            for i in range(5)
+        ]
+        result = shortlist_candidates(current, pool_clips, k=2)
+        assert len(result) == 2
+        # Most similar first
+        assert result[0][0].id == "c0"
+
+    def test_missing_embeddings_falls_back_to_random_sample(self):
+        current = _make_clip("current", embedding=None)
+        pool_clips = [(_make_clip(f"c{i}", embedding=None), _source()) for i in range(20)]
+        result = shortlist_candidates(current, pool_clips, k=5)
+        assert len(result) == 5
+
+    def test_fewer_clips_than_k_returns_all(self):
+        current = _make_clip("current", embedding=_normalize([1.0, 0.0]))
+        pool_clips = [
+            (_make_clip(f"c{i}", embedding=_normalize([1.0, 0.1])), _source())
+            for i in range(3)
+        ]
+        result = shortlist_candidates(current, pool_clips, k=10)
+        assert len(result) == 3
+
+    def test_mixed_embeddings_pads_with_non_embedding_clips(self):
+        current = _make_clip("current", embedding=_normalize([1.0, 0.0]))
+        with_emb = [
+            (_make_clip(f"e{i}", embedding=_normalize([1.0, 0.0])), _source())
+            for i in range(2)
+        ]
+        without_emb = [
+            (_make_clip(f"n{i}", embedding=None), _source()) for i in range(5)
+        ]
+        result = shortlist_candidates(current, with_emb + without_emb, k=4)
+        assert len(result) == 4
+        # First two should be the embedding-equipped clips
+        assert all(c.id.startswith("e") for c, _ in result[:2])
+
+
+def _normalize(vec: list[float]) -> list[float]:
+    arr = np.array(vec, dtype=np.float32)
+    return (arr / np.linalg.norm(arr)).tolist()
+
+
+# ---------------------------------------------------------------------------
+# build_id_mapping
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIdMapping:
+    def test_bidirectional_mapping(self):
+        candidates = [
+            (_make_clip("uuid-1"), _source()),
+            (_make_clip("uuid-2"), _source()),
+            (_make_clip("uuid-3"), _source()),
+        ]
+        short_to_full, full_to_short = build_id_mapping(candidates)
+        assert short_to_full["c1"] == "uuid-1"
+        assert short_to_full["c2"] == "uuid-2"
+        assert short_to_full["c3"] == "uuid-3"
+        assert full_to_short["uuid-1"] == "c1"
+
+    def test_round_trip(self):
+        candidates = [(_make_clip(f"uuid-{i}"), _source()) for i in range(5)]
+        short_to_full, full_to_short = build_id_mapping(candidates)
+        for clip, _ in candidates:
+            assert short_to_full[full_to_short[clip.id]] == clip.id
+
+
+# ---------------------------------------------------------------------------
+# propose_next_clip
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(content: str | None) -> Mock:
+    response = Mock()
+    response.choices = [Mock()]
+    response.choices[0].message.content = content
+    return response
+
+
+def _mock_settings() -> Mock:
+    settings = Mock()
+    settings.exquisite_corpus_model = "gemini-2.5-flash"
+    settings.exquisite_corpus_temperature = 0.7
+    return settings
+
+
+class TestProposeNextClip:
+    def test_happy_path_returns_clip_id_and_rationale(self):
+        candidates = [("c1", "CU | warm | bright"), ("c2", "wide | cool | dark")]
+        response = _mock_response(
+            json.dumps({"clip_id": "c2", "rationale": "Contrast makes the cut sharp."})
+        )
+
+        with patch("core.settings.load_settings", return_value=_mock_settings()), \
+             patch("core.settings.get_llm_api_key", return_value="key"), \
+             patch("litellm.completion", return_value=response):
+            clip_id, rationale = propose_next_clip(
+                current_clip_metadata="Description: a close-up",
+                candidate_digests=candidates,
+                recent_rationales=[],
+                rejected_short_ids=[],
+            )
+
+        assert clip_id == "c2"
+        assert rationale == "Contrast makes the cut sharp."
+
+    def test_none_content_raises_valueerror(self):
+        """Regression guard for the documented LLM None bug pattern."""
+        candidates = [("c1", "CU"), ("c2", "wide")]
+        response = _mock_response(None)
+
+        with patch("core.settings.load_settings", return_value=_mock_settings()), \
+             patch("core.settings.get_llm_api_key", return_value="key"), \
+             patch("litellm.completion", return_value=response), \
+             pytest.raises(ValueError, match="no content"):
+            propose_next_clip(
+                current_clip_metadata="x",
+                candidate_digests=candidates,
+                recent_rationales=[],
+                rejected_short_ids=[],
+            )
+
+    def test_empty_string_content_raises_valueerror(self):
+        candidates = [("c1", "CU")]
+        response = _mock_response("   ")
+
+        with patch("core.settings.load_settings", return_value=_mock_settings()), \
+             patch("core.settings.get_llm_api_key", return_value="key"), \
+             patch("litellm.completion", return_value=response), \
+             pytest.raises(ValueError, match="no content"):
+            propose_next_clip(
+                current_clip_metadata="x",
+                candidate_digests=candidates,
+                recent_rationales=[],
+                rejected_short_ids=[],
+            )
+
+    def test_malformed_json_raises_valueerror(self):
+        candidates = [("c1", "CU")]
+        response = _mock_response("This is not JSON at all")
+
+        with patch("core.settings.load_settings", return_value=_mock_settings()), \
+             patch("core.settings.get_llm_api_key", return_value="key"), \
+             patch("litellm.completion", return_value=response), \
+             pytest.raises(ValueError, match="No JSON object"):
+            propose_next_clip(
+                current_clip_metadata="x",
+                candidate_digests=candidates,
+                recent_rationales=[],
+                rejected_short_ids=[],
+            )
+
+    def test_hallucinated_clip_id_raises_valueerror(self):
+        candidates = [("c1", "CU"), ("c2", "wide")]
+        response = _mock_response(
+            json.dumps({"clip_id": "c99", "rationale": "Great match"})
+        )
+
+        with patch("core.settings.load_settings", return_value=_mock_settings()), \
+             patch("core.settings.get_llm_api_key", return_value="key"), \
+             patch("litellm.completion", return_value=response), \
+             pytest.raises(ValueError, match="not in candidate set"):
+            propose_next_clip(
+                current_clip_metadata="x",
+                candidate_digests=candidates,
+                recent_rationales=[],
+                rejected_short_ids=[],
+            )
+
+    def test_rejected_clip_id_raises_valueerror(self):
+        candidates = [("c1", "CU"), ("c2", "wide")]
+        response = _mock_response(
+            json.dumps({"clip_id": "c1", "rationale": "Ignoring rejection"})
+        )
+
+        with patch("core.settings.load_settings", return_value=_mock_settings()), \
+             patch("core.settings.get_llm_api_key", return_value="key"), \
+             patch("litellm.completion", return_value=response), \
+             pytest.raises(ValueError, match="rejected set"):
+            propose_next_clip(
+                current_clip_metadata="x",
+                candidate_digests=candidates,
+                recent_rationales=[],
+                rejected_short_ids=["c1"],
+            )
+
+    def test_handles_markdown_fenced_json(self):
+        candidates = [("c1", "CU")]
+        response = _mock_response(
+            "```json\n"
+            + json.dumps({"clip_id": "c1", "rationale": "Good fit"})
+            + "\n```"
+        )
+
+        with patch("core.settings.load_settings", return_value=_mock_settings()), \
+             patch("core.settings.get_llm_api_key", return_value="key"), \
+             patch("litellm.completion", return_value=response):
+            clip_id, _ = propose_next_clip(
+                current_clip_metadata="x",
+                candidate_digests=candidates,
+                recent_rationales=[],
+                rejected_short_ids=[],
+            )
+        assert clip_id == "c1"
+
+
+# ---------------------------------------------------------------------------
+# _parse_proposal_response — unit tests for the parser helper
+# ---------------------------------------------------------------------------
+
+
+class TestParseProposalResponse:
+    def test_plain_json(self):
+        clip_id, rationale = _parse_proposal_response(
+            '{"clip_id": "c2", "rationale": "Nice transition"}'
+        )
+        assert clip_id == "c2"
+        assert rationale == "Nice transition"
+
+    def test_missing_clip_id_raises(self):
+        with pytest.raises(ValueError, match="'clip_id'"):
+            _parse_proposal_response('{"rationale": "only rationale"}')
+
+    def test_missing_rationale_raises(self):
+        with pytest.raises(ValueError, match="'rationale'"):
+            _parse_proposal_response('{"clip_id": "c1"}')
+
+    def test_json_array_instead_of_object_raises(self):
+        with pytest.raises(ValueError):
+            _parse_proposal_response('["c1", "reason"]')

--- a/tests/test_free_association_dialog.py
+++ b/tests/test_free_association_dialog.py
@@ -1,0 +1,422 @@
+"""Tests for FreeAssociationDialog.
+
+Per the plan, tests cover state transitions and data flow with mocked
+workers rather than full UI rendering. Workers are never started — we
+drive state transitions by calling handler methods directly.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from models.clip import Clip, Source
+
+
+@pytest.fixture
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _make_source(source_id: str = "s1") -> Source:
+    return Source(
+        id=source_id,
+        file_path=Path("/test/video.mp4"),
+        duration_seconds=60.0,
+        fps=30.0,
+        width=1920,
+        height=1080,
+    )
+
+
+def _make_clip(clip_id: str, source_id: str = "s1", **extra) -> Clip:
+    kwargs = dict(
+        id=clip_id,
+        source_id=source_id,
+        start_frame=0,
+        end_frame=30,
+        description=f"Description for {clip_id}",
+        shot_type="close-up",
+    )
+    kwargs.update(extra)
+    return Clip(**kwargs)
+
+
+@pytest.fixture(autouse=True)
+def _no_real_workers():
+    """Replace _spawn_worker on the class for the test duration so that
+    _request_next_proposal never actually starts a QThread."""
+    from ui.dialogs.free_association_dialog import FreeAssociationDialog
+
+    original = FreeAssociationDialog._spawn_worker
+
+    def noop_spawn(self, *args, **kwargs):
+        from ui.dialogs.free_association_dialog import PAGE_LOADING
+
+        # Still switch to LOADING so any state-transition test sees the
+        # stack update that would happen in production.
+        self.stack.setCurrentIndex(PAGE_LOADING)
+        self._proposal_handled = False
+
+    FreeAssociationDialog._spawn_worker = noop_spawn
+    yield
+    FreeAssociationDialog._spawn_worker = original
+
+
+def _build_dialog(clips, source=None):
+    """Construct a dialog with the given clips. Workers never actually spawn
+    (see the _no_real_workers fixture)."""
+    from ui.dialogs.free_association_dialog import FreeAssociationDialog
+
+    src = source or _make_source()
+    sources_by_id = {src.id: src}
+    project = MagicMock()
+    return FreeAssociationDialog(clips, sources_by_id, project)
+
+
+class TestInitialization:
+    def test_opens_on_first_clip_select_page(self, qapp):
+        from ui.dialogs.free_association_dialog import PAGE_FIRST_CLIP_SELECT
+
+        clips = [_make_clip("c1"), _make_clip("c2")]
+        dialog = _build_dialog(clips)
+        assert dialog.stack.currentIndex() == PAGE_FIRST_CLIP_SELECT
+        # Start button is enabled when clips exist
+        assert dialog.start_btn.isEnabled() is True
+        # List has the clips
+        assert dialog.first_clip_list.count() == 2
+
+    def test_empty_pool_disables_start_button(self, qapp):
+        """With zero clips, the dialog opens on the empty-state."""
+        dialog = _build_dialog([])
+        assert dialog.start_btn.isEnabled() is False
+        # The list shows a placeholder item (not enabled)
+        assert dialog.first_clip_list.count() == 1
+        item = dialog.first_clip_list.item(0)
+        # Placeholder item has no enabled flag
+        from PySide6.QtCore import Qt
+
+        assert not (item.flags() & Qt.ItemIsEnabled)
+
+
+class TestFirstClipSelection:
+    def test_selecting_first_clip_adds_it_to_sequence(self, qapp):
+        clips = [_make_clip("c1"), _make_clip("c2")]
+        dialog = _build_dialog(clips)
+
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+
+        assert len(dialog.sequence_built) == 1
+        assert dialog.sequence_built[0][0].id == "c1"
+        # First clip has no rationale
+        assert dialog.rationales == [None]
+        # Pool was reduced
+        assert len(dialog.available_pool) == 1
+        # Log entry was added
+        assert dialog.log_list.count() == 1
+
+    def test_start_without_selection_shows_warning(self, qapp):
+        clips = [_make_clip("c1")]
+        dialog = _build_dialog(clips)
+        # No selection made
+        with patch(
+            "ui.dialogs.free_association_dialog.QMessageBox.information"
+        ) as mock_info:
+            dialog._on_start_clicked()
+            mock_info.assert_called_once()
+        assert len(dialog.sequence_built) == 0
+
+
+class TestProposalFlow:
+    def test_proposal_ready_transitions_to_proposal_page(self, qapp):
+        from ui.dialogs.free_association_dialog import (
+            PAGE_FIRST_CLIP_SELECT,
+            PAGE_PROPOSAL,
+        )
+
+        clips = [_make_clip("c1"), _make_clip("c2"), _make_clip("c3")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        # Now simulate proposal_ready from a worker
+        # Manually set up what _request_next_proposal would have prepared
+        dialog._current_candidates = [
+            (c, dialog.available_pool[i][1])
+            for i, c in enumerate([p[0] for p in dialog.available_pool])
+        ]
+        dialog._current_short_to_full = {"c1": "c2", "c2": "c3"}
+        dialog._proposal_handled = False
+
+        dialog._on_proposal_ready("c1", "Matched on close-up framing")
+
+        assert dialog.stack.currentIndex() == PAGE_PROPOSAL
+        assert dialog._proposed_clip is not None
+        assert dialog._proposed_clip[0].id == "c2"
+        assert dialog._proposed_rationale == "Matched on close-up framing"
+        assert dialog._proposal_handled is True
+
+    def test_duplicate_proposal_ready_is_suppressed(self, qapp):
+        """Guard flag prevents Qt's double-signal-fire from being processed twice."""
+        clips = [_make_clip("c1"), _make_clip("c2"), _make_clip("c3")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        dialog._current_candidates = [dialog.available_pool[0]]
+        dialog._current_short_to_full = {"c1": "c2"}
+        dialog._proposal_handled = False
+
+        dialog._on_proposal_ready("c1", "First rationale")
+        first_proposed = dialog._proposed_clip
+        # Simulate duplicate signal fire
+        dialog._on_proposal_ready("c1", "Second rationale")
+        # Second call should not overwrite state
+        assert dialog._proposed_clip is first_proposed
+
+    def test_hallucinated_clip_id_routes_to_error(self, qapp):
+        from ui.dialogs.free_association_dialog import PAGE_ERROR
+
+        clips = [_make_clip("c1"), _make_clip("c2")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        dialog._current_candidates = [dialog.available_pool[0]]
+        dialog._current_short_to_full = {"c1": "c2"}
+        dialog._proposal_handled = False
+
+        # LLM returns a short ID not in the mapping
+        dialog._on_proposal_ready("c99", "Won't work")
+
+        assert dialog.stack.currentIndex() == PAGE_ERROR
+
+
+class TestAcceptFlow:
+    def test_accept_adds_clip_and_rationale(self, qapp):
+        clips = [_make_clip("c1"), _make_clip("c2"), _make_clip("c3")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+
+        # Set up a pending proposal
+        proposed_clip = dialog.available_pool[0]
+        dialog._proposed_clip = proposed_clip
+        dialog._proposed_rationale = "Nice warm transition"
+        dialog.rejected_for_position = {"c99"}  # should be cleared
+
+        dialog._on_accept_clicked()
+
+        assert len(dialog.sequence_built) == 2
+        assert dialog.sequence_built[1] == proposed_clip
+        assert dialog.rationales == [None, "Nice warm transition"]
+        # Rejection set cleared on accept
+        assert dialog.rejected_for_position == set()
+        # Clip removed from pool
+        assert proposed_clip not in dialog.available_pool
+        # Log was appended
+        assert dialog.log_list.count() == 2
+
+
+class TestRejectFlow:
+    def test_reject_adds_to_rejection_set_without_logging(self, qapp):
+        clips = [_make_clip("c1"), _make_clip("c2"), _make_clip("c3")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        log_count_before = dialog.log_list.count()
+
+        proposed_clip = dialog.available_pool[0]
+        dialog._proposed_clip = proposed_clip
+        dialog._proposed_rationale = "Reject me"
+
+        dialog._on_reject_clicked()
+
+        assert proposed_clip[0].id in dialog.rejected_for_position
+        # Clip stays in pool (not removed)
+        assert proposed_clip in dialog.available_pool
+        # Log did NOT grow
+        assert dialog.log_list.count() == log_count_before
+        # Last rejected is stashed for Reconsider
+        assert dialog._last_rejected_proposal == proposed_clip
+
+
+class TestStopFlow:
+    def test_stop_under_threshold_does_not_confirm(self, qapp):
+        from ui.dialogs.free_association_dialog import PAGE_COMPLETE
+
+        clips = [_make_clip("c1"), _make_clip("c2")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        # Only 1 accepted — below threshold of 3
+
+        with patch(
+            "ui.dialogs.free_association_dialog.QMessageBox.question"
+        ) as mock_confirm:
+            dialog._on_stop_clicked()
+            mock_confirm.assert_not_called()
+
+        assert dialog.stack.currentIndex() == PAGE_COMPLETE
+
+    def test_stop_at_or_above_threshold_asks_confirmation(self, qapp):
+        from PySide6.QtWidgets import QMessageBox
+        from ui.dialogs.free_association_dialog import PAGE_COMPLETE, PAGE_PROPOSAL
+
+        clips = [_make_clip(f"c{i}") for i in range(5)]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        # Manually inflate sequence_built to reach threshold
+        dialog.sequence_built.extend(
+            [dialog.available_pool[i] for i in range(2)]
+        )
+        dialog.rationales.extend(["r1", "r2"])
+        dialog.stack.setCurrentIndex(PAGE_PROPOSAL)
+
+        # Case: user cancels the confirmation
+        with patch(
+            "ui.dialogs.free_association_dialog.QMessageBox.question",
+            return_value=QMessageBox.No,
+        ):
+            dialog._on_stop_clicked()
+        assert dialog.stack.currentIndex() == PAGE_PROPOSAL  # did not move
+
+        # Case: user confirms
+        with patch(
+            "ui.dialogs.free_association_dialog.QMessageBox.question",
+            return_value=QMessageBox.Yes,
+        ):
+            dialog._on_stop_clicked()
+        assert dialog.stack.currentIndex() == PAGE_COMPLETE
+
+
+class TestErrorRecovery:
+    def test_error_routes_to_error_page_preserving_sequence(self, qapp):
+        from ui.dialogs.free_association_dialog import PAGE_ERROR
+
+        clips = [_make_clip("c1"), _make_clip("c2")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        assert len(dialog.sequence_built) == 1  # first clip accepted
+
+        dialog._proposal_handled = False
+        dialog._on_proposal_error("Network timed out")
+
+        assert dialog.stack.currentIndex() == PAGE_ERROR
+        # Sequence is preserved
+        assert len(dialog.sequence_built) == 1
+        assert "preserved" in dialog.error_reassurance.text().lower()
+
+    def test_cancel_from_error_routes_to_complete(self, qapp):
+        from ui.dialogs.free_association_dialog import PAGE_COMPLETE, PAGE_ERROR
+
+        clips = [_make_clip("c1"), _make_clip("c2")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        dialog._proposal_handled = False
+        dialog._on_proposal_error("An error")
+        assert dialog.stack.currentIndex() == PAGE_ERROR
+
+        dialog._on_cancel_from_error()
+        assert dialog.stack.currentIndex() == PAGE_COMPLETE
+
+
+class TestApply:
+    def test_apply_emits_sequence_ready_with_three_tuples(self, qapp):
+        clips = [_make_clip("c1"), _make_clip("c2"), _make_clip("c3")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        # Simulate accepting another clip
+        dialog._proposed_clip = dialog.available_pool[0]
+        dialog._proposed_rationale = "Second clip rationale"
+        dialog._on_accept_clicked()
+
+        emitted = []
+        dialog.sequence_ready.connect(lambda payload: emitted.append(payload))
+        dialog._on_apply_clicked()
+
+        assert len(emitted) == 1
+        payload = emitted[0]
+        assert len(payload) == 2
+        # First entry: clip, source, None
+        assert payload[0][0].id == "c1"
+        assert payload[0][2] is None
+        # Second entry: has rationale
+        assert payload[1][2] == "Second clip rationale"
+
+    def test_close_without_applying_under_threshold(self, qapp):
+        clips = [_make_clip("c1"), _make_clip("c2")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        dialog._show_complete_page()
+
+        emitted = []
+        dialog.sequence_ready.connect(lambda p: emitted.append(p))
+
+        with patch(
+            "ui.dialogs.free_association_dialog.QMessageBox.question"
+        ) as mock_confirm:
+            dialog._on_close_from_complete()
+            mock_confirm.assert_not_called()  # under threshold, no confirm
+
+        # sequence_ready was NOT emitted
+        assert emitted == []
+
+
+class TestRationaleLog:
+    def test_log_accumulates_only_accepted_transitions(self, qapp):
+        clips = [_make_clip(f"c{i}") for i in range(4)]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        # First clip added to log
+        assert dialog.log_list.count() == 1
+
+        # Reject a proposal — should NOT add to log
+        dialog._proposed_clip = dialog.available_pool[0]
+        dialog._proposed_rationale = "rejected rationale"
+        dialog._on_reject_clicked()
+        assert dialog.log_list.count() == 1  # unchanged
+
+        # Accept next — should add
+        dialog._proposed_clip = dialog.available_pool[-1]
+        dialog._proposed_rationale = "accepted rationale"
+        dialog._on_accept_clicked()
+        assert dialog.log_list.count() == 2
+
+    def test_first_log_entry_marks_opening_clip(self, qapp):
+        clips = [_make_clip("c1"), _make_clip("c2")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+        first_text = dialog.log_list.item(0).text()
+        assert "opening clip" in first_text.lower()
+
+
+class TestPoolExhausted:
+    def test_shows_pool_exhausted_page_when_all_candidates_rejected(self, qapp):
+        from ui.dialogs.free_association_dialog import PAGE_POOL_EXHAUSTED
+
+        # Two clips total — after selecting one, only 1 candidate remains
+        clips = [_make_clip("c1"), _make_clip("c2")]
+        dialog = _build_dialog(clips)
+        dialog.first_clip_list.setCurrentRow(0)
+        dialog._on_start_clicked()
+
+        # Reject the only remaining candidate
+        dialog._proposed_clip = dialog.available_pool[0]
+        dialog._proposed_rationale = "no good"
+        dialog._on_reject_clicked()
+        # _request_next_proposal should have transitioned to POOL_EXHAUSTED
+
+        assert dialog.stack.currentIndex() == PAGE_POOL_EXHAUSTED
+        # Reconsider button should be enabled (we have a last-rejected stash)
+        assert dialog.reconsider_btn.isEnabled() is True

--- a/tests/test_free_association_integration.py
+++ b/tests/test_free_association_integration.py
@@ -204,20 +204,23 @@ class TestEndToEndPersistence:
 class TestCardAvailability:
     def test_free_association_appears_in_availability_mapping(self, qapp):
         """The card grid uses a hand-maintained dict — ensure free_association
-        is registered so the card is visible."""
+        is registered so the card is visible. Stubs feature-registry probes
+        so the test doesn't depend on transformers/other optional packages."""
         from ui.tabs.sequence_tab import SequenceTab
 
         tab = SequenceTab()
-        # Give it some clips so the availability update runs meaningfully
         source = _make_source()
         clip = _make_clip("c1")
         tab._clips = [clip]
 
-        # Capture the dict passed to set_algorithm_availability
         captured = {}
         tab.card_grid.set_algorithm_availability = (
             lambda d: captured.update(d) or None
         )
-        tab._update_card_availability()
+
+        with patch(
+            "ui.tabs.sequence_tab.check_feature_ready", return_value=(True, [])
+        ):
+            tab._update_card_availability()
 
         assert "free_association" in captured

--- a/tests/test_free_association_integration.py
+++ b/tests/test_free_association_integration.py
@@ -1,0 +1,223 @@
+"""Tests for Free Association integration into SequenceTab.
+
+Covers routing, apply-time rationale preservation, and end-to-end
+save/load verification of R10 (rationale persistence).
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# SequenceTab contains video widgets — use offscreen for headless runs
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _make_source(source_id: str = "src-1", fps: float = 30.0) -> "Source":
+    from models.clip import Source
+
+    return Source(
+        id=source_id,
+        file_path=Path("/test/video.mp4"),
+        duration_seconds=60.0,
+        fps=fps,
+        width=1920,
+        height=1080,
+    )
+
+
+def _make_clip(clip_id: str, source_id: str = "src-1", **extra) -> "Clip":
+    from models.clip import Clip
+
+    kwargs = dict(
+        id=clip_id,
+        source_id=source_id,
+        start_frame=0,
+        end_frame=30,
+        description=f"Description for {clip_id}",
+    )
+    kwargs.update(extra)
+    return Clip(**kwargs)
+
+
+class TestRouting:
+    def test_card_click_routes_free_association_to_dialog(self, qapp, monkeypatch):
+        from ui.tabs.sequence_tab import SequenceTab
+
+        tab = SequenceTab()
+        source = _make_source()
+        clip = _make_clip("c1")
+        tab.set_available_clips(
+            [(clip, source)], all_clips=[clip], sources_by_id={source.id: source}
+        )
+        tab._gui_state = SimpleNamespace(
+            analyze_selected_ids=[clip.id], cut_selected_ids=[]
+        )
+
+        dialog_calls = []
+        monkeypatch.setattr(
+            tab,
+            "_show_free_association_dialog",
+            lambda clips: dialog_calls.append(clips),
+        )
+
+        tab._on_card_clicked("free_association")
+
+        assert len(dialog_calls) == 1
+        assert len(dialog_calls[0]) == 1
+
+    def test_show_dialog_without_descriptions_warns_and_does_not_open(self, qapp):
+        from ui.tabs.sequence_tab import SequenceTab
+
+        tab = SequenceTab()
+        source = _make_source()
+        clip = _make_clip("c1", description=None)  # no description
+
+        with patch(
+            "ui.tabs.sequence_tab.QMessageBox.warning"
+        ) as mock_warn, patch(
+            "ui.tabs.sequence_tab.FreeAssociationDialog"
+        ) as mock_dialog_class:
+            tab._show_free_association_dialog([(clip, source)])
+
+        mock_warn.assert_called_once()
+        mock_dialog_class.assert_not_called()
+
+
+class TestApplyRationalePreservation:
+    def test_apply_attaches_rationales_to_sequence_clips(self, qapp):
+        from ui.tabs.sequence_tab import SequenceTab
+
+        tab = SequenceTab()
+        source = _make_source(fps=30.0)
+        clip1 = _make_clip("c1")
+        clip1.end_frame = 30  # 30 frames
+        clip2 = _make_clip("c2")
+        clip2.end_frame = 60  # 60 frames
+        clip3 = _make_clip("c3")
+        clip3.end_frame = 45  # 45 frames
+
+        # Seed the tab's source lookup so the timeline can resolve videos
+        tab._sources = {source.id: source}
+
+        # Stub the video player and timeline_preview to avoid file I/O
+        tab.video_player = MagicMock()
+        tab.timeline_preview = MagicMock()
+
+        payload = [
+            (clip1, source, None),  # First clip has no rationale
+            (clip2, source, "Rationale for clip 2"),
+            (clip3, source, "Rationale for clip 3"),
+        ]
+
+        tab._apply_free_association_sequence(payload)
+
+        sequence = tab.timeline.get_sequence()
+        seq_clips = sequence.get_all_clips()
+        assert len(seq_clips) == 3
+
+        # First clip: no rationale
+        assert seq_clips[0].rationale is None
+        # Second and third: rationales attached
+        assert seq_clips[1].rationale == "Rationale for clip 2"
+        assert seq_clips[2].rationale == "Rationale for clip 3"
+
+        # Algorithm key set on the sequence
+        assert sequence.algorithm == "free_association"
+
+    def test_apply_with_empty_payload_is_no_op(self, qapp):
+        from ui.tabs.sequence_tab import SequenceTab
+
+        tab = SequenceTab()
+        # Should not raise
+        tab._apply_free_association_sequence([])
+
+
+class TestEndToEndPersistence:
+    def test_applied_sequence_survives_project_roundtrip(self, qapp):
+        """Regression-guard for R10: the most important integration test.
+
+        Build a real sequence via _apply_free_association_sequence, save a
+        project containing it, load it back, and verify the rationales
+        are still attached to the SequenceClips.
+        """
+        from core.project import Project
+        from models.sequence import Sequence
+        from ui.tabs.sequence_tab import SequenceTab
+
+        tab = SequenceTab()
+        source = _make_source(fps=30.0)
+        clip1 = _make_clip("c1")
+        clip1.end_frame = 30
+        clip2 = _make_clip("c2")
+        clip2.end_frame = 45
+
+        tab._sources = {source.id: source}
+        tab.video_player = MagicMock()
+        tab.timeline_preview = MagicMock()
+
+        payload = [
+            (clip1, source, None),
+            (clip2, source, "Both share close-up framing"),
+        ]
+        tab._apply_free_association_sequence(payload)
+        built_sequence: Sequence = tab.timeline.get_sequence()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            video = tmp / "video.mp4"
+            video.touch()
+            project_path = tmp / "project.json"
+
+            project = Project.new(name="FA roundtrip")
+            # Use a matching file path on the source we persist
+            source.file_path = video
+            project.add_source(source)
+            project.add_clips([clip1, clip2])
+            project.sequence = built_sequence
+
+            assert project.save(project_path) is True
+
+            loaded = Project.load(project_path)
+
+        assert loaded.sequence is not None
+        assert loaded.sequence.algorithm == "free_association"
+        loaded_clips = loaded.sequence.get_all_clips()
+        assert len(loaded_clips) == 2
+        assert loaded_clips[0].rationale is None
+        assert loaded_clips[1].rationale == "Both share close-up framing"
+
+
+class TestCardAvailability:
+    def test_free_association_appears_in_availability_mapping(self, qapp):
+        """The card grid uses a hand-maintained dict — ensure free_association
+        is registered so the card is visible."""
+        from ui.tabs.sequence_tab import SequenceTab
+
+        tab = SequenceTab()
+        # Give it some clips so the availability update runs meaningfully
+        source = _make_source()
+        clip = _make_clip("c1")
+        tab._clips = [clip]
+
+        # Capture the dict passed to set_algorithm_availability
+        captured = {}
+        tab.card_grid.set_algorithm_availability = (
+            lambda d: captured.update(d) or None
+        )
+        tab._update_card_availability()
+
+        assert "free_association" in captured

--- a/tests/test_free_association_worker.py
+++ b/tests/test_free_association_worker.py
@@ -1,0 +1,165 @@
+"""Tests for FreeAssociationWorker.
+
+Tests call worker.run() directly (synchronously) rather than start() to
+avoid QThread scheduling complications in the test environment. This is
+the same pattern used in tests/test_gaze_worker.py.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+def _worker_args():
+    """Minimal valid arguments for constructing the worker."""
+    return {
+        "current_clip_metadata": "Description: a close-up",
+        "candidate_digests": [("c1", "CU | warm"), ("c2", "wide | cool")],
+        "recent_rationales": [],
+        "rejected_short_ids": [],
+    }
+
+
+class TestFreeAssociationWorker:
+    def test_happy_path_emits_proposal_ready(self):
+        from ui.workers.free_association_worker import FreeAssociationWorker
+
+        proposals = []
+        errors = []
+
+        with patch(
+            "ui.workers.free_association_worker.propose_next_clip",
+            return_value=("c1", "Good transition based on shared warm tones"),
+        ):
+            worker = FreeAssociationWorker(**_worker_args())
+            worker.proposal_ready.connect(
+                lambda cid, rat: proposals.append((cid, rat))
+            )
+            worker.error.connect(lambda msg: errors.append(msg))
+            worker.run()
+
+        assert proposals == [("c1", "Good transition based on shared warm tones")]
+        assert errors == []
+
+    def test_value_error_emits_error_signal(self):
+        """ValueError from propose_next_clip (None content, bad JSON, etc.)."""
+        from ui.workers.free_association_worker import FreeAssociationWorker
+
+        proposals = []
+        errors = []
+
+        with patch(
+            "ui.workers.free_association_worker.propose_next_clip",
+            side_effect=ValueError("LLM returned no content"),
+        ):
+            worker = FreeAssociationWorker(**_worker_args())
+            worker.proposal_ready.connect(
+                lambda cid, rat: proposals.append((cid, rat))
+            )
+            worker.error.connect(lambda msg: errors.append(msg))
+            worker.run()
+
+        assert proposals == []
+        assert errors == ["LLM returned no content"]
+
+    def test_network_exception_emits_error_signal(self):
+        """Generic exceptions (network, auth) are caught and routed to error."""
+        from ui.workers.free_association_worker import FreeAssociationWorker
+
+        proposals = []
+        errors = []
+
+        with patch(
+            "ui.workers.free_association_worker.propose_next_clip",
+            side_effect=ConnectionError("Connection timed out"),
+        ):
+            worker = FreeAssociationWorker(**_worker_args())
+            worker.proposal_ready.connect(
+                lambda cid, rat: proposals.append((cid, rat))
+            )
+            worker.error.connect(lambda msg: errors.append(msg))
+            worker.run()
+
+        assert proposals == []
+        assert len(errors) == 1
+        assert "LLM call failed" in errors[0]
+        assert "Connection timed out" in errors[0]
+
+    def test_cancelled_before_llm_call_does_not_emit_proposal(self):
+        """Worker cancelled after LLM call succeeds does not emit."""
+        from ui.workers.free_association_worker import FreeAssociationWorker
+
+        proposals = []
+        errors = []
+
+        def cancel_then_return(**kwargs):
+            # Simulate cancellation happening mid-flight by setting the flag
+            # before returning the "successful" result
+            worker.cancel()
+            return ("c1", "Would be a great proposal")
+
+        with patch(
+            "ui.workers.free_association_worker.propose_next_clip",
+            side_effect=cancel_then_return,
+        ):
+            worker = FreeAssociationWorker(**_worker_args())
+            worker.proposal_ready.connect(
+                lambda cid, rat: proposals.append((cid, rat))
+            )
+            worker.error.connect(lambda msg: errors.append(msg))
+            worker.run()
+
+        assert proposals == []
+        assert errors == []
+
+    def test_cancelled_after_error_does_not_emit_error(self):
+        """If cancelled during an error path, the error signal is suppressed."""
+        from ui.workers.free_association_worker import FreeAssociationWorker
+
+        proposals = []
+        errors = []
+
+        def cancel_then_raise(**kwargs):
+            worker.cancel()
+            raise ValueError("some error")
+
+        with patch(
+            "ui.workers.free_association_worker.propose_next_clip",
+            side_effect=cancel_then_raise,
+        ):
+            worker = FreeAssociationWorker(**_worker_args())
+            worker.proposal_ready.connect(
+                lambda cid, rat: proposals.append((cid, rat))
+            )
+            worker.error.connect(lambda msg: errors.append(msg))
+            worker.run()
+
+        assert proposals == []
+        assert errors == []  # Suppressed because cancelled
+
+    def test_passes_constructor_args_to_propose_next_clip(self):
+        """Worker forwards all its constructor args to the core function."""
+        from ui.workers.free_association_worker import FreeAssociationWorker
+
+        with patch(
+            "ui.workers.free_association_worker.propose_next_clip",
+            return_value=("c1", "ok"),
+        ) as mock_propose:
+            worker = FreeAssociationWorker(
+                current_clip_metadata="current meta",
+                candidate_digests=[("c1", "digest one"), ("c2", "digest two")],
+                recent_rationales=["r1", "r2"],
+                rejected_short_ids=["c3"],
+                model="gemini-custom",
+                temperature=0.5,
+            )
+            worker.run()
+
+            mock_propose.assert_called_once_with(
+                current_clip_metadata="current meta",
+                candidate_digests=[("c1", "digest one"), ("c2", "digest two")],
+                recent_rationales=["r1", "r2"],
+                rejected_short_ids=["c3"],
+                model="gemini-custom",
+                temperature=0.5,
+            )

--- a/tests/test_sequence_clip_rationale.py
+++ b/tests/test_sequence_clip_rationale.py
@@ -1,0 +1,117 @@
+"""Tests for SequenceClip.rationale persistence (Free Association sequencer)."""
+
+import tempfile
+from pathlib import Path
+
+from models.clip import Clip, Source
+from core.project import Project
+from models.sequence import Sequence, SequenceClip, Track
+from ui.algorithm_config import get_algorithm_config
+
+
+def test_rationale_defaults_to_none():
+    """New SequenceClips have no rationale by default."""
+    clip = SequenceClip(source_clip_id="c1", source_id="s1")
+    assert clip.rationale is None
+
+
+def test_rationale_to_dict_omitted_when_none():
+    """rationale is not included in to_dict when None (backward-compatible)."""
+    clip = SequenceClip(source_clip_id="c1", source_id="s1")
+    data = clip.to_dict()
+    assert "rationale" not in data
+
+
+def test_rationale_to_dict_included_when_set():
+    """rationale is included in to_dict when set."""
+    clip = SequenceClip(
+        source_clip_id="c1",
+        source_id="s1",
+        rationale="Both clips share close-up framing with warm tones",
+    )
+    data = clip.to_dict()
+    assert data["rationale"] == "Both clips share close-up framing with warm tones"
+
+
+def test_rationale_roundtrip():
+    """rationale survives to_dict/from_dict roundtrip."""
+    clip = SequenceClip(
+        source_clip_id="c1",
+        source_id="s1",
+        rationale="The transition preserves visual rhythm",
+    )
+    data = clip.to_dict()
+    restored = SequenceClip.from_dict(data)
+    assert restored.rationale == "The transition preserves visual rhythm"
+
+
+def test_rationale_backward_compatible_load():
+    """Old project data without rationale loads with rationale=None."""
+    data = {
+        "id": "sc-1",
+        "source_clip_id": "c1",
+        "source_id": "s1",
+        "track_index": 0,
+        "start_frame": 0,
+        "in_point": 0,
+        "out_point": 30,
+    }
+    clip = SequenceClip.from_dict(data)
+    assert clip.rationale is None
+
+
+def test_rationale_survives_full_project_roundtrip():
+    """rationale persists through a full project save/load cycle."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        video = tmp / "video.mp4"
+        video.touch()
+        project_path = tmp / "project.json"
+
+        # Build project with a sequence containing a rationale-bearing clip
+        project = Project.new(name="Rationale Roundtrip")
+        source = Source(
+            id="src-1",
+            file_path=video,
+            duration_seconds=60.0,
+            fps=30.0,
+            width=1920,
+            height=1080,
+        )
+        project.add_source(source)
+        clip = Clip(id="clip-1", source_id="src-1", start_frame=0, end_frame=30)
+        project.add_clips([clip])
+
+        sequence = Sequence(name="Test", fps=30.0, algorithm="free_association")
+        sequence.tracks[0].add_clip(
+            SequenceClip(
+                source_clip_id="clip-1",
+                source_id="src-1",
+                start_frame=0,
+                in_point=0,
+                out_point=30,
+                rationale="Opening shot, user-selected",
+            )
+        )
+        project.sequence = sequence
+        assert project.save(project_path) is True
+
+        # Load back and verify rationale survived
+        loaded = Project.load(project_path)
+        assert loaded.sequence is not None
+        assert loaded.sequence.algorithm == "free_association"
+        loaded_clips = loaded.sequence.get_all_clips()
+        assert len(loaded_clips) == 1
+        assert loaded_clips[0].rationale == "Opening shot, user-selected"
+
+
+def test_free_association_registered_in_algorithm_config():
+    """Free Association algorithm appears in ALGORITHM_CONFIG with is_dialog=True."""
+    config = get_algorithm_config("free_association")
+    assert config["label"] == "Free Association"
+    assert config["is_dialog"] is True
+    assert config["required_analysis"] == ["describe"]
+    # embeddings is NOT required — the core module falls back to random
+    # sampling when embeddings are missing, so gating on them would contradict
+    # graceful degradation
+    assert "embeddings" not in config["required_analysis"]

--- a/tests/test_sorting_card_grid.py
+++ b/tests/test_sorting_card_grid.py
@@ -14,12 +14,12 @@ app = QApplication.instance() or QApplication(sys.argv)
 
 
 EXPECTED_COUNTS = {
-    "All": 19,
+    "All": 20,
     "Arrange": 9,
     "Find": 4,
-    "Connect": 5,
+    "Connect": 6,  # +1 for free_association
     "Audio": 3,
-    "Text": 2,
+    "Text": 3,  # +1 for free_association
 }
 
 ARRANGE_KEYS = {
@@ -27,7 +27,7 @@ ARRANGE_KEYS = {
     "brightness", "volume", "shot_type", "proximity", "gaze_sort",
 }
 
-TEXT_KEYS = {"exquisite_corpus", "storyteller"}
+TEXT_KEYS = {"exquisite_corpus", "storyteller", "free_association"}
 
 
 def _visible_keys(grid: SortingCardGrid) -> set[str]:
@@ -45,7 +45,7 @@ class TestCategoryFiltering:
     def setup_method(self):
         self.grid = SortingCardGrid()
 
-    def test_all_shows_19_cards(self):
+    def test_all_shows_every_registered_algorithm(self):
         self.grid.set_category("All")
         assert _visible_keys(self.grid) == set(ALGORITHM_CONFIG.keys())
 
@@ -86,9 +86,9 @@ class TestCategoryFiltering:
 
     def test_reflow_text_to_all(self):
         self.grid.set_category("Text")
-        assert len(_visible_keys(self.grid)) == 2
+        assert len(_visible_keys(self.grid)) == 3
         self.grid.set_category("All")
-        assert len(_visible_keys(self.grid)) == 19
+        assert len(_visible_keys(self.grid)) == 20
 
     def test_selection_cleared_on_hidden_card(self):
         # Select a card in Arrange

--- a/ui/algorithm_config.py
+++ b/ui/algorithm_config.py
@@ -106,6 +106,15 @@ ALGORITHM_CONFIG = {
         "is_dialog": True,
         "categories": ["text"],
     },
+    "free_association": {
+        "icon": "\U0001f4ad",  # thought balloon
+        "label": "Free Association",
+        "description": "Build a sequence one clip at a time with an LLM collaborator",
+        "allow_duplicates": False,
+        "required_analysis": ["describe"],
+        "is_dialog": True,
+        "categories": ["connect", "text"],
+    },
     "reference_guided": {
         "icon": "\U0001f3af",
         "label": "Reference Guide",

--- a/ui/dialogs/__init__.py
+++ b/ui/dialogs/__init__.py
@@ -11,6 +11,7 @@ from .rose_hobart_dialog import RoseHobartDialog
 from .dice_roll_dialog import DiceRollDialog
 from .staccato_dialog import StaccatoDialog
 from .eyes_without_a_face_dialog import EyesWithoutAFaceDialog
+from .free_association_dialog import FreeAssociationDialog
 from .url_import_dialog import URLImportDialog
 
 __all__ = [
@@ -26,5 +27,6 @@ __all__ = [
     "DiceRollDialog",
     "StaccatoDialog",
     "EyesWithoutAFaceDialog",
+    "FreeAssociationDialog",
     "URLImportDialog",
 ]

--- a/ui/dialogs/free_association_dialog.py
+++ b/ui/dialogs/free_association_dialog.py
@@ -1,0 +1,847 @@
+"""Interactive dialog for the Free Association sequencer.
+
+The user selects a first clip, then the LLM proposes each next clip based
+on clip metadata. Accept adds the clip and moves on; Reject asks for a
+different proposal. A rationale log on the right side accumulates the
+editorial record of the final sequence.
+
+Design notes (see docs/plans/2026-04-12-001-feat-free-association-sequencer-plan.md):
+
+- Single-step worker per proposal; dialog owns all state.
+- Guard flag + Qt.UniqueConnection for worker signal safety.
+- No worker.wait() on cancel — in-flight HTTP calls could block the UI
+  thread up to 120s. Instead call worker.cancel() and worker.deleteLater().
+- The emitted signal payload is list[tuple[Clip, Source, Optional[str]]] —
+  the third element is the rationale for each transition (None for the
+  user-selected first clip).
+"""
+
+import logging
+from typing import Optional
+
+from PySide6.QtCore import Qt, Signal
+from PySide6.QtGui import QFont, QPixmap
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QScrollArea,
+    QSizePolicy,
+    QSplitter,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from core.remix.free_association import (
+    DEFAULT_RECENT_RATIONALES,
+    DEFAULT_SHORTLIST_SIZE,
+    build_id_mapping,
+    format_clip_digest,
+    format_clip_full_metadata,
+    shortlist_candidates,
+)
+from ui.theme import theme
+from ui.workers.free_association_worker import FreeAssociationWorker
+
+logger = logging.getLogger(__name__)
+
+# Page indices
+PAGE_FIRST_CLIP_SELECT = 0
+PAGE_LOADING = 1
+PAGE_PROPOSAL = 2
+PAGE_ERROR = 3
+PAGE_POOL_EXHAUSTED = 4
+PAGE_COMPLETE = 5
+
+# Threshold for requiring confirmation on stop/discard
+CONFIRMATION_THRESHOLD = 3
+
+
+class FreeAssociationDialog(QDialog):
+    """Interactive step-by-step sequencer dialog.
+
+    Signals:
+        sequence_ready(list): emitted with the built sequence as a list of
+            (Clip, Source, Optional[str]) tuples, where the third element
+            is the rationale for that transition (None for the first clip).
+    """
+
+    sequence_ready = Signal(list)
+
+    def __init__(self, clips, sources_by_id, project, parent=None):
+        super().__init__(parent)
+        self.clips = list(clips)
+        self.sources_by_id = sources_by_id
+        self.project = project
+
+        # Dialog state (source of truth — not kept on the worker)
+        # sequence_built parallels rationales; rationales[0] is always None
+        self.sequence_built: list[tuple] = []  # [(Clip, Source), ...]
+        self.rationales: list[Optional[str]] = []
+        self.available_pool: list[tuple] = self._initial_pool()
+        # IDs rejected for the current position, cleared on accept
+        self.rejected_for_position: set[str] = set()
+
+        # Current proposal state (valid on PAGE_PROPOSAL)
+        self._current_candidates: list[tuple] = []
+        self._current_short_to_full: dict[str, str] = {}
+        self._proposed_clip: Optional[tuple] = None  # (Clip, Source)
+        self._proposed_rationale: str = ""
+        self._last_rejected_proposal: Optional[tuple] = None  # for "Reconsider"
+
+        # Worker lifecycle
+        self._worker: Optional[FreeAssociationWorker] = None
+        self._proposal_handled = False  # guard against duplicate signal delivery
+
+        self.setWindowTitle("Free Association")
+        self.setMinimumSize(900, 600)
+        self.setModal(True)
+
+        self._setup_ui()
+        self._apply_theme()
+
+        # Start on FIRST_CLIP_SELECT (or empty state)
+        if not self.available_pool:
+            self._show_empty_state()
+        else:
+            self.stack.setCurrentIndex(PAGE_FIRST_CLIP_SELECT)
+
+    def _initial_pool(self) -> list[tuple]:
+        """Build the initial pool from clips + sources."""
+        pool = []
+        for clip in self.clips:
+            source = self.sources_by_id.get(clip.source_id)
+            if source is not None:
+                pool.append((clip, source))
+        return pool
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(10)
+
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.setChildrenCollapsible(False)
+
+        # Left: interaction stack
+        self.stack = QStackedWidget()
+        self.stack.addWidget(self._build_first_clip_page())
+        self.stack.addWidget(self._build_loading_page())
+        self.stack.addWidget(self._build_proposal_page())
+        self.stack.addWidget(self._build_error_page())
+        self.stack.addWidget(self._build_pool_exhausted_page())
+        self.stack.addWidget(self._build_complete_page())
+        splitter.addWidget(self.stack)
+
+        # Right: rationale log panel
+        splitter.addWidget(self._build_log_panel())
+
+        # 70/30 split
+        splitter.setStretchFactor(0, 7)
+        splitter.setStretchFactor(1, 3)
+
+        layout.addWidget(splitter, 1)
+
+    def _build_first_clip_page(self) -> QWidget:
+        page = QWidget()
+        page_layout = QVBoxLayout(page)
+        page_layout.setContentsMargins(0, 0, 0, 0)
+
+        header = QLabel("Pick your opening clip")
+        header_font = QFont()
+        header_font.setPointSize(16)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        page_layout.addWidget(header)
+
+        subhead = QLabel(
+            "The Free Association sequencer will propose each subsequent clip "
+            "based on the metadata of the one that came before. Select the clip "
+            "that should open the sequence."
+        )
+        subhead.setWordWrap(True)
+        page_layout.addWidget(subhead)
+
+        # Scrollable list of available clips — simple list with thumbnails
+        self.first_clip_list = QListWidget()
+        self.first_clip_list.setIconSize(self._thumbnail_size())
+        self.first_clip_list.itemDoubleClicked.connect(self._on_first_clip_double_clicked)
+        for clip, source in self.available_pool:
+            item = QListWidgetItem(self._clip_list_label(clip, source))
+            item.setData(Qt.UserRole, clip.id)
+            pixmap = self._thumbnail_for(clip)
+            if pixmap is not None:
+                item.setIcon(pixmap)
+            self.first_clip_list.addItem(item)
+        page_layout.addWidget(self.first_clip_list, 1)
+
+        # Start button row
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self._on_cancel_from_first_page)
+        btn_row.addWidget(cancel_btn)
+        self.start_btn = QPushButton("Start")
+        self.start_btn.setDefault(True)
+        self.start_btn.clicked.connect(self._on_start_clicked)
+        btn_row.addWidget(self.start_btn)
+        page_layout.addLayout(btn_row)
+
+        return page
+
+    def _build_loading_page(self) -> QWidget:
+        page = QWidget()
+        lay = QVBoxLayout(page)
+        lay.setAlignment(Qt.AlignCenter)
+
+        header = QLabel("Thinking…")
+        header_font = QFont()
+        header_font.setPointSize(14)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        header.setAlignment(Qt.AlignCenter)
+        lay.addWidget(header)
+
+        self.loading_status = QLabel("Finding the next clip…")
+        self.loading_status.setAlignment(Qt.AlignCenter)
+        lay.addWidget(self.loading_status)
+
+        bar = QProgressBar()
+        bar.setMinimum(0)
+        bar.setMaximum(0)  # indeterminate
+        bar.setFixedWidth(300)
+        lay.addWidget(bar, alignment=Qt.AlignCenter)
+
+        # Stop button
+        stop_row = QHBoxLayout()
+        stop_row.addStretch()
+        loading_stop_btn = QPushButton("Stop")
+        loading_stop_btn.clicked.connect(self._on_stop_clicked)
+        stop_row.addWidget(loading_stop_btn)
+        stop_row.addStretch()
+        lay.addLayout(stop_row)
+
+        return page
+
+    def _build_proposal_page(self) -> QWidget:
+        page = QWidget()
+        lay = QVBoxLayout(page)
+
+        header = QLabel("Next clip")
+        header_font = QFont()
+        header_font.setPointSize(14)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        lay.addWidget(header)
+
+        # Proposed clip thumbnail + name
+        self.proposal_thumbnail = QLabel()
+        self.proposal_thumbnail.setAlignment(Qt.AlignCenter)
+        self.proposal_thumbnail.setFixedHeight(200)
+        lay.addWidget(self.proposal_thumbnail)
+
+        self.proposal_name = QLabel("")
+        name_font = QFont()
+        name_font.setPointSize(12)
+        name_font.setBold(True)
+        self.proposal_name.setFont(name_font)
+        lay.addWidget(self.proposal_name)
+
+        # Metadata summary
+        self.proposal_metadata = QLabel("")
+        self.proposal_metadata.setWordWrap(True)
+        self.proposal_metadata.setStyleSheet("color: gray; font-size: 11px;")
+        lay.addWidget(self.proposal_metadata)
+
+        # Rationale
+        rationale_heading = QLabel("Rationale")
+        rationale_heading.setStyleSheet("font-weight: bold;")
+        lay.addWidget(rationale_heading)
+
+        self.proposal_rationale = QLabel("")
+        self.proposal_rationale.setWordWrap(True)
+        rationale_scroll = QScrollArea()
+        rationale_scroll.setWidget(self.proposal_rationale)
+        rationale_scroll.setWidgetResizable(True)
+        rationale_scroll.setFrameShape(QScrollArea.NoFrame)
+        rationale_scroll.setFixedHeight(80)
+        lay.addWidget(rationale_scroll)
+
+        lay.addStretch()
+
+        # Action row: Accept / Reject / Stop
+        action_row = QHBoxLayout()
+        self.stop_btn = QPushButton("Stop")
+        self.stop_btn.clicked.connect(self._on_stop_clicked)
+        action_row.addWidget(self.stop_btn)
+        action_row.addStretch()
+        self.reject_btn = QPushButton("Reject")
+        self.reject_btn.clicked.connect(self._on_reject_clicked)
+        action_row.addWidget(self.reject_btn)
+        self.accept_btn = QPushButton("Accept")
+        self.accept_btn.setDefault(True)
+        self.accept_btn.clicked.connect(self._on_accept_clicked)
+        action_row.addWidget(self.accept_btn)
+        lay.addLayout(action_row)
+
+        return page
+
+    def _build_error_page(self) -> QWidget:
+        page = QWidget()
+        lay = QVBoxLayout(page)
+        lay.setAlignment(Qt.AlignCenter)
+
+        header = QLabel("Something went wrong")
+        header_font = QFont()
+        header_font.setPointSize(14)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        header.setAlignment(Qt.AlignCenter)
+        lay.addWidget(header)
+
+        self.error_message = QLabel("")
+        self.error_message.setWordWrap(True)
+        self.error_message.setAlignment(Qt.AlignCenter)
+        lay.addWidget(self.error_message)
+
+        self.error_reassurance = QLabel("")
+        self.error_reassurance.setAlignment(Qt.AlignCenter)
+        self.error_reassurance.setStyleSheet("color: gray;")
+        lay.addWidget(self.error_reassurance)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        cancel_btn = QPushButton("Cancel")
+        cancel_btn.clicked.connect(self._on_cancel_from_error)
+        btn_row.addWidget(cancel_btn)
+        retry_btn = QPushButton("Retry")
+        retry_btn.setDefault(True)
+        retry_btn.clicked.connect(self._on_retry_clicked)
+        btn_row.addWidget(retry_btn)
+        btn_row.addStretch()
+        lay.addLayout(btn_row)
+
+        return page
+
+    def _build_pool_exhausted_page(self) -> QWidget:
+        page = QWidget()
+        lay = QVBoxLayout(page)
+        lay.setAlignment(Qt.AlignCenter)
+
+        header = QLabel("No more candidates")
+        header_font = QFont()
+        header_font.setPointSize(14)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        header.setAlignment(Qt.AlignCenter)
+        lay.addWidget(header)
+
+        msg = QLabel(
+            "Every clip that could follow here has been rejected. "
+            "You can keep the sequence as it stands or reconsider the most "
+            "recently rejected clip."
+        )
+        msg.setWordWrap(True)
+        msg.setAlignment(Qt.AlignCenter)
+        lay.addWidget(msg)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        end_btn = QPushButton("End sequence")
+        end_btn.clicked.connect(self._on_end_from_pool_exhausted)
+        btn_row.addWidget(end_btn)
+        self.reconsider_btn = QPushButton("Reconsider last rejected")
+        self.reconsider_btn.setDefault(True)
+        self.reconsider_btn.clicked.connect(self._on_reconsider_clicked)
+        btn_row.addWidget(self.reconsider_btn)
+        btn_row.addStretch()
+        lay.addLayout(btn_row)
+
+        return page
+
+    def _build_complete_page(self) -> QWidget:
+        page = QWidget()
+        lay = QVBoxLayout(page)
+
+        header = QLabel("Sequence ready")
+        header_font = QFont()
+        header_font.setPointSize(14)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        lay.addWidget(header)
+
+        self.complete_summary = QLabel("")
+        lay.addWidget(self.complete_summary)
+
+        self.complete_list = QListWidget()
+        lay.addWidget(self.complete_list, 1)
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        close_btn = QPushButton("Close without applying")
+        close_btn.clicked.connect(self._on_close_from_complete)
+        btn_row.addWidget(close_btn)
+        apply_btn = QPushButton("Apply")
+        apply_btn.setDefault(True)
+        apply_btn.clicked.connect(self._on_apply_clicked)
+        btn_row.addWidget(apply_btn)
+        lay.addLayout(btn_row)
+
+        return page
+
+    def _build_log_panel(self) -> QWidget:
+        panel = QWidget()
+        lay = QVBoxLayout(panel)
+        lay.setContentsMargins(0, 0, 0, 0)
+
+        heading = QLabel("Rationale log")
+        heading_font = QFont()
+        heading_font.setPointSize(12)
+        heading_font.setBold(True)
+        heading.setFont(heading_font)
+        lay.addWidget(heading)
+
+        self.log_list = QListWidget()
+        self.log_list.setWordWrap(True)
+        self.log_list.setAlternatingRowColors(True)
+        lay.addWidget(self.log_list, 1)
+
+        self.log_placeholder = QLabel(
+            "Proposals and rationales will appear here as you build the sequence."
+        )
+        self.log_placeholder.setWordWrap(True)
+        self.log_placeholder.setStyleSheet("color: gray; font-size: 11px;")
+        lay.addWidget(self.log_placeholder)
+
+        return panel
+
+    def _apply_theme(self):
+        try:
+            self.setStyleSheet(
+                f"""
+                QDialog {{ background-color: {theme().background_primary}; }}
+                QLabel {{ color: {theme().text_primary}; }}
+                QListWidget {{
+                    background-color: {theme().background_tertiary};
+                    color: {theme().text_primary};
+                    border: 1px solid {theme().border_primary};
+                    border-radius: 4px;
+                }}
+                QListWidget::item {{ padding: 6px; }}
+                QPushButton {{
+                    background-color: {theme().background_tertiary};
+                    color: {theme().text_primary};
+                    border: 1px solid {theme().border_primary};
+                    border-radius: 4px;
+                    padding: 8px 16px;
+                }}
+                QPushButton:hover {{ background-color: {theme().background_elevated}; }}
+                QPushButton:disabled {{
+                    background-color: {theme().background_secondary};
+                    color: {theme().text_muted};
+                }}
+                QProgressBar {{
+                    background-color: {theme().background_secondary};
+                    border: 1px solid {theme().border_primary};
+                    border-radius: 4px;
+                }}
+                QProgressBar::chunk {{ background-color: {theme().accent_blue}; }}
+                """
+            )
+        except Exception:  # theme may not be available in some test contexts
+            logger.debug("Skipping theme application (theme unavailable)")
+
+    # ------------------------------------------------------------------
+    # Empty state
+    # ------------------------------------------------------------------
+
+    def _show_empty_state(self):
+        """Replace the first-clip page with an empty-state message."""
+        # Disable the Start button and show a message inline
+        self.first_clip_list.clear()
+        empty_item = QListWidgetItem("No clips available — add clips in the Cut tab first")
+        empty_item.setFlags(Qt.NoItemFlags)
+        self.first_clip_list.addItem(empty_item)
+        self.start_btn.setEnabled(False)
+        self.stack.setCurrentIndex(PAGE_FIRST_CLIP_SELECT)
+
+    # ------------------------------------------------------------------
+    # First clip selection
+    # ------------------------------------------------------------------
+
+    def _on_first_clip_double_clicked(self, _item):
+        # Double-click to confirm (convenience) — same path as Start button
+        self._on_start_clicked()
+
+    def _on_start_clicked(self):
+        item = self.first_clip_list.currentItem()
+        if item is None or not (item.flags() & Qt.ItemIsEnabled):
+            QMessageBox.information(
+                self, "Select a clip", "Choose a clip to open the sequence."
+            )
+            return
+
+        clip_id = item.data(Qt.UserRole)
+        # Find the (clip, source) in available_pool
+        selected = next(
+            ((c, s) for c, s in self.available_pool if c.id == clip_id), None
+        )
+        if selected is None:
+            QMessageBox.warning(self, "Error", "Selected clip not found in pool.")
+            return
+
+        clip, source = selected
+        self.sequence_built.append((clip, source))
+        self.rationales.append(None)  # First clip has no rationale
+        self.available_pool.remove((clip, source))
+        self._log_placeholder_hide()
+        self._append_log_entry(
+            position=1, clip_name=self._clip_list_label(clip, source), rationale=None
+        )
+        self._request_next_proposal()
+
+    # ------------------------------------------------------------------
+    # Proposal request / response
+    # ------------------------------------------------------------------
+
+    def _request_next_proposal(self):
+        """Shortlist candidates and spawn a worker to propose the next clip."""
+        if not self.available_pool:
+            # All clips placed — go directly to COMPLETE
+            self._show_complete_page()
+            return
+
+        current_clip, _ = self.sequence_built[-1]
+        candidates = shortlist_candidates(
+            current_clip, self.available_pool, k=DEFAULT_SHORTLIST_SIZE
+        )
+        # Filter out candidates already rejected for this position
+        unrejected = [(c, s) for c, s in candidates if c.id not in self.rejected_for_position]
+        if not unrejected:
+            # All candidates for this position have been rejected
+            self._show_pool_exhausted()
+            return
+
+        self._current_candidates = unrejected
+        short_to_full, full_to_short = build_id_mapping(unrejected)
+        self._current_short_to_full = short_to_full
+
+        candidate_digests = [
+            (full_to_short[clip.id], format_clip_digest(clip)) for clip, _ in unrejected
+        ]
+        current_meta = format_clip_full_metadata(current_clip)
+        recent_rationales = [
+            r for r in self.rationales[-DEFAULT_RECENT_RATIONALES :] if r
+        ]
+        # Rejected IDs must be converted to the current short-ID space.
+        # Since we already filtered unrejected, pass an empty rejected list
+        # to propose_next_clip — all candidates in the prompt are valid.
+        rejected_short_ids: list[str] = []
+
+        self._spawn_worker(
+            current_meta, candidate_digests, recent_rationales, rejected_short_ids
+        )
+
+    def _spawn_worker(
+        self,
+        current_meta: str,
+        candidate_digests: list[tuple[str, str]],
+        recent_rationales: list[str],
+        rejected_short_ids: list[str],
+    ):
+        """Create and start a new single-step worker."""
+        # Clean up any previous worker reference
+        self._teardown_worker()
+        self._proposal_handled = False
+
+        self.stack.setCurrentIndex(PAGE_LOADING)
+        position = len(self.sequence_built) + 1
+        self.loading_status.setText(f"Finding clip for position {position}…")
+
+        self._worker = FreeAssociationWorker(
+            current_clip_metadata=current_meta,
+            candidate_digests=candidate_digests,
+            recent_rationales=recent_rationales,
+            rejected_short_ids=rejected_short_ids,
+            parent=self,
+        )
+        self._worker.proposal_ready.connect(
+            self._on_proposal_ready, Qt.UniqueConnection
+        )
+        self._worker.error.connect(self._on_proposal_error, Qt.UniqueConnection)
+        # Auto-cleanup when the worker finishes — avoids worker.wait() on cancel
+        self._worker.finished.connect(self._worker.deleteLater)
+        self._worker.start()
+
+    def _teardown_worker(self):
+        """Cancel and drop reference to the current worker, if any."""
+        if self._worker is not None:
+            try:
+                self._worker.cancel()
+            except Exception:
+                logger.debug("Worker cancel raised; ignoring")
+            self._worker = None
+
+    def _on_proposal_ready(self, clip_short_id: str, rationale: str):
+        # Guard against duplicate signal delivery (Qt finished can fire twice)
+        if self._proposal_handled:
+            logger.debug("Duplicate proposal_ready suppressed")
+            return
+        self._proposal_handled = True
+
+        clip_id = self._current_short_to_full.get(clip_short_id)
+        if clip_id is None:
+            self._show_error(
+                f"LLM returned an unknown clip ID ({clip_short_id}). Try again."
+            )
+            return
+
+        # Find (clip, source) in current candidates
+        selected = next(
+            ((c, s) for c, s in self._current_candidates if c.id == clip_id), None
+        )
+        if selected is None:
+            self._show_error(
+                "The proposed clip is no longer in the candidate set. Try again."
+            )
+            return
+
+        self._proposed_clip = selected
+        self._proposed_rationale = rationale
+        self._display_proposal(selected, rationale)
+        self.stack.setCurrentIndex(PAGE_PROPOSAL)
+
+    def _on_proposal_error(self, message: str):
+        if self._proposal_handled:
+            return
+        self._proposal_handled = True
+        self._show_error(message)
+
+    def _show_error(self, message: str):
+        self.error_message.setText(message)
+        n_accepted = len(self.sequence_built)
+        if n_accepted > 0:
+            plural = "s" if n_accepted != 1 else ""
+            self.error_reassurance.setText(
+                f"Your {n_accepted} accepted clip{plural} will be preserved if you retry or cancel."
+            )
+        else:
+            self.error_reassurance.setText("")
+        self.stack.setCurrentIndex(PAGE_ERROR)
+
+    def _display_proposal(self, proposed: tuple, rationale: str):
+        clip, source = proposed
+        pixmap = self._thumbnail_for(clip, scaled=True)
+        if pixmap is not None:
+            self.proposal_thumbnail.setPixmap(pixmap)
+        else:
+            self.proposal_thumbnail.setText("(no thumbnail)")
+        self.proposal_name.setText(self._clip_list_label(clip, source))
+        self.proposal_metadata.setText(format_clip_digest(clip))
+        self.proposal_rationale.setText(rationale)
+
+    # ------------------------------------------------------------------
+    # Accept / Reject / Stop
+    # ------------------------------------------------------------------
+
+    def _on_accept_clicked(self):
+        if self._proposed_clip is None:
+            return
+        clip, source = self._proposed_clip
+        self.sequence_built.append((clip, source))
+        self.rationales.append(self._proposed_rationale)
+        self.available_pool.remove((clip, source))
+        self.rejected_for_position.clear()
+        self._last_rejected_proposal = None
+
+        self._append_log_entry(
+            position=len(self.sequence_built),
+            clip_name=self._clip_list_label(clip, source),
+            rationale=self._proposed_rationale,
+        )
+
+        self._proposed_clip = None
+        self._proposed_rationale = ""
+        self._request_next_proposal()
+
+    def _on_reject_clicked(self):
+        if self._proposed_clip is None:
+            return
+        clip, source = self._proposed_clip
+        self.rejected_for_position.add(clip.id)
+        self._last_rejected_proposal = (clip, source)
+        self._proposed_clip = None
+        self._proposed_rationale = ""
+        self._request_next_proposal()
+
+    def _on_reconsider_clicked(self):
+        """User chose to reconsider the most recently rejected clip."""
+        if self._last_rejected_proposal is None:
+            # Shouldn't happen — fall through to complete
+            self._show_complete_page()
+            return
+        clip, source = self._last_rejected_proposal
+        self.rejected_for_position.discard(clip.id)
+        # Synthesize a proposal from the resurrected clip — the LLM has
+        # already provided a rationale for it earlier in this session.
+        # We prompt the user to decide again with a fresh rationale stub;
+        # this keeps the flow simple without another LLM round-trip.
+        self._proposed_clip = (clip, source)
+        self._proposed_rationale = (
+            "(Resurrected from rejection — decide if this transition now fits.)"
+        )
+        self._display_proposal(self._proposed_clip, self._proposed_rationale)
+        self.stack.setCurrentIndex(PAGE_PROPOSAL)
+
+    def _on_stop_clicked(self):
+        """User clicked Stop — confirm if >=3 clips accepted."""
+        n = len(self.sequence_built)
+        if n >= CONFIRMATION_THRESHOLD:
+            reply = QMessageBox.question(
+                self,
+                "End sequence?",
+                f"You have accepted {n} clips. End the sequence here?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if reply != QMessageBox.Yes:
+                return
+        self._teardown_worker()
+        self._show_complete_page()
+
+    def _on_retry_clicked(self):
+        """Retry the current position from ERROR state."""
+        # Same position, same rejection set — just re-spawn the worker
+        self._request_next_proposal()
+
+    def _on_cancel_from_error(self):
+        """Cancel from ERROR — preserve partial sequence, go to COMPLETE."""
+        self._teardown_worker()
+        self._show_complete_page()
+
+    def _on_cancel_from_first_page(self):
+        """Cancel before any clip is selected — close without applying."""
+        self._teardown_worker()
+        self.reject()
+
+    def _on_end_from_pool_exhausted(self):
+        self._teardown_worker()
+        self._show_complete_page()
+
+    # ------------------------------------------------------------------
+    # Complete page
+    # ------------------------------------------------------------------
+
+    def _show_complete_page(self):
+        self._populate_complete_summary()
+        self.stack.setCurrentIndex(PAGE_COMPLETE)
+
+    def _show_pool_exhausted(self):
+        self.reconsider_btn.setEnabled(self._last_rejected_proposal is not None)
+        self.stack.setCurrentIndex(PAGE_POOL_EXHAUSTED)
+
+    def _populate_complete_summary(self):
+        n = len(self.sequence_built)
+        total_seconds = sum(
+            clip.duration_seconds(source.fps) for clip, source in self.sequence_built
+        )
+        minutes, seconds = divmod(int(total_seconds), 60)
+        self.complete_summary.setText(
+            f"{n} clip{'s' if n != 1 else ''} · {minutes}:{seconds:02d} total"
+        )
+        self.complete_list.clear()
+        for idx, (clip, source) in enumerate(self.sequence_built, start=1):
+            self.complete_list.addItem(
+                f"{idx}. {self._clip_list_label(clip, source)}"
+            )
+
+    def _on_apply_clicked(self):
+        """Emit the final sequence as (Clip, Source, rationale) triples."""
+        self._teardown_worker()
+        payload = [
+            (clip, source, self.rationales[idx])
+            for idx, (clip, source) in enumerate(self.sequence_built)
+        ]
+        self.sequence_ready.emit(payload)
+        self.accept()
+
+    def _on_close_from_complete(self):
+        """Close without applying — confirm if >=3 clips accepted."""
+        n = len(self.sequence_built)
+        if n >= CONFIRMATION_THRESHOLD:
+            reply = QMessageBox.question(
+                self,
+                "Discard sequence?",
+                f"Discard the sequence with {n} accepted clips?",
+                QMessageBox.Yes | QMessageBox.No,
+                QMessageBox.No,
+            )
+            if reply != QMessageBox.Yes:
+                return
+        self._teardown_worker()
+        self.reject()
+
+    # ------------------------------------------------------------------
+    # Close event
+    # ------------------------------------------------------------------
+
+    def closeEvent(self, event):  # noqa: N802 — Qt override
+        """Handle dialog close (X button) — cancel worker without blocking."""
+        self._teardown_worker()
+        # No worker.wait() — blocking HTTP calls could freeze up to 120s
+        event.accept()
+
+    # ------------------------------------------------------------------
+    # Rationale log panel
+    # ------------------------------------------------------------------
+
+    def _append_log_entry(
+        self, position: int, clip_name: str, rationale: Optional[str]
+    ):
+        """Append an accepted transition to the rationale log."""
+        if rationale is None:
+            text = f"{position}. {clip_name}\n    (opening clip — user-selected)"
+        else:
+            text = f"{position}. {clip_name}\n    {rationale}"
+        item = QListWidgetItem(text)
+        self.log_list.addItem(item)
+        self.log_list.scrollToBottom()
+
+    def _log_placeholder_hide(self):
+        self.log_placeholder.setVisible(False)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _thumbnail_size():
+        from PySide6.QtCore import QSize
+
+        return QSize(96, 54)
+
+    def _thumbnail_for(self, clip, scaled: bool = False) -> Optional[QPixmap]:
+        path = getattr(clip, "thumbnail_path", None)
+        if not path:
+            return None
+        pixmap = QPixmap(str(path))
+        if pixmap.isNull():
+            return None
+        if scaled:
+            return pixmap.scaledToHeight(180, Qt.SmoothTransformation)
+        return pixmap
+
+    def _clip_list_label(self, clip, source) -> str:
+        source_name = getattr(source, "file_path", None)
+        source_name = source_name.name if source_name is not None else ""
+        return clip.display_name(source_filename=str(source_name), fps=source.fps)

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -699,8 +699,8 @@ class SettingsDialog(QDialog):
 
         layout.addWidget(text_group)
 
-        # LLM Sequencer (Storyteller + Exquisite Corpus) group
-        corpus_group = QGroupBox("LLM Sequencer (Storyteller / Exquisite Corpus)")
+        # LLM Sequencer (Storyteller + Exquisite Corpus + Free Association) group
+        corpus_group = QGroupBox("LLM Sequencer (Storyteller / Exquisite Corpus / Free Association)")
         corpus_layout = QVBoxLayout(corpus_group)
 
         # Model selection

--- a/ui/tabs/sequence_tab.py
+++ b/ui/tabs/sequence_tab.py
@@ -21,7 +21,7 @@ from .base_tab import BaseTab
 from ui.video_player import VideoPlayer
 from ui.timeline import TimelineWidget
 from ui.widgets import SortingCardGrid, TimelinePreview, CostEstimatePanel
-from ui.dialogs import ExquisiteCorpusDialog, StorytellerDialog, MissingDescriptionsDialog, ReferenceGuideDialog, SignatureStyleDialog, RoseHobartDialog, DiceRollDialog
+from ui.dialogs import ExquisiteCorpusDialog, StorytellerDialog, MissingDescriptionsDialog, ReferenceGuideDialog, SignatureStyleDialog, RoseHobartDialog, DiceRollDialog, FreeAssociationDialog
 from ui.theme import theme, Spacing, TypeScale, UISizes
 from ui.workers.sequence_worker import SequenceWorker
 from core.remix import generate_sequence
@@ -661,6 +661,9 @@ class SequenceTab(BaseTab):
             if algorithm == "eyes_without_a_face":
                 self._show_eyes_without_a_face_dialog(clips)
                 return
+            if algorithm == "free_association":
+                self._show_free_association_dialog(clips)
+                return
 
         # Compute cost estimates for this algorithm
         clip_objects = [clip for clip, source in clips]
@@ -983,6 +986,94 @@ class SequenceTab(BaseTab):
     def _apply_storyteller_sequence(self, sequence_clips: list):
         """Apply the sequence from Storyteller dialog."""
         self._apply_dialog_sequence(sequence_clips, "storyteller", "Storyteller")
+
+    def _show_free_association_dialog(self, clips: list):
+        """Show the Free Association dialog for step-by-step LLM sequencing.
+
+        Args:
+            clips: List of (Clip, Source) tuples to process
+        """
+        sources_by_id = {source.id: source for clip, source in clips}
+        clip_objects = [clip for clip, source in clips]
+
+        clips_with_desc = [c for c in clip_objects if c.description]
+        if not clips_with_desc:
+            QMessageBox.warning(
+                self,
+                "No Descriptions",
+                "None of the selected clips have descriptions.\n\n"
+                "Run description analysis in the Analyze tab first, "
+                "then return to build a Free Association sequence.",
+            )
+            return
+
+        dialog = FreeAssociationDialog(
+            clips=clips_with_desc,
+            sources_by_id=sources_by_id,
+            project=None,
+            parent=self,
+        )
+        dialog.sequence_ready.connect(self._apply_free_association_sequence)
+        dialog.exec()
+
+    @Slot(list)
+    def _apply_free_association_sequence(self, payload: list):
+        """Apply the sequence from the Free Association dialog.
+
+        The payload is a list of (Clip, Source, Optional[str]) triples — the
+        third element is the LLM-generated rationale for that transition
+        (None for the user-selected first clip). This differs from the
+        generic _apply_dialog_sequence path because that path's timeline
+        pipeline reconstructs SequenceClip internally with no mechanism
+        to thread a rationale parameter through.
+
+        Args:
+            payload: List of (Clip, Source, Optional[str]) tuples in order.
+        """
+        if not payload:
+            logger.warning("No clips in Free Association sequence")
+            return
+
+        # Strip rationales to feed the standard apply path that already
+        # handles timeline clearing, clip addition, fps/video setup, etc.
+        sequence_clips = [(clip, source) for clip, source, _ in payload]
+        try:
+            self._apply_dialog_sequence(
+                sequence_clips, "free_association", "Free Association"
+            )
+        except Exception:
+            logger.exception("Failed to apply Free Association sequence")
+            return
+
+        # Now thread rationales onto the SequenceClips the timeline just
+        # created. Match by (source_clip_id, start_frame) which is unique
+        # for the clips we just placed sequentially in this apply call.
+        sequence = self.timeline.get_sequence()
+        existing_clips = {
+            (sc.source_clip_id, sc.start_frame): sc for sc in sequence.get_all_clips()
+        }
+
+        current_frame = 0
+        attached = 0
+        for clip, _source, rationale in payload:
+            if rationale is not None:
+                key = (clip.id, current_frame)
+                seq_clip = existing_clips.get(key)
+                if seq_clip is not None:
+                    seq_clip.rationale = rationale
+                    attached += 1
+                else:
+                    logger.warning(
+                        "Could not find SequenceClip for (%s, %s) to attach rationale",
+                        clip.id,
+                        current_frame,
+                    )
+            current_frame += clip.duration_frames
+
+        logger.info(
+            "Attached %d rationale(s) to Free Association sequence",
+            attached,
+        )
 
     def _show_reference_guide_dialog(self, clips: list):
         """Show the Reference Guide dialog for reference-guided remixing.
@@ -1607,6 +1698,7 @@ class SequenceTab(BaseTab):
             ),
             "exquisite_corpus": True,  # Always available - dialog handles text extraction
             "storyteller": True,
+            "free_association": True,  # Dialog handles its own prereqs
             "reference_guided": True,  # Dialog handles its own prereqs
             "signature_style": True,  # Dialog handles its own prereqs
             "gaze_sort": (has_gaze, "Run gaze analysis first" if not has_gaze else ""),

--- a/ui/widgets/sorting_card_grid.py
+++ b/ui/widgets/sorting_card_grid.py
@@ -72,7 +72,8 @@ class SortingCardGrid(QWidget):
             "shuffle", "sequential", "duration", "color",
             "brightness", "volume", "shot_type", "proximity",
             "similarity_chain", "match_cut", "exquisite_corpus", "storyteller",
-            "reference_guided", "signature_style", "rose_hobart", "staccato",
+            "free_association", "reference_guided", "signature_style",
+            "rose_hobart", "staccato",
             "gaze_sort", "gaze_consistency", "eyes_without_a_face",
         ]
 

--- a/ui/workers/free_association_worker.py
+++ b/ui/workers/free_association_worker.py
@@ -1,0 +1,86 @@
+"""Single-step LLM proposal worker for the Free Association sequencer.
+
+Each worker instance makes exactly one LLM call to propose the next clip.
+The dialog spawns a fresh worker per proposal, which keeps the lifecycle
+simple: create, start, emit one signal, clean up via deleteLater. This
+avoids the complexity of inter-thread signaling for accept/reject loops.
+
+No worker.wait() on cancellation — litellm.completion is a blocking HTTP
+call that can take up to 120s to return, and waiting would freeze the UI.
+"""
+
+import logging
+from typing import Optional
+
+from PySide6.QtCore import Signal
+
+from core.remix.free_association import propose_next_clip
+from ui.workers.base import CancellableWorker
+
+logger = logging.getLogger(__name__)
+
+
+class FreeAssociationWorker(CancellableWorker):
+    """Run one LLM call to propose the next clip.
+
+    Signals:
+        proposal_ready(str, str): emitted with (clip_short_id, rationale)
+            when the LLM successfully returns a valid proposal.
+        error(str): emitted with a human-readable message when the LLM
+            call fails, returns None/malformed content, or returns a
+            hallucinated/rejected clip ID.
+    """
+
+    proposal_ready = Signal(str, str)  # (clip_short_id, rationale)
+
+    def __init__(
+        self,
+        current_clip_metadata: str,
+        candidate_digests: list[tuple[str, str]],
+        recent_rationales: list[str],
+        rejected_short_ids: list[str],
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self._current_clip_metadata = current_clip_metadata
+        self._candidate_digests = candidate_digests
+        self._recent_rationales = recent_rationales
+        self._rejected_short_ids = rejected_short_ids
+        self._model = model
+        self._temperature = temperature
+
+    def run(self):
+        """Execute the single-step proposal."""
+        self._log_start()
+        try:
+            clip_id, rationale = propose_next_clip(
+                current_clip_metadata=self._current_clip_metadata,
+                candidate_digests=self._candidate_digests,
+                recent_rationales=self._recent_rationales,
+                rejected_short_ids=self._rejected_short_ids,
+                model=self._model,
+                temperature=self._temperature,
+            )
+        except ValueError as exc:
+            # Malformed JSON, None content, hallucinated ID, rejected ID
+            logger.warning("%s: ValueError from propose_next_clip: %s", self.worker_name, exc)
+            if not self.is_cancelled():
+                self.error.emit(str(exc))
+            self._log_complete()
+            return
+        except Exception as exc:  # noqa: BLE001 — network / provider errors
+            # Network timeout, auth failure, provider outage, etc.
+            logger.exception("%s: unexpected error during LLM call", self.worker_name)
+            if not self.is_cancelled():
+                self.error.emit(f"LLM call failed: {exc}")
+            self._log_complete()
+            return
+
+        if self.is_cancelled():
+            self._log_cancelled()
+            return
+
+        self.proposal_ready.emit(clip_id, rationale)
+        self._log_complete()


### PR DESCRIPTION
## Summary

Adds a new sequencer algorithm called **Free Association**. The user picks a first clip, and an LLM proposes each next clip based on clip metadata, providing a rationale for every transition. Accept / Reject / Stop interaction with a running rationale log that persists with the sequence.

This is the first iterative, human-in-the-loop sequencer in the app — all existing LLM sequencers (Storyteller, Exquisite Corpus) operate in batch mode.

## How it works

- **First clip**: user picks from a grid
- **Each next proposal**: LLM reads the current clip's full metadata + compact digests for 12 shortlisted candidates (pre-filtered locally by cosine similarity) + the last 3-5 accepted rationales — ~800 tokens/step regardless of total clip count
- **Accept** adds the clip + rationale to the sequence and triggers the next proposal
- **Reject** asks for a different clip, keeping rejection memory for the current position only
- **Rationales** are stored on `SequenceClip.rationale` and persist through project save/reload

## Design decisions

See the origin documents for full context:
- [`docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md`](docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md)
- [`docs/plans/2026-04-12-001-feat-free-association-sequencer-plan.md`](docs/plans/2026-04-12-001-feat-free-association-sequencer-plan.md)

Highlights:

- **Tiered metadata strategy** keeps per-step prompt cost bounded regardless of clip count. Local shortlisting via cosine similarity absorbs scaling; the LLM never sees more than ~12 candidate digests.
- **Single-step worker per proposal** — each accept/reject spawns a fresh `QThread` worker for the next LLM call. The dialog owns all state; workers are stateless and single-use. Guard flag + `Qt.UniqueConnection` prevent duplicate signal delivery (documented codebase bug pattern).
- **No `worker.wait()` on cancel** — `litellm.completion` is a blocking HTTP call that can take up to 120s. Instead, `worker.finished.connect(worker.deleteLater)` cleans up when the thread exits naturally.
- **None-safe LLM response extraction** follows the `drawing_vlm.py` pattern, not the older `storyteller.py` pattern (which has a latent `AttributeError` on `None` content — a known codebase bug).
- **New `_apply_free_association_sequence` method** preserves rationales through the apply pipeline by setting `rationale` on each `SequenceClip` after the timeline creates it. The existing `_apply_dialog_sequence` reconstructs `SequenceClip` internally and would silently drop the rationale — this was a P0 finding in the plan review.
- **Stop / Close confirmations** trigger only when ≥3 clips are accepted, so a two-clip exploratory session doesn't need a confirm.
- **POOL_EXHAUSTED state** handles the case where every shortlisted candidate has been rejected for the current position; offers End or Reconsider the last rejected clip.

## Test plan

All 6 commits have inline tests. Full breakdown:

- [x] `tests/test_sequence_clip_rationale.py` — 7 tests covering `SequenceClip.rationale` serialization, backward-compatible loading, and a **full project save/load round-trip** that verifies R10 end-to-end
- [x] `tests/test_free_association.py` — 24 tests covering metadata formatters, cosine shortlisting with graceful fallback, LLM proposal with all error paths (None content, malformed JSON, hallucinated IDs, rejected IDs), markdown-fence handling
- [x] `tests/test_free_association_worker.py` — 6 tests covering signal routing for happy path, `ValueError`, network exceptions, and cancellation-suppresses-stale-signals
- [x] `tests/test_free_association_dialog.py` — 18 tests covering dialog initialization, empty pool, accept/reject flows, stop confirmation thresholds, error recovery, apply emission, rationale log lifecycle (accepted only), pool exhaustion, and duplicate-signal suppression
- [x] `tests/test_free_association_integration.py` — 6 tests covering routing, missing-descriptions warning, rationale attachment to SequenceClips at apply time, card availability mapping, and another **end-to-end save/reload** verification through the real `_apply_free_association_sequence` path
- [x] Updated `tests/test_algorithm_config.py` and `tests/test_sorting_card_grid.py` counts to reflect the new algorithm

**Full suite result:** 1833 passed, 2 pre-existing unrelated failures (`test_export_bundle_*` tries to write to a missing USB volume, confirmed on `main`). All 61 Free Association tests pass.

### Smoke test before merging

- [ ] Open a project with clips that have descriptions (and ideally embeddings) in the Analyze tab
- [ ] Go to the Sequence tab, click the 💭 Free Association card
- [ ] Pick a first clip, click Start
- [ ] Accept / reject a few proposals, verify rationales appear in the right-side log
- [ ] Click Stop with 3+ accepted, confirm the dialog, verify sequence lands in the timeline
- [ ] Save the project, reload, verify rationales are still on the sequence clips (e.g., via a tooltip / detail view if available)