### PR TITLE
feat: Add Embeddings as a user-triggerable analysis operation

### DIFF
--- a/core/analysis_availability.py
+++ b/core/analysis_availability.py
@@ -28,6 +28,8 @@ def operation_is_complete_for_clip(op_key: str, clip) -> bool:
         return clip.face_embeddings is not None
     if op_key == "gaze":
         return clip.gaze_category is not None
+    if op_key == "embeddings":
+        return clip.embedding is not None
     if op_key == "custom_query":
         # Each custom query is unique — never auto-skip, always allow rerun
         return False

--- a/core/analysis_operations.py
+++ b/core/analysis_operations.py
@@ -72,6 +72,11 @@ ANALYSIS_OPERATIONS: list[AnalysisOperation] = [
         "sequential", False,
     ),
     AnalysisOperation(
+        "embeddings", "Generate Embeddings",
+        "Extract DINOv2 visual feature vectors for similarity-based sequencing",
+        "sequential", False,
+    ),
+    AnalysisOperation(
         "custom_query", "Custom Query",
         "Search clips for specific visual content using a VLM (e.g., 'blue flower')",
         "cloud", False, cloud_capable=True,

--- a/docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md
+++ b/docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md
@@ -1,0 +1,72 @@
+---
+date: 2026-04-12
+topic: free-association-sequencer
+---
+
+# Free Association Sequencer
+
+## Problem Frame
+
+Scene Ripper's existing sequencers operate on fixed axes — similarity chains use embeddings, storyteller follows narrative arcs, shuffle is random. None let the user leverage the full breadth of clip metadata through an LLM that makes practical, grounded associative decisions one clip at a time. Editors want a sequencer that acts like a knowledgeable collaborator: it sees everything about each clip and proposes connections the editor can accept, reject, or re-roll.
+
+## Requirements
+
+**Core Sequencing**
+- R1. The sequencer accepts a user-selected first clip and iteratively builds a sequence by proposing one next clip at a time.
+- R2. Each proposal is informed by a tiered metadata strategy to keep per-step token cost bounded (~800 tokens input):
+  - **Current clip**: full metadata (description, shot type, dominant colors, brightness, volume, objects, faces, transcript, cinematography, gaze, extracted text).
+  - **Candidate pool**: a shortlist of ~10-15 clips pre-filtered locally using embedding similarity, each represented as a compact metadata digest (~20-30 tokens per clip, e.g., "CU | warm tones | bright | 2 people | outdoor | dialogue | slow pan"). The shortlist is built from structured fields with no LLM cost.
+  - **Sequence history**: a rolling theme summary (~50-100 tokens) updated after each acceptance, not the full metadata of every placed clip.
+- R3. The rolling sequence summary captures motifs, patterns, and variety so the LLM avoids repetitive transitions without needing the full history of every placed clip.
+
+**Rationale**
+- R4. Each proposed clip includes a rationale explaining the metadata-driven connection (e.g., "Both clips share close-up framing with warm dominant colors and similar motion energy").
+- R5. Rationales are displayed in a scrollable side panel log that accumulates as the sequence is built, showing each transition decision.
+
+**Accept / Reject Interaction**
+- R6. The user can accept the proposed clip (it's added to the sequence, LLM proposes the next one) or reject it.
+- R7. On rejection, the LLM proposes a different clip, knowing which clips have been rejected for this position. The user can re-roll as many times as needed.
+- R8. Rejected clips return to the available pool for future positions — they're only excluded from the current position's proposals.
+
+**Completion**
+- R9. Sequencing ends when all clips are placed or the user explicitly stops early.
+- R10. The accumulated rationale log persists with the sequence so it can be reviewed after the dialog is closed.
+
+## Success Criteria
+
+- User can build a full sequence one clip at a time with meaningful, metadata-grounded rationales for each transition.
+- Reject/re-roll produces a different clip with a different rationale.
+- Rationale log is readable and useful as editorial notes.
+
+## Scope Boundaries
+
+- No abstract/poetic mode — rationales are grounded in actual metadata values.
+- No multi-candidate selection (showing ranked alternatives). Single proposal with re-roll.
+- No "regenerate from midpoint" — this is a step-by-step sequencer, not batch-with-rewind.
+- No new metadata fields or analysis types — uses whatever metadata already exists on clips. The compact digest and rolling summary are ephemeral prompt artifacts, not persisted data.
+
+## Key Decisions
+
+- **Step-by-step over one-shot**: Gives the editor creative control at each transition rather than reviewing a fait accompli. More engaging and educational (you learn what metadata connections exist).
+- **Single re-roll over ranked alternatives**: Keeps the UI simple. Showing 3 candidates with rationales would be noisy and slow (3x LLM output per step).
+- **Side panel log over inline card annotations**: Keeps the sequence grid clean while providing full transparency. The log reads like editor's notes.
+- **Tiered metadata over full dump**: The current clip gets full detail, candidates get compact digests, and history is a rolling summary. This keeps per-step cost at ~800 tokens regardless of total clip count — local embedding similarity absorbs the scaling, not the LLM context. The LLM still sees all metadata dimensions for the current clip and can weight what matters per transition.
+- **Local pre-filtering over LLM pool scanning**: Using existing embeddings to shortlist ~10-15 candidates keeps the LLM focused on making a good choice from strong options rather than scanning 100+ clips. This also bounds latency and cost per step.
+
+## Dependencies / Assumptions
+
+- Clips must have at least `description` populated for meaningful associations. Other metadata fields enrich the output but aren't strictly required.
+- Existing LLM infrastructure (`core/llm_client.py`, LiteLLM) handles the model calls. Each LLM response must be validated for None/empty content before parsing — this is a documented codebase bug pattern (existing sequencers don't guard against it). A failed call mid-sequence must not discard the user's accepted clips.
+- Dialog-based sequencer pattern (QDialog + QThread worker) is established by Storyteller and Exquisite Corpus. However, the iterative accept/reject loop is a novel interaction pattern — existing dialogs run to completion in one go. Planning must design a new worker lifecycle (e.g., single-step worker invoked per proposal, not a long-running worker).
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R5, R10][Technical] Whether the rationale log should be a new field on SequenceClip or a separate data structure on the sequence, and its serialization format for project save/load.
+- [Affects R2][Technical] Exact format of the compact metadata digest — which fields to include, field ordering, and how to handle missing metadata gracefully.
+- [Affects R2][Technical] Shortlist size tuning — 10-15 is the starting target, but the right number may depend on how diverse the candidate pool is.
+- [Affects R1][Technical] Worker lifecycle design for the iterative accept/reject loop — single-step worker per proposal vs. long-lived worker with inter-thread signaling.
+
+## Next Steps
+
+-> `/ce:plan` for structured implementation planning

--- a/docs/plans/2026-04-12-001-feat-free-association-sequencer-plan.md
+++ b/docs/plans/2026-04-12-001-feat-free-association-sequencer-plan.md
@@ -1,0 +1,394 @@
+---
+title: "feat: Add Free Association sequencer"
+type: feat
+status: active
+date: 2026-04-12
+deepened: 2026-04-13
+origin: docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md
+---
+
+# feat: Add Free Association sequencer
+
+## Overview
+
+Add a new LLM-powered sequencer algorithm called "Free Association" that builds a clip sequence one transition at a time through an interactive accept/reject dialog. The user selects a first clip, and the LLM proposes each subsequent clip based on clip metadata, providing a rationale for each transition. This is the first iterative, human-in-the-loop sequencer in the app.
+
+## Problem Frame
+
+Scene Ripper has 16 sequencer algorithms, including two LLM-powered ones (Storyteller, Exquisite Corpus), but all operate in batch mode — the user configures and generates a complete sequence at once. Free Association fills a gap: a step-by-step sequencer where the editor collaborates with the LLM one transition at a time, reviewing metadata-grounded rationales for each choice. (see origin: `docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md`)
+
+## Requirements Trace
+
+- R1. User-selected first clip with iterative one-at-a-time proposal
+- R2. Tiered metadata strategy (total ~800 tokens/step): full metadata for current clip, compact digests for 12 shortlisted candidates, last 3-5 rationale entries for sequence context
+- R3. Last 3-5 rationale entries serve as sequence context so the LLM avoids repetitive transitions
+- R4. Each proposal includes a metadata-grounded rationale
+- R5. Scrollable side panel log displaying rationale entries
+- R6. Accept adds clip to sequence and triggers next proposal
+- R7. Reject proposes a different clip with rejection memory per position
+- R8. Rejected clips return to pool for future positions
+- R9. Ends when all clips placed or user stops early
+- R10. Rationale log persists with the sequence via `SequenceClip.rationale` field
+
+## Scope Boundaries
+
+- No abstract/poetic mode — rationales reference actual metadata values
+- No multi-candidate selection — single proposal with re-roll
+- No regenerate-from-midpoint — step-by-step only
+- No new analysis types (the `SequenceClip.rationale` field is added, but no new clip-level metadata)
+- The compact digest and recent-rationales prompt window are ephemeral generation artifacts. The final rationale text for each accepted clip **is** persisted on `SequenceClip.rationale` (see R10).
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `core/remix/storyteller.py` — LLM sequencer pattern: `litellm.completion()`, short ID mapping (c1/c2/...), JSON response parsing, markdown fence stripping
+- `core/remix/exquisite_corpus.py` — Alternative LLM sequencer with same call pattern
+- `core/remix/similarity_chain.py` — `_cosine_distance_matrix()` for embedding similarity, L2-normalized vectors
+- `ui/dialogs/storyteller_dialog.py` — Dialog + QThread worker pattern: `QStackedWidget` pages, `sequence_ready` signal, preview with reorder
+- `ui/algorithm_config.py` — Algorithm registration with `is_dialog: True`, zero-dependency module
+- `ui/tabs/sequence_tab.py` — Dialog routing at `_on_card_clicked()`, `_apply_dialog_sequence()` for applying results
+- `models/sequence.py` — `Sequence` and `SequenceClip` dataclasses with `to_dict`/`from_dict`
+- `ui/workers/base.py` — `CancellableWorker` base class
+- `core/settings.py` — Model/temperature settings pattern (see `exquisite_corpus_model`)
+
+### Institutional Learnings
+
+- **QThread finished signal duplication** (`docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`): Qt `finished` signal can fire twice. Use guard flags + `Qt.UniqueConnection`. Critical for iterative worker pattern.
+- **Sequence overwrite** (`docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md`): Dialog output must write to the same Sequence object the UI reads from. Use `_apply_dialog_sequence()` path.
+- **Algorithm config location** (`docs/solutions/logic-errors/circular-import-config-consolidation.md`): Register in `ui/algorithm_config.py` only, never inline.
+- **Worker ID sync** (`docs/solutions/ui-bugs/pyside6-thumbnail-source-id-mismatch.md`): Worker-created objects must reference existing UI-state IDs.
+- **LLM None responses** (CLAUDE.md): `litellm.completion()` can return None content without exception. Always validate before `.strip()`.
+
+## Key Technical Decisions
+
+- **Single-step worker per proposal over long-lived worker**: Each accept/reject spawns a fresh `QThread` worker for the next LLM call. The dialog maintains all state (sequence, pool, rejections). This avoids inter-thread signaling complexity and follows the guard flag pattern from institutional learnings. Old workers are cleaned up via `worker.finished.connect(worker.deleteLater)`.
+- **Rationale stored on SequenceClip**: Add `rationale: Optional[str] = None` to `SequenceClip`. Co-located with clip data, serializes through existing `to_dict`/`from_dict` pipeline. First clip gets `None` (user-selected).
+- **Recent rationales as sequence context**: Instead of a separate rolling summary, include the last 3-5 rationale entries in each prompt. These already describe transitions and metadata connections. Keeps history at ~150-200 tokens without an extra LLM call.
+- **Local shortlisting via cosine similarity**: Use existing `_cosine_distance_matrix()` pattern from `similarity_chain.py` to pre-filter to 12 candidates closest to the current clip. Caps prompt cost regardless of total clip count.
+- **Short ID mapping**: Map clip UUIDs to `c1, c2, ...` for LLM communication (following Storyteller pattern). Map back on parse.
+- **Pipe-delimited compact digest**: Format each candidate as `"c3: CU | warm tones | bright | 2 people | outdoor | dialogue | slow pan"` — structured fields, no LLM cost to generate, ~20-30 tokens each.
+- **No worker.wait() on early stop**: Cancel sets flag, dialog closes immediately with partial sequence. Worker cleans up via `deleteLater`. Avoids 120s UI freeze from blocking HTTP calls.
+- **New apply method instead of reusing `_apply_dialog_sequence()`**: The existing dialog apply path reconstructs SequenceClip objects internally with no mechanism to carry a rationale field. A new `_apply_free_association_sequence()` method preserves rationale by setting it on the SequenceClip immediately after the timeline creates it. The dialog emits `list[tuple[Clip, Source, Optional[str]]]` (the third element being rationale) to make this explicit in the signal contract.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Rationale storage location**: `SequenceClip.rationale` field — co-located, serializes naturally, no separate data structure needed
+- **Worker lifecycle**: Single-step worker per proposal, dialog owns all state
+- **Token budget strategy**: Tiered metadata (~800 tokens/step) with local shortlisting — scales to any clip count
+- **Sequence history representation**: Last 3-5 rationale entries — no extra LLM call, natural context window
+- **Pool exhaustion**: When every clip in the shortlist for the current position has been rejected (and no other candidates remain in the pool), enter `POOL_EXHAUSTED` state. The dialog shows a page offering "End sequence with clips placed so far" or "Back to previous proposal" (which resurrects the most recently rejected clip and treats it as if proposed again, letting the user reconsider). No "Skip position" — a gap in the sequence has no meaning in this sequencer.
+- **LLM error recovery**: Retry button for current step; sequence built so far is preserved; cancel closes with partial sequence
+- **Stop flow (user-initiated early stop)**: Confirmation dialog if 3+ clips have been accepted ("End sequence with N clips?"). On confirm, transition directly to COMPLETE with partial sequence preserved. Skip confirmation if 0-2 clips accepted (low-cost to start over).
+- **Rationale log behavior**: Only accepted transitions appear in the log. Rejected proposals never enter the log — the log is the record of the final sequence, not the exploration path. Log is not cleared when the dialog errors and recovers.
+- **Rationale preservation through apply pipeline**: `_apply_dialog_sequence()` does not propagate custom SequenceClip fields (it reconstructs clips). Free Association uses a new apply method that sets `rationale` on each created SequenceClip after the timeline creates it (see Unit 5).
+- **Rejection history in prompt**: Include rejected short IDs with instruction to avoid them
+
+### Deferred to Implementation
+
+- **Exact prompt wording**: System prompt and user prompt templates will be tuned during implementation based on LLM output quality
+- **Shortlist size tuning**: Starting at 12, may adjust based on diversity of proposals
+- **Compact digest field ordering**: Which fields to prioritize when not all metadata is available
+- **Model/temperature defaults**: Will match existing sequencer settings pattern but specific defaults TBD
+- **Rationale-lookup mechanism in `_apply_free_association_sequence()`**: Prefer extending `timeline_widget.add_clip()` to return the created `SequenceClip` (cleaner). Fall back to matching by `source_clip_id` on `sequence.get_all_clips()` if the timeline API change is invasive. Decide when touching the code.
+- **Shortlisting diversity vs similarity**: Pure cosine similarity may pre-filter too narrowly for true "free association." If early testing shows homogeneous proposals, consider a hybrid shortlist (e.g., 6 most similar + 6 random from remaining pool). Start pure, adjust after validation.
+- **Cross-position rejection cooldown**: The current design only remembers rejections within the current position. If testing shows rejected clips cycling back immediately at the next position and annoying users, add a short cooldown (last 2-3 positions).
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Dialog
+    participant Worker
+    participant LLM
+    participant Pool as Candidate Pool
+
+    User->>Dialog: Select first clip
+    Dialog->>Dialog: Add to sequence, update pool
+
+    loop For each position
+        Dialog->>Pool: Shortlist 12 candidates (cosine similarity)
+        Dialog->>Worker: Spawn single-step worker
+        Worker->>LLM: Send prompt (current clip + digests + recent rationales + rejected IDs)
+        LLM-->>Worker: Response (clip_id + rationale)
+        Worker-->>Dialog: proposal_ready signal
+
+        alt User accepts
+            Dialog->>Dialog: Add clip to sequence, log rationale
+        else User rejects
+            Dialog->>Dialog: Add to rejection set for this position
+            Note over Dialog: Spawn new worker with updated rejection list
+        else Pool exhausted for position
+            Dialog->>User: Skip position / End sequence
+        end
+    end
+
+    Dialog->>Dialog: Emit sequence_ready with SequenceClips (rationales attached)
+```
+
+**State machine for the dialog:**
+- `FIRST_CLIP_SELECT` → user picks first clip + clicks Start → `LOADING`
+- `LOADING` → worker emits `proposal_ready` → `PROPOSAL` / worker emits `error` → `ERROR` / user clicks Stop → `COMPLETE` (partial)
+- `PROPOSAL` → Accept → `LOADING` (next position) / Reject → `LOADING` (same position, new candidate) / Stop → confirmation if ≥3 clips → `COMPLETE` (partial)
+- `LOADING` (after reject when shortlist-minus-rejected is empty) → `POOL_EXHAUSTED`
+- `POOL_EXHAUSTED` → End sequence → `COMPLETE` / Reconsider last rejected → `PROPOSAL` (with resurrected clip)
+- `ERROR` → Retry → `LOADING` (same position) / Cancel → `COMPLETE` (partial, clips so far preserved)
+- `COMPLETE` → Apply → emit `sequence_ready`, dialog closes / Close → discard (confirmation if ≥3 clips)
+
+**COMPLETE vs POOL_EXHAUSTED distinction:**
+- `COMPLETE` is a terminal state entered deliberately: all clips placed (pool empty via acceptance), user chose to stop early, or error recovery cancel.
+- `POOL_EXHAUSTED` is a transient state entered when no unrejected candidates remain at the current position; the user resolves it (end or reconsider) and the flow continues.
+
+## Implementation Units
+
+- [ ] **Unit 1: Data model and algorithm registration**
+
+  **Goal:** Add `SequenceClip.rationale` field (new persistent field, the first generic metadata string on SequenceClip) and register Free Association in `ALGORITHM_CONFIG`.
+
+  **Requirements:** R10 (persistence)
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `models/sequence.py` — add `rationale` field to `SequenceClip`
+  - Modify: `ui/algorithm_config.py` — add `free_association` entry
+  - Test: `tests/test_sequence_model.py` — field persistence + project round-trip
+
+  **Approach:**
+  - **Data model change (explicit call-out)**: Add `rationale: Optional[str] = None` to the `SequenceClip` dataclass. This is the first SequenceClip field intended for free-form human/LLM text, so ensure it does not break existing equality, hashing, or repr expectations in tests.
+  - Update `to_dict()` to include `rationale` when non-None (skip when None to keep serialized size small and backward-compatible).
+  - Update `from_dict()` to read `rationale` with `None` default (old projects without the key load cleanly).
+  - Verify the field survives through the full save/load chain: `SequenceClip` → `Track.to_dict()` → `Sequence.to_dict()` → `Project` save → load back. No intermediate layer should cherry-pick fields.
+  - Add `"free_association"` entry to `ALGORITHM_CONFIG` with `is_dialog: True`, appropriate icon, label, description, `categories`, and `required_analysis: ["describe"]` (embeddings are *not* required — the core module falls back to random sampling when embeddings are missing, so gating on embeddings would contradict the graceful degradation design in Unit 2).
+
+  **Patterns to follow:**
+  - Existing optional fields on `SequenceClip` (e.g., `prerendered_path`)
+  - Existing dialog algorithm entries in `ALGORITHM_CONFIG` (Storyteller, Exquisite Corpus)
+
+  **Test scenarios:**
+  - Happy path: SequenceClip with rationale serializes to dict and deserializes back with rationale preserved
+  - Happy path: SequenceClip without rationale serializes without rationale key (backward-compatible)
+  - Edge case: `from_dict` on old data (no rationale key) returns SequenceClip with `rationale=None`
+  - Integration: Full project round-trip — create a Sequence with a SequenceClip carrying a rationale, save project to disk, load back, verify rationale text survives intact. Catches any serialization layer that drops unknown fields.
+  - Happy path: `get_algorithm_config("free_association")` returns valid config with `is_dialog: True` and `required_analysis: ["describe"]`
+
+  **Verification:**
+  - Existing project save/load tests still pass (backward compatibility)
+  - New algorithm appears in `ALGORITHM_CONFIG` and returns correct config
+  - Rationale text survives a full project save/load round-trip
+
+- [ ] **Unit 2: Core algorithm module**
+
+  **Goal:** Implement metadata formatting, candidate shortlisting, and LLM proposal logic.
+
+  **Requirements:** R2, R3, R4, R7
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `core/remix/free_association.py`
+  - Test: `tests/test_free_association.py`
+
+  **Approach:**
+  - `format_clip_digest(clip: Clip) -> str` — Pipe-delimited compact summary from structured fields (shot_type, color descriptor from dominant_colors, brightness descriptor, person_count, object labels, transcript keywords, camera motion from cinematography). Omit missing fields gracefully.
+  - `format_clip_full_metadata(clip: Clip) -> str` — Richer text block for the current clip: description, shot type, colors, brightness, volume, objects, faces, transcript excerpt, cinematography, gaze, extracted text.
+  - `shortlist_candidates(current_clip: Clip, pool: list[tuple[Clip, Source]], k: int = 12) -> list[tuple[Clip, Source]]` — Compute cosine similarity using the same L2-normalized dot-product pattern from `similarity_chain.py`. Return top-k most similar candidates. Fall back to random sample if embeddings are missing.
+  - `propose_next_clip(current_clip_metadata: str, candidate_digests: list[tuple[str, str]], recent_rationales: list[str], rejected_ids: list[str], model: str, temperature: float) -> tuple[str, str]` — Build prompt, call `litellm.completion()`, parse JSON response for `(clip_short_id, rationale)`. **Critical: do NOT follow `storyteller.py`'s response extraction pattern** — it calls `response.choices[0].message.content.strip()` without a None check, which crashes with `AttributeError` when the LLM returns None content (a documented codebase bug pattern). Instead follow `core/remix/drawing_vlm.py`: extract content first, validate for None/empty, then strip. Raise `ValueError("LLM returned no content")` on None. Use short ID mapping (c1, c2, ...) following Storyteller's ID pattern. Strip markdown fences before JSON parse. Validate returned short ID is in the candidate set (reject hallucinated IDs).
+  - `build_id_mapping(candidates: list[tuple[Clip, Source]]) -> tuple[dict[str, str], dict[str, str]]` — Map between UUIDs and short IDs.
+
+  **Patterns to follow:**
+  - `core/remix/storyteller.py` — `litellm.completion()` call setup, short ID mapping, JSON parsing, model prefix normalization. **Do NOT copy its response extraction** (missing None guard).
+  - `core/remix/drawing_vlm.py` — Correct response extraction pattern: extract `.content`, None-check, then process.
+  - `core/remix/similarity_chain.py` — cosine similarity computation (L2-normalized dot product)
+
+  **Test scenarios:**
+  - Happy path: `format_clip_digest` with fully populated clip produces pipe-delimited string with all fields
+  - Edge case: `format_clip_digest` with clip missing most metadata produces short but valid string (only description)
+  - Edge case: `format_clip_digest` with clip having no metadata at all returns minimal placeholder
+  - Happy path: `shortlist_candidates` with 50 clips and valid embeddings returns top 12 by similarity
+  - Edge case: `shortlist_candidates` with clips missing embeddings falls back to random sample of k
+  - Edge case: `shortlist_candidates` with fewer clips than k returns all clips
+  - Happy path: `propose_next_clip` with mocked `litellm.completion` returning valid JSON extracts clip ID and rationale
+  - Error path: `propose_next_clip` with mocked `litellm.completion` returning None content raises ValueError with clear message
+  - Error path: `propose_next_clip` with mocked `litellm.completion` returning malformed JSON raises ValueError
+  - Happy path: `build_id_mapping` creates bidirectional short ID ↔ UUID mapping
+  - Happy path: short ID mapping round-trips — UUID → short ID → UUID
+
+  **Verification:**
+  - All formatting functions handle missing metadata without crashing
+  - Shortlisting respects k parameter and embedding similarity ordering
+  - LLM call uses short IDs and maps back correctly
+  - None/malformed response raises clear errors
+
+- [ ] **Unit 3: Single-step worker**
+
+  **Goal:** Create a QThread worker that executes one LLM proposal call per invocation.
+
+  **Requirements:** R1, R6, R7
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Create: `ui/workers/free_association_worker.py`
+  - Test: `tests/test_free_association_worker.py`
+
+  **Approach:**
+  - Extend `CancellableWorker` from `ui/workers/base.py`
+  - Constructor receives: current clip metadata (str), candidate digests (list), recent rationales (list), rejected IDs (list), model, temperature
+  - `run()` calls `propose_next_clip()` from the core module
+  - Emits `proposal_ready(str, str)` signal with (clip_short_id, rationale) on success
+  - Emits `error(str)` signal with message on failure (catches ValueError from None/malformed response, litellm exceptions)
+  - Uses `_cancelled` flag from base class — checks after LLM call returns
+  - Each instance is single-use: created, started, emits one result, then cleaned up via `deleteLater`
+
+  **Patterns to follow:**
+  - `ui/workers/base.py` — `CancellableWorker` interface (provides thread-safe cancellation via `threading.Event`)
+  - `ui/dialogs/storyteller_dialog.py` — Worker signal connection pattern with `Qt.UniqueConnection`. Note: `StorytellerWorker` extends `QThread` directly with a bare `_cancelled` flag — this worker should extend `CancellableWorker` instead, which is the correct base class for new workers.
+
+  **Test scenarios:**
+  - Happy path: Worker with mocked `propose_next_clip` emits `proposal_ready` with correct clip ID and rationale
+  - Error path: Worker with `propose_next_clip` raising ValueError emits `error` signal with message
+  - Error path: Worker with `propose_next_clip` raising network exception emits `error` signal
+  - Edge case: Worker cancelled before LLM call completes does not emit `proposal_ready`
+
+  **Verification:**
+  - Worker never crashes — all exceptions caught and routed to `error` signal
+  - Single-use lifecycle: one invocation, one signal, then cleanup
+
+- [ ] **Unit 4: Dialog UI**
+
+  **Goal:** Build the interactive dialog with first-clip selection, proposal display, accept/reject controls, and rationale log panel.
+
+  **Requirements:** R1, R5, R6, R7, R8, R9, R10
+
+  **Dependencies:** Unit 1, Unit 2, Unit 3
+
+  **Files:**
+  - Create: `ui/dialogs/free_association_dialog.py`
+  - Test: `tests/test_free_association_dialog.py`
+
+  **Approach:**
+  - `QDialog` subclass with `sequence_ready = Signal(list)` emitting `list[tuple[Clip, Source]]`
+  - Constructor: `(clips, sources_by_id, project, parent=None)`
+  - **Layout**: Two-column — left side has the main interaction area (stacked widget), right side has the scrollable rationale log panel. Minimum dialog width: wide enough for two columns (~900px). The log panel takes ~30% of width.
+  - **Pages** via `QStackedWidget`:
+    - `FIRST_CLIP_SELECT`: Fixed grid view of available clips with thumbnails (no list/grid toggle — keep it simple). User single-clicks to select (visual highlight), then clicks a **Start** button to confirm. No double-click-to-start (too easy to trigger accidentally). If the clip pool is empty at dialog open time, show a message "No clips available — add clips in the Cut tab first" with a Close button (no Start).
+    - `LOADING`: Spinner + status label below: "Finding clip for position N of the sequence…" (position number makes progress legible). A **Stop** button is visible (same behavior as stopping from PROPOSAL). No position total is shown — this is an open-ended sequence.
+    - `PROPOSAL`: Shows proposed clip (thumbnail, name, key metadata from digest) with rationale text. **Accept** and **Reject** buttons enabled. **Stop** button also visible to end the sequence early.
+    - `ERROR`: Error message with **Retry** and **Cancel** buttons. Sequence built so far is preserved on either action. Cancel routes to COMPLETE with partial sequence.
+    - `POOL_EXHAUSTED`: Message "All remaining candidates for this position have been rejected." Two buttons: **End sequence** (routes to COMPLETE with partial sequence) and **Reconsider last rejected** (resurrects the most recently rejected clip and re-enters PROPOSAL with it). No "Skip position" — gaps have no meaning here.
+    - `COMPLETE`: Summary content: count of accepted clips, total approximate duration (sum of clip durations), and a scrollable list of accepted clip names in sequence order. **Apply** button commits the sequence (emits `sequence_ready`). **Close** discards the session without applying — confirmation required if 3+ clips were accepted ("Discard sequence with N clips?").
+  - **Rationale log panel**: `QListWidget` (read-only) on the right side. Each entry: position number + clip name + rationale text (multiline, word-wrapped). Auto-scrolls to latest on new entry. **Only accepted transitions appear in the log** — rejected proposals never enter the log. The log is the record of the final sequence, not the exploration path. The log is not cleared during ERROR/recovery. During FIRST_CLIP_SELECT the panel shows a placeholder "Proposals and rationales will appear here."
+  - **Dialog state** (owned by dialog, not worker):
+    - `sequence_built: list[tuple[Clip, Source]]` — accepted clips in order
+    - `rationales: list[str]` — parallel list of rationale strings
+    - `available_pool: list[tuple[Clip, Source]]` — remaining candidates
+    - `rejected_for_position: set[str]` — clip IDs rejected for current position, cleared on accept or skip
+  - **Accept flow**: Add proposed clip to `sequence_built`, add rationale to `rationales`, remove clip from `available_pool`, clear `rejected_for_position`, shortlist from updated pool, append entry to rationale log, spawn new worker.
+  - **Reject flow**: Add proposed clip ID to `rejected_for_position`, **do not touch the rationale log** (rejected proposals never enter it), re-shortlist excluding rejected IDs, spawn new worker with updated rejection list.
+  - **Pool exhaustion**: When shortlisting returns zero unrejected candidates for the current position, transition to POOL_EXHAUSTED page. The most recently rejected clip ID is stashed so "Reconsider last rejected" can resurrect it.
+  - **Early stop flow**: "Stop" button visible during LOADING and PROPOSAL pages. On click, if `len(sequence_built) >= 3`, show a confirmation dialog "End sequence with N clips?". On confirm (or if fewer than 3 clips), call `worker.cancel()` (no `worker.wait()`), transition to COMPLETE with partial sequence. Worker cleans up via `deleteLater`.
+  - **Finish / Apply**: When the user clicks Apply on COMPLETE, emit `sequence_ready` with a payload of `list[tuple[Clip, Source, Optional[str]]]` — the third tuple element is the rationale for that clip (None for the first/user-selected clip). This three-tuple signature allows the sequence tab to set `rationale` on each SequenceClip after the timeline creates it (see Unit 5 for the apply mechanism). Do not emit pre-built SequenceClip objects — the existing timeline pipeline reconstructs clips internally, and sending pre-built ones would be confusing.
+  - **Worker lifecycle**: Guard flag (`_proposal_handled = False`) on `_on_proposal_ready`, reset before spawning new worker. Connect with `Qt.UniqueConnection`. **IMPORTANT: Do not follow `storyteller_dialog.py`'s `_on_cancel`/`closeEvent` pattern of calling `worker.wait()`** — that blocks the UI thread for the duration of the in-flight HTTP call (up to 120s). Instead, call `worker.cancel()` and use `worker.finished.connect(worker.deleteLater)` for cleanup. Close the dialog immediately with the partial sequence.
+
+  **Patterns to follow:**
+  - `ui/dialogs/storyteller_dialog.py` — Dialog structure, signal emission, worker management, `QStackedWidget` pages
+  - `ui/dialogs/exquisite_corpus_dialog.py` — Alternative dialog pattern
+
+  **Test scenarios:**
+  - Happy path: Dialog initializes with clips, shows FIRST_CLIP_SELECT page
+  - Happy path: Selecting first clip + clicking Start transitions to LOADING, then PROPOSAL when worker completes
+  - Edge case: Empty clip pool at dialog open shows empty-state message with Close button, no Start button
+  - Happy path: Accepting proposal adds clip to sequence, appends rationale entry to log, transitions to LOADING for next
+  - Happy path: Rejecting proposal adds clip to rejection set, does NOT append to log, spawns new worker for same position
+  - Happy path: Completing full sequence (pool empty via acceptance) transitions to COMPLETE; Apply emits `sequence_ready` with correct three-tuple payload including rationales
+  - Happy path: First clip in emitted payload has `rationale=None` (user-selected)
+  - Edge case: Early stop with 1-2 clips accepted skips confirmation, goes directly to COMPLETE
+  - Edge case: Early stop with 3+ clips accepted shows confirmation dialog; cancel keeps session, confirm goes to COMPLETE
+  - Edge case: Pool exhaustion (all shortlisted rejected) transitions to POOL_EXHAUSTED page; End sequence → COMPLETE; Reconsider last rejected → PROPOSAL with resurrected clip
+  - Error path: Worker emits `error`, transitions to ERROR page; Retry spawns new worker; Cancel routes to COMPLETE with clips so far preserved
+  - Edge case: Multiple rapid rejects during LOADING don't create duplicate workers (guard flag + button disabled during LOADING)
+  - Edge case: Dialog Close on COMPLETE with 3+ accepted clips shows "Discard sequence?" confirmation
+  - Integration: Rationale log accumulates only accepted transitions in order, scrolls to latest
+  - Integration: Log is preserved across ERROR → Retry cycle (not cleared)
+
+  **Verification:**
+  - Dialog never discards accepted clips on error — partial sequence is always recoverable
+  - Accept/Reject buttons disabled during LOADING — no race conditions
+  - Rationale log shows all transitions in order
+  - SequenceClips emitted have `rationale` field populated
+
+- [ ] **Unit 5: Sequence tab integration with rationale-preserving apply path**
+
+  **Goal:** Wire the Free Association dialog into the sequence tab's algorithm routing and implement a new apply method that preserves per-clip rationales (which the existing `_apply_dialog_sequence()` cannot do).
+
+  **Requirements:** R1, R9, R10
+
+  **Dependencies:** Unit 4
+
+  **Files:**
+  - Modify: `ui/tabs/sequence_tab.py` — routing, new apply method, card availability mapping
+  - Test: `tests/test_sequence_tab.py`
+
+  **Approach:**
+  - **Why a new apply method is needed (critical design constraint)**: `_apply_dialog_sequence()` iterates over `(Clip, Source)` tuples and calls `self.timeline.add_clip(clip, source, ...)`. That path internally constructs a fresh `SequenceClip` inside `timeline_scene.add_clip_to_track()` with only the fields it knows about (source_clip_id, source_id, track_index, start_frame, in_point, out_point). It has no mechanism to thread a `rationale` parameter through, so any SequenceClip built by the dialog would be discarded in favor of a freshly-reconstructed one without rationale. R10 would silently fail.
+  - **Apply mechanism**: Add `_apply_free_association_sequence(payload: list[tuple[Clip, Source, Optional[str]]])`. For each entry, call `self.timeline.add_clip(clip, source, ...)` as the existing path does, then **look up the just-created `SequenceClip` in the Sequence and set `rationale`**. Options for the lookup:
+    - (a) If `timeline_scene.add_clip_to_track()` returns the created `SequenceClip`, extend `timeline_widget.add_clip()` to return it as well, then set `.rationale` on the returned object.
+    - (b) After `add_clip`, iterate `sequence.get_all_clips()` to find the newest entry matching `source_clip_id` and set `.rationale`.
+    - Prefer (a) — cleaner, single object reference. Fall back to (b) if (a) requires invasive changes to the timeline widget API. Document the choice at implementation time under `Deferred to Implementation`.
+  - After applying all clips, set `sequence.algorithm = "free_association"` so the sequence is tracked.
+  - **Routing in `_on_card_clicked()`**: Add `free_association` to the `is_dialog` branch. Open dialog, connect `sequence_ready` to `_apply_free_association_sequence()`.
+  - **Routing in `_on_confirm_generate()`**: `sequence_tab.py` has a second dialog-routing if-chain around line 502. Dialog-based algorithms with `is_dialog: True` bypass the cost confirmation gate via the early return in `_on_card_clicked` (line 639), so `_on_confirm_generate` is not reached for Free Association. Verify this assumption by tracing the control flow during implementation; if it is reachable, add routing there as well.
+  - **Card availability mapping**: `sequence_tab.py` has a hand-maintained availability dict in `_update_card_availability()` (around line 1587) that does NOT auto-derive from `ALGORITHM_CONFIG`. Add a `free_association` entry following the Storyteller pattern (dialog handles its own prerequisite checks, so the card can be unconditionally available when there are clips available). Without this entry the card will not appear or will be silently disabled.
+
+  **Patterns to follow:**
+  - `ui/tabs/sequence_tab.py` — Existing `_show_storyteller_dialog()` routing pattern, existing `_update_card_availability()` availability dict pattern
+  - Existing `_apply_dialog_sequence()` for the iteration shape (but not the full logic — the new method must preserve rationale)
+
+  **Test scenarios:**
+  - Happy path: Clicking Free Association card in sequence tab opens the dialog
+  - Happy path: Dialog `sequence_ready` signal applies clips to the timeline with each SequenceClip's `rationale` populated from the payload
+  - Integration: Sequence object has `algorithm="free_association"` after dialog completes
+  - Integration: After apply + project save + reload, rationales survive on each SequenceClip (this is the end-to-end R10 verification)
+  - Happy path: First clip in the applied sequence has `rationale=None` (user-selected, no LLM rationale)
+  - Edge case: Dialog cancelled (no `sequence_ready` emitted) leaves sequence tab unchanged
+  - Edge case: Partial sequence (user stopped early) applies the accepted N clips with correct rationales
+  - Happy path: Free Association card appears in the algorithm grid with correct availability state
+
+  **Verification:**
+  - Free Association appears in the sequence tab algorithm grid
+  - Completing the dialog populates the timeline with clips in the expected order and rationales attached to each SequenceClip
+  - Rationale text appears on the SequenceClip objects both in memory and after save/reload
+  - Sequence overwrite pattern is avoided — the new apply method still writes to the correct (single-source-of-truth) Sequence object
+
+## System-Wide Impact
+
+- **Interaction graph:** Dialog emits `sequence_ready` → sequence tab applies via `_apply_dialog_sequence()` → timeline widget updates. Same path as Storyteller/Exquisite Corpus. No new callbacks or middleware.
+- **Error propagation:** LLM errors caught in worker, routed to dialog via `error` signal. Dialog shows retry UI. No error reaches sequence tab or main window.
+- **State lifecycle risks:** Single-step worker pattern avoids long-lived thread state. Dialog owns all mutable state. Worker is stateless and single-use. Guard flags prevent duplicate signal delivery.
+- **API surface parity:** No CLI or MCP server changes needed — this is a UI-only sequencer. Agent tool integration (adding "free_association" to `generate_sequence` tool) is out of scope for this plan.
+- **Unchanged invariants:** Existing sequencers unaffected. `SequenceClip.rationale` defaults to `None` — no change to existing serialization. `_apply_dialog_sequence()` interface unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| LLM proposes clip not in candidate list (hallucinated ID) | Validate proposed short ID against the candidates sent. Treat as error and auto-retry once before showing error UI. |
+| LLM re-proposes rejected clip despite instructions | Validate proposed ID against `rejected_for_position` set. Auto-retry with stronger prompt emphasis. |
+| Latency per step feels slow (3-10s) | Loading state with progress indicator. Compact prompt (~800 tokens) keeps call fast. Can tune model choice for speed. |
+| Cost accumulation over many steps | `required_analysis` gate ensures clips have metadata before starting. LLM call cost is bounded by tiered prompt. Consider adding step count display (e.g., "Step 12 of 47"). |
+| Embedding quality varies (CLIP vs DINOv2) | `shortlist_candidates` falls back to random sample when embeddings are missing. Digests still give LLM enough to make reasonable choices. |
+| Cosine similarity pre-filter narrows "free association" creatively | Start pure; if early use shows homogeneous proposals, switch to hybrid (6 similar + 6 random). Tracked as deferred implementation decision. |
+| LLM hallucinates clip ID not in candidate set | Validate short ID against sent candidates; auto-retry once with stronger prompt; show error UI if two attempts fail. |
+| Rationale silently dropped at apply time | New `_apply_free_association_sequence()` sets rationale on each SequenceClip immediately after timeline creation. Integration test verifies end-to-end R10 via save/reload. |
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md](docs/brainstorms/2026-04-12-free-association-sequencer-requirements.md)
+- Related code: `core/remix/storyteller.py`, `core/remix/similarity_chain.py`, `ui/dialogs/storyteller_dialog.py`
+- Institutional learnings: `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`, `docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md`, `docs/solutions/logic-errors/circular-import-config-consolidation.md`

--- a/docs/plans/2026-04-13-001-feat-embeddings-analysis-operation-plan.md
+++ b/docs/plans/2026-04-13-001-feat-embeddings-analysis-operation-plan.md
@@ -1,0 +1,245 @@
+---
+title: "feat: Add Embeddings as a user-triggerable analysis operation"
+type: feat
+status: active
+date: 2026-04-13
+deepened: 2026-04-13
+---
+
+# feat: Add Embeddings as a user-triggerable analysis operation
+
+## Overview
+
+Add **Generate Embeddings** as a first-class checkbox in the Analyze tab's analysis picker dialog, alongside other operations like Extract Colors / Classify Shots / Detect Gaze. Embeddings already exist as a Clip field and are auto-computed as a side effect of running similarity_chain or staccato — but there is no UI affordance to compute them directly. This makes the new Free Association sequencer (which uses embeddings for local candidate shortlisting) harder to get good results from on a fresh project.
+
+## Problem Frame
+
+Embeddings (DINOv2 visual vectors, 768-dim) are a building block used by multiple sequencers — similarity_chain, staccato, the new free_association — and by reference_guided's embedding dimension. Today, getting them onto your clips requires running one of those sequencers, which has visible side effects (you get an unwanted sequence). Several other analysis operations follow the same shape (run an extractor, write back to the Clip, persist) and are already exposed as checkboxes via `core/analysis_operations.py`. Embeddings is the conspicuous missing entry. Adding it requires no new infrastructure — just registration, a worker, and a dispatch entry.
+
+## Requirements Trace
+
+- R1. The analysis picker dialog shows a "Generate Embeddings" checkbox in the appropriate phase group.
+- R2. Selecting the checkbox and running analysis populates `clip.embedding` and `clip.embedding_model` for clips that don't already have embeddings.
+- R3. Already-computed embeddings are skipped (no redundant work).
+- R4. The operation respects cancellation — partial results persist on cancel (mutate-in-place pattern, mirroring gaze).
+- R5. The dependency check (torch + transformers) prompts the user to install if missing, using the existing feature registry pattern.
+- R6. Embeddings are persisted via the existing `Clip.to_dict`/`from_dict` path (no schema change needed).
+- R7. The auto-compute path used by similarity_chain / staccato / free_association continues to work as a fallback when the user hasn't explicitly run embeddings.
+
+## Scope Boundaries
+
+- **No** boundary embeddings (`first_frame_embedding` / `last_frame_embedding`) — those are computed only by match_cut via `extract_boundary_embeddings`, on a different code path. Adding them would be a separate operation.
+- **No** model selection UI — DINOv2 is the hardcoded default and there's no existing setting for picking CLIP vs DINOv2.
+- **No** GPU/MPS device selector — torch handles device automatically; existing `core/analysis/embeddings.py` doesn't expose this.
+- **No** new Clip schema fields — `embedding` and `embedding_model` already exist.
+- **No** changes to cost estimation infrastructure — `TIME_PER_CLIP`, `OPERATION_LABELS`, `METADATA_CHECKS`, and `local_model_parallelism` for embeddings are already wired.
+- **No** changes to the existing `_auto_compute_embeddings` fallback path — it already checks `clip.embedding is None` so it becomes a no-op when the user has run embeddings explicitly.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `core/analysis_operations.py` — `AnalysisOperation` dataclass and the `ANALYSIS_OPERATIONS` registry. Phase one of: `local | sequential | cloud`. Embeddings should be `sequential` (model load/unload lifecycle, not parallelizable across processes).
+- `ui/workers/gaze_worker.py` — closest reference pattern. Extends `CancellableWorker`, signals `progress(int, int)`, `<op>_ready(...)`, `<op>_completed()`, plus inherited `error(str)` and `finished()`. Mutates clips in place.
+- `core/analysis/embeddings.py` — `extract_clip_embeddings_batch(thumbnail_paths) -> list[list[float]]`, `is_model_loaded()`, `unload_model()`, model tag `"dinov2-vit-b-14"`.
+- `core/remix/__init__.py:473` — `_auto_compute_embeddings(clips)` — the synchronous fallback. Shows the exact "skip already-computed" + "call batch function" + "assign back" pattern. Worker should mirror this logic.
+- `ui/main_window.py:3280` — `_launch_analysis_worker(op_key, clips)` if/elif chain. Add `elif op_key == "embeddings":` branch and a `_launch_embeddings_worker(clips)` method modeled after `_launch_gaze_worker` (line 3399).
+- `ui/main_window.py:3688` — `_on_pipeline_gaze_finished` shows the guard-flag + `_on_analysis_phase_worker_finished(op_key)` completion handler pattern. Mirror it for embeddings.
+- `core/cost_estimates.py` — already has all four entries for embeddings (TIME_PER_CLIP, OPERATION_LABELS, METADATA_CHECKS, parallelism). No changes needed.
+- `core/feature_registry.py` — `FEATURE_DEPS["embeddings"]` already declares `torch + transformers`, ~450 MB. The dialog flow at `ui/dialogs/reference_guide_dialog.py:437` shows the install-prompt pattern.
+
+### Institutional Learnings
+
+- `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md` — Qt's `finished` signal can be delivered twice. Use a guard flag (`self._embeddings_finished_handled = False`) plus `Qt.UniqueConnection` on the completion signal. This is the same pattern already used by gaze (`_gaze_finished_handled`) and other workers in `main_window.py`.
+
+## Key Technical Decisions
+
+- **Phase = `"sequential"`**: Matches gaze. The DINOv2 model is loaded once into memory and reused across all clips in a batch — running this in parallel with other model-loading operations would compete for GPU/RAM. Sequential phase ensures it runs alone in its slot.
+- **Default enabled = `False`**: Heavy optional dependency (~450 MB). Users opt in. Matches the convention for other heavy operations like `face_embeddings` and `gaze`.
+- **Operation key = `"embeddings"`**: Matches the key already used by `METADATA_CHECKS`, `FEATURE_DEPS`, `TIME_PER_CLIP`, and `algorithm_config.py`'s `required_analysis: ["embeddings"]` references. Reusing the existing key avoids any ripple changes.
+- **Batch processing inside the worker**: `extract_clip_embeddings_batch` already batches internally (size 32). For UX, the worker chunks the input into windows of N (default 16) so progress can update mid-job and cancellation is checked between chunks. The chunk size is a tradeoff between overhead (small chunks = repeated model warm-up signals) and responsiveness; 16 keeps progress visible without much overhead since the model stays loaded.
+- **Skip-existing default = `True`**: Match gaze. Re-run requires either the user clearing the field manually or a separate "force regenerate" affordance (out of scope). The auto-compute path uses the same skip logic, so they stay consistent.
+- **Mutate clips in place**: Same pattern as every other analysis worker. Partial results survive cancellation.
+- **Fail soft on missing thumbnails**: Skip clips without `thumbnail_path` and log a warning, rather than aborting the whole run. Matches the auto-compute path.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Where to insert the operation in the picker order**: After `face_embeddings` and `gaze` (the other heavy sequential ML operations). Keeps related operations grouped.
+- **Should we expose the chunk size as a setting?** No — it's an implementation tuning parameter, not a user-facing concern. Hardcode at 16 with a module-level constant for easy adjustment.
+- **Should we handle cases where the model is already loaded from a previous run?** Yes — `is_model_loaded()` exists for this. Skip the load if true; only unload at the end if we loaded it.
+- **Cost confirmation gate**: All three phases (`local`, `sequential`, `cloud`) pass through the same cost-estimation code path — the phase only affects ordering/parallelism, not whether the cost gate runs. Verify during implementation that the gate displays the embeddings line correctly using the existing `OPERATION_LABELS["embeddings"]` and `TIME_PER_CLIP["embeddings"]` entries.
+
+### Deferred to Implementation
+
+- **Exact wording of the tooltip and label**: Draft "Generate Embeddings" / "Extract DINOv2 visual feature vectors for similarity-based sequencing". Adjust if it reads awkwardly next to other operations.
+- **Whether to emit a per-batch or per-clip `embedding_ready` signal**: Per-clip is more uniform with other workers but requires the worker to map batch outputs back to individual clips (already done — same logic as `_auto_compute_embeddings`). Per-batch is simpler. Decide based on whether any UI consumer needs per-clip notification (no current consumer does, but a future "thumbnails go green when analyzed" UI would).
+
+## Implementation Units
+
+- [ ] **Unit 1: Register embeddings in the analysis operations catalog**
+
+  **Goal:** Add the operation entry so it appears in the analysis picker.
+
+  **Requirements:** R1
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `core/analysis_operations.py`
+  - Test: `tests/test_analysis_operations.py` (extend if it exists, otherwise add focused assertions to an existing analysis-config test)
+
+  **Approach:**
+  - Add `AnalysisOperation("embeddings", "Generate Embeddings", "Extract DINOv2 visual feature vectors for similarity-based sequencing", "sequential", False)` to the `ANALYSIS_OPERATIONS` list, ordered after `face_embeddings` and `gaze`.
+  - The operation is automatically picked up by `OPERATIONS_BY_KEY`, `SEQUENTIAL_OPS`, and the picker dialog (which iterates `ANALYSIS_OPERATIONS`).
+
+  **Patterns to follow:**
+  - `gaze` and `face_embeddings` entries in the same file.
+
+  **Test scenarios:**
+  - Happy path: `OPERATIONS_BY_KEY["embeddings"]` returns an `AnalysisOperation` with `key="embeddings"`, `phase="sequential"`, `default_enabled=False`.
+  - Happy path: `"embeddings" in SEQUENTIAL_OPS`.
+  - Edge case: `"embeddings" not in DEFAULT_SELECTED` (it's opt-in).
+
+  **Verification:**
+  - Launching the app and opening the analysis picker shows a "Generate Embeddings" checkbox under the sequential phase group.
+
+- [ ] **Unit 2: Add EmbeddingAnalysisWorker**
+
+  **Goal:** Background worker that runs DINOv2 batch extraction on selected clips, mutating `clip.embedding` and `clip.embedding_model` in place.
+
+  **Requirements:** R2, R3, R4 (the install-prompt R5 is enforced by the launch site in Unit 3, not inside the worker)
+
+  **Dependencies:** Unit 1
+
+  **Files:**
+  - Create: `ui/workers/embedding_worker.py`
+  - Modify: `ui/workers/__init__.py` (export `EmbeddingAnalysisWorker`)
+  - Test: `tests/test_embedding_worker.py`
+
+  **Approach:**
+  - Class `EmbeddingAnalysisWorker(CancellableWorker)` mirroring `GazeAnalysisWorker`.
+  - Constructor: `(clips, sources_by_id=None, skip_existing=True, chunk_size=16, parent=None)`. `sources_by_id` is accepted for launch-site API parity with other workers but is **never read inside the worker** — embeddings only need each clip's `thumbnail_path`. Document this in the docstring.
+  - Signals: `progress(int, int)`, `embedding_ready(str)` (clip_id), `analysis_completed()`, plus inherited `error(str)` and `finished()`.
+  - `run()`:
+    1. Filter clips: skip those with `clip.embedding is not None` if `skip_existing`, skip those with no `thumbnail_path` (log warning). `extract_clip_embeddings_batch` itself handles unreadable image files internally (returns zero vectors), so per-thumbnail try/except inside the worker is redundant — the only worker-level filter needed is the `thumbnail_path` existence check.
+    2. If 0 clips remain → emit `analysis_completed` and return early.
+    3. Always-load-then-unload pattern (matches `gaze_worker.py`): track a single `model_loaded` boolean. If `is_model_loaded()` returns False, call the embeddings module's lazy loader and set `model_loaded = True`. **Don't** try to detect "someone else loaded it and skip the unload" — the underlying `is_model_loaded()` reads `_model` without holding `_model_lock`, so the check has a TOCTOU window. Sequential phase guarantees no concurrent embeddings consumer is active, so simpler is correct.
+    4. Process in chunks of `chunk_size`. Maintain a per-chunk list of `(clip, thumbnail_path)` pairs so the returned vectors map back 1:1 by index (per-chunk equivalent of `_auto_compute_embeddings`'s `zip(needs_embedding, embeddings)`). For each chunk: check `is_cancelled()`, call `extract_clip_embeddings_batch(thumbnail_paths)`, zip results back to the chunk's clips, assign `clip.embedding` and `clip.embedding_model = _EMBEDDING_MODEL_TAG` (import the constant from `core.analysis.embeddings` — it exists at module scope, line 31; do not duplicate the literal string). Emit `embedding_ready(clip.id)` per clip and `progress(processed_so_far, total)` after each chunk.
+    5. In `finally`: unload the model if `model_loaded` is True; always emit `analysis_completed`.
+    6. **Chunk-level error policy: abort with `error(str)` signal.** A model-level exception (OOM, model corruption, library mismatch) usually means subsequent chunks will also fail. Catch the exception around each chunk's `extract_clip_embeddings_batch` call, emit `error` once with a descriptive message, break the chunk loop, let `finally` unload and emit `analysis_completed`. Partial results from already-processed chunks are preserved on the clips (mutate-in-place).
+
+  **Patterns to follow:**
+  - `ui/workers/gaze_worker.py` — overall structure, model load/unload lifecycle, mutate-in-place + signal emission, `try/finally` for completion.
+  - `core/remix/__init__.py:473` `_auto_compute_embeddings` — exact filter/call/assign sequence for embeddings specifically.
+
+  **Test scenarios:**
+  - Happy path: Worker with mocked `extract_clip_embeddings_batch` returning N vectors processes N clips, sets `clip.embedding` and `clip.embedding_model` on each, emits `embedding_ready` per clip, emits final `analysis_completed`.
+  - Happy path: `skip_existing=True` and clips already have embeddings → `extract_clip_embeddings_batch` is never called, `analysis_completed` still emits.
+  - Edge case: Empty clip list → no model load, immediate `analysis_completed`.
+  - Edge case: Mix of clips with and without thumbnails → only clips with thumbnails are processed; missing-thumbnail clips logged and skipped.
+  - Edge case: Cancellation between chunks (set `_cancel_event` before second chunk) → second chunk does not run, partial results persist on already-processed clips, `analysis_completed` still emits.
+  - Error path: `extract_clip_embeddings_batch` raises in the middle of a chunk → worker emits `error` exactly once, breaks the chunk loop, partial results from prior chunks are preserved on the clips, `analysis_completed` still emits in `finally`.
+  - Edge case: Model already loaded when worker starts (`is_model_loaded() == True`) → worker does NOT call the loader, but DOES still call `unload_model()` in `finally` (always-unload pattern; matches gaze).
+
+  **Verification:**
+  - All clips with thumbnails get `embedding` and `embedding_model` set.
+  - The worker never crashes on bad input (missing thumbnail, bad clip, empty list).
+  - Cancellation produces partial results, never corrupted state.
+
+- [ ] **Unit 3: Wire the worker into the analysis dispatch**
+
+  **Goal:** Hook the new worker into the `_launch_analysis_worker` dispatch chain in `MainWindow` so selecting the checkbox actually runs the worker.
+
+  **Requirements:** R2, R3, R5, R7
+
+  **Dependencies:** Unit 2
+
+  **Files:**
+  - Modify: `ui/main_window.py`
+  - Test: `tests/test_main_window_analysis_dispatch.py` (or extend existing test if there is one — search for any existing test that exercises `_launch_analysis_worker`)
+
+  **Approach:**
+  - Add `elif op_key == "embeddings": self._launch_embeddings_worker(clips)` in `_launch_analysis_worker` (around line 3313, alongside the other `elif` entries).
+  - Add `_launch_embeddings_worker(self, clips: list)` method modeled directly on `_launch_gaze_worker` (line 3399). Set guard flag `self._embeddings_finished_handled = False`, build `sources_by_id`, instantiate `EmbeddingAnalysisWorker`, connect signals (`progress` → `_on_embeddings_progress`, `embedding_ready` → `_on_embedding_ready`, `analysis_completed` → `_on_pipeline_embeddings_finished` with `Qt.UniqueConnection`, `error` → `_on_embeddings_error`, `finished` → `deleteLater` and clearing the worker reference).
+  - Add the four `@Slot()` handlers: `_on_embeddings_progress(current, total)` updates the progress bar; `_on_embedding_ready(clip_id)` updates clip-browser visual state if applicable (look at `_on_gaze_ready` for the precedent — may be a no-op for embeddings since there's no visible per-clip indicator yet); `_on_pipeline_embeddings_finished` uses the guard flag and calls `_on_analysis_phase_worker_finished("embeddings")`; `_on_embeddings_error` logs and shows a status-bar message.
+  - **No additional `check_feature_ready` guard inside `_launch_embeddings_worker`.** The pipeline already filters via `_filter_available_analysis_operations` (`ui/main_window.py:3209`), which calls `_ensure_analysis_operation_available` → `get_operation_feature_candidates` → `check_feature_ready`, and `core/analysis_dependencies.py:43-44` already maps `embeddings` to the `embeddings` feature. By the time a worker is launched, the user has already been prompted (and either installed or declined). Adding a second check duplicates pipeline-level filtering — the gaze worker (the reference template) does not do this. R5 is satisfied by the existing pipeline plumbing, not by a launcher-level guard.
+
+  **Patterns to follow:**
+  - `_launch_gaze_worker` and its handlers (`_on_pipeline_gaze_finished`, `_on_gaze_error`, etc.) — exact structural template.
+  - `ui/dialogs/reference_guide_dialog.py:434-457` — the `check_feature_ready` + install-prompt pattern.
+
+  **Test scenarios:**
+  - Happy path: `_launch_analysis_worker("embeddings", clips)` instantiates an `EmbeddingAnalysisWorker` and starts it.
+  - Happy path: Worker `analysis_completed` signal triggers `_on_pipeline_embeddings_finished` exactly once even if the signal fires twice (guard flag works).
+  - Integration: Worker `error` signal logs and shows a status-bar message but does not block subsequent operations.
+  - Integration: When the user declines installing torch+transformers at the pipeline-filter step (existing path, not new code), the embeddings operation is filtered out before any launcher runs — the launcher itself never executes.
+
+  **Verification:**
+  - Toggling the "Generate Embeddings" checkbox in the picker and clicking Run triggers a worker that processes the selected clips end to end.
+  - The progress bar updates during processing and clears on completion.
+
+- [ ] **Unit 4: Verify and document**
+
+  **Goal:** Confirm the new operation is visible to the rest of the app correctly (cost gate, sequence-tab card availability, auto-compute fallback). This unit performs no code changes — it is a docs + manual-verification pass to catch any regression in the surfaces R5/R6/R7 implicitly cover.
+
+  **Requirements:** R7 (verifies the auto-compute fallback in `core/remix/__init__.py` is unaffected; R5 was implemented in Unit 3 via the existing pipeline-level filter, R6 was already satisfied by existing serialization code per Scope Boundaries — both are verified in passing here but not newly implemented)
+
+  **Dependencies:** Unit 3
+
+  **Files:**
+  - Modify: `docs/user-guide/` — add a brief note about the new analysis option (locate the appropriate file, e.g., `analyze.md` or similar).
+  - No code changes expected; this unit is verification + docs.
+
+  **Approach:**
+  - Open the cost gate by selecting embeddings + a few clips and verify the line item shows "Embeddings" with a sensible time estimate. If the line is missing or labeled wrong, debug — but research shows `OPERATION_LABELS["embeddings"]` and `TIME_PER_CLIP["embeddings"]` already exist.
+  - Run embeddings on a few clips, then go to the Sequence tab and confirm the `similarity_chain` algorithm (UI label "Human Centipede") is now available without the install prompt or warning.
+  - Open and re-load a project that has clips with `clip.embedding` populated; verify the embeddings survived the round-trip (this is already covered by existing tests, but worth a manual pass).
+  - Confirm the existing `_auto_compute_embeddings` fallback in `core/remix/__init__.py` still runs for clips without embeddings (didn't accidentally break the auto path).
+  - Add a section to the user guide explaining how to run embeddings explicitly and why a user might want to.
+
+  **Test scenarios:**
+  - Test expectation: none — this unit is documentation + manual verification. Behavioral correctness is covered by Units 2 and 3.
+
+  **Verification:**
+  - User-facing docs mention the new operation.
+  - Manual smoke test confirms end-to-end: pick clips → check embeddings → Run → embeddings populated → Free Association / Human Centipede now use them automatically.
+
+## System-Wide Impact
+
+- **Interaction graph:** `MainWindow._launch_analysis_worker` adds one new branch; the new worker emits to four new handler methods (progress / ready / completed / error). No new cross-component callbacks beyond the established analysis-pipeline pattern.
+- **Error propagation:** Worker errors route to `_on_embeddings_error` → status bar message + log. Pipeline advances via `_on_analysis_phase_worker_finished("embeddings")` so a single failure doesn't stall subsequent operations.
+- **State lifecycle risks:** Mutate-in-place pattern means partial results persist on cancel — same as gaze. No risk of corrupted state.
+- **API surface parity:** Embeddings are produced by both the new explicit operation AND the existing `_auto_compute_embeddings` path used by similarity_chain / staccato / free_association. Both paths must produce embeddings in the same shape (768-dim list, same `embedding_model` tag). Since both call `extract_clip_embeddings_batch` directly, this is guaranteed.
+- **Integration coverage:** A clip processed by the explicit operation should subsequently NOT be re-processed by the auto-compute fallback. Guaranteed by the `clip.embedding is None` check at both call sites.
+- **Unchanged invariants:** Existing `Clip.embedding` / `Clip.embedding_model` schema, serialization, and validation are unchanged. The `_auto_compute_embeddings` fallback is unchanged. Cost-estimate infrastructure is unchanged. Feature registry is unchanged. Sequence-tab card-availability mapping is unchanged (it already checks for embeddings the right way).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| QThread `finished` signal duplicate delivery causes pipeline-advance handler to fire twice | Apply the guard flag pattern from the documented learning (`_embeddings_finished_handled = False` on launch, set True in handler, return early on second invocation). Use `Qt.UniqueConnection` on the `analysis_completed` connection. |
+| Heavy dependency (torch + transformers, ~450 MB) not installed | Use the existing `check_feature_ready("embeddings")` + `install_for_feature("embeddings")` flow (proven in `reference_guide_dialog.py`). On decline, advance the pipeline without aborting it. |
+| Model already loaded from a prior call (e.g., similarity_chain ran during this session), then unloaded by the worker, leaving subsequent algorithms slow | Track a `we_loaded_it` boolean — only call `unload_model()` if we were the ones who loaded it. |
+| Single bad thumbnail crashes the whole batch | Wrap `extract_clip_embeddings_batch` per-chunk in `try/except`; on chunk failure, log and abort with `error` signal (a chunk-level failure usually indicates a systemic issue like OOM). |
+| Cancellation latency feels poor for large jobs | Chunk processing (default 16 clips/chunk) gives cancellation checkpoints between chunks. Acceptable for most use cases; large projects may want a smaller chunk size. |
+
+## Documentation / Operational Notes
+
+- Update `docs/user-guide/` to mention "Generate Embeddings" as an analysis option, and explain why a user might want to run it explicitly (Free Association, Human Centipede, Reference Guide all use embeddings; running it once up-front is faster than letting each sequencer auto-compute).
+- No migration concerns — existing projects' clips that already have `embedding` set are unaffected.
+- No changes to release notes / CI / build pipeline.
+
+## Sources & References
+
+- Related code:
+  - `core/analysis_operations.py`
+  - `ui/workers/gaze_worker.py`
+  - `core/analysis/embeddings.py`
+  - `core/remix/__init__.py` (`_auto_compute_embeddings`)
+  - `ui/main_window.py` (`_launch_analysis_worker`, `_launch_gaze_worker`)
+  - `core/cost_estimates.py`
+  - `core/feature_registry.py`
+- Related PRs/issues: #87 (Free Association sequencer — the immediate consumer that motivated this work)
+- Institutional learnings: `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`

--- a/docs/user-guide/analysis.md
+++ b/docs/user-guide/analysis.md
@@ -422,6 +422,24 @@ The detector samples one frame per second through each clip, so it catches faces
 
 ---
 
+## Generate Embeddings
+
+Extracts a 768-dimensional DINOv2 visual feature vector from each clip's thumbnail. Embeddings capture what each clip "looks like" in a way that lets algorithms compare clips by visual similarity rather than by discrete metadata like shot type or color.
+
+**Produces:**
+- A 768-dim embedding vector on each clip (`embedding`)
+- The model tag (`dinov2-vit-b-14`) so you can tell which version generated the vector
+
+**Required first:** Scene detection with thumbnails (the default). Clips without thumbnails are skipped.
+**Runs:** Locally (DINOv2 via transformers, no API key needed). Downloads ~450 MB of model files on first use.
+**Speed:** Moderate (processes in batches on GPU if available, otherwise CPU).
+
+**Used by:** Human Centipede (similarity chaining), Staccato, Reference Guide (when the embedding dimension is active), and Free Association (for local candidate shortlisting).
+
+> **Tip:** If you haven't run this explicitly and try to use a sequencer that needs embeddings, the app will auto-compute them as a side effect of running the sequencer. Running Generate Embeddings up front is faster when you plan to use multiple embedding-based sequencers on the same clips.
+
+---
+
 ## Custom Query
 
 Ask a yes/no question about each clip and get a boolean answer with confidence. Useful for filtering clips by arbitrary criteria that other analyses don't cover.

--- a/tests/test_analysis_availability.py
+++ b/tests/test_analysis_availability.py
@@ -44,3 +44,16 @@ def test_extract_text_empty_list_still_counts_as_needing_analysis():
 
     disabled = compute_disabled_operations([clip], ["extract_text"])
     assert disabled == set()
+
+
+def test_embeddings_completeness_matches_embedding_field():
+    clip_with = make_test_clip("with")
+    clip_with.embedding = [0.1] * 768
+    clip_without = make_test_clip("without")
+    clip_without.embedding = None
+
+    assert compute_disabled_operations([clip_with], ["embeddings"]) == {"embeddings"}
+    assert compute_disabled_operations([clip_without], ["embeddings"]) == set()
+    assert compute_disabled_operations(
+        [clip_with, clip_without], ["embeddings"]
+    ) == set()

--- a/tests/test_analysis_operations.py
+++ b/tests/test_analysis_operations.py
@@ -17,9 +17,9 @@ from core.analysis_operations import (
 class TestAnalysisOperationRegistry:
     """Tests for the operation registry."""
 
-    def test_registry_has_11_operations(self):
-        """All 11 operations are registered."""
-        assert len(ANALYSIS_OPERATIONS) == 11
+    def test_registry_has_12_operations(self):
+        """All 12 operations are registered."""
+        assert len(ANALYSIS_OPERATIONS) == 12
 
     def test_operations_by_key_matches(self):
         """OPERATIONS_BY_KEY has an entry for every operation."""
@@ -82,3 +82,30 @@ class TestAnalysisOperationRegistry:
             assert op.label, f"Operation missing label: {op}"
             assert op.tooltip, f"Operation missing tooltip: {op}"
             assert op.phase in PHASE_ORDER, f"Invalid phase '{op.phase}' for {op.key}"
+
+
+class TestEmbeddingsOperation:
+    """Tests for the 'embeddings' operation specifically."""
+
+    def test_embeddings_is_registered(self):
+        assert "embeddings" in OPERATIONS_BY_KEY
+
+    def test_embeddings_is_sequential_phase(self):
+        op = OPERATIONS_BY_KEY["embeddings"]
+        assert op.phase == "sequential"
+        assert "embeddings" in SEQUENTIAL_OPS
+
+    def test_embeddings_is_opt_in(self):
+        op = OPERATIONS_BY_KEY["embeddings"]
+        assert op.default_enabled is False
+        assert "embeddings" not in DEFAULT_SELECTED
+
+    def test_embeddings_has_user_facing_label(self):
+        op = OPERATIONS_BY_KEY["embeddings"]
+        assert op.label == "Generate Embeddings"
+        assert op.tooltip  # non-empty
+
+    def test_embeddings_is_not_cloud_capable(self):
+        """DINOv2 runs locally only."""
+        op = OPERATIONS_BY_KEY["embeddings"]
+        assert op.cloud_capable is False

--- a/tests/test_analysis_picker_dialog.py
+++ b/tests/test_analysis_picker_dialog.py
@@ -76,6 +76,7 @@ def test_dialog_run_disabled_when_every_operation_complete(qapp):
     clip.cinematography = object()
     clip.face_embeddings = [{"bbox": [0, 0, 50, 50], "embedding": [0.1] * 512, "confidence": 0.9}]
     clip.gaze_category = "at_camera"
+    clip.embedding = [0.1] * 768  # DINOv2 visual embedding
     clip.custom_queries = [{"query": "test", "match": True, "confidence": 0.9, "model": "test"}]
 
     settings = _Settings(selected=["colors", "shots", "transcribe"])

--- a/tests/test_embedding_worker.py
+++ b/tests/test_embedding_worker.py
@@ -1,0 +1,297 @@
+"""Tests for EmbeddingAnalysisWorker.
+
+Following the convention from tests/test_gaze_worker.py: call worker.run()
+directly (synchronously) rather than start() to avoid QThread scheduling
+complications in the test environment.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import make_test_clip
+
+
+@pytest.fixture
+def source(tmp_path):
+    """A Source with a real file path (used only for the worker's ignored sources_by_id param)."""
+    video_file = tmp_path / "video.mp4"
+    video_file.write_bytes(b"\x00" * 100)
+    from models.clip import Source
+
+    return Source(
+        id="src-1",
+        file_path=video_file,
+        duration_seconds=60.0,
+        fps=30.0,
+    )
+
+
+@pytest.fixture
+def sources_by_id(source):
+    return {source.id: source}
+
+
+@pytest.fixture
+def clip_with_thumb(tmp_path):
+    """A clip with a real (but empty) thumbnail file on disk."""
+    thumb = tmp_path / "thumb-c1.jpg"
+    thumb.write_bytes(b"\x00" * 10)
+    clip = make_test_clip("c1")
+    clip.thumbnail_path = thumb
+    return clip
+
+
+class TestEmbeddingWorkerFiltering:
+    def test_skips_clips_already_having_embeddings(self, qapp_fixture, sources_by_id, tmp_path):
+        from ui.workers.embedding_worker import EmbeddingAnalysisWorker
+
+        thumb = tmp_path / "t.jpg"
+        thumb.write_bytes(b"\x00")
+        clip1 = make_test_clip("c1")
+        clip1.thumbnail_path = thumb
+        clip1.embedding = [0.5] * 768  # already analyzed
+
+        clip2 = make_test_clip("c2")
+        clip2.thumbnail_path = thumb
+
+        with patch(
+            "core.analysis.embeddings.extract_clip_embeddings_batch",
+            return_value=[[0.1] * 768],
+        ) as mock_extract, patch("core.analysis.embeddings.unload_model"):
+            worker = EmbeddingAnalysisWorker(
+                [clip1, clip2], sources_by_id=sources_by_id, skip_existing=True
+            )
+            worker.run()
+
+        # Only clip2 was processed
+        mock_extract.assert_called_once()
+        passed_paths = mock_extract.call_args[0][0]
+        assert len(passed_paths) == 1
+        # clip2 got a new embedding; clip1 kept its original
+        assert clip1.embedding == [0.5] * 768
+        assert clip2.embedding == [0.1] * 768
+
+    def test_skips_clips_without_thumbnails(self, qapp_fixture, sources_by_id):
+        from ui.workers.embedding_worker import EmbeddingAnalysisWorker
+
+        clip = make_test_clip("c1")
+        clip.thumbnail_path = None
+
+        completions = []
+        with patch(
+            "core.analysis.embeddings.extract_clip_embeddings_batch"
+        ) as mock_extract, patch("core.analysis.embeddings.unload_model"):
+            worker = EmbeddingAnalysisWorker([clip], sources_by_id=sources_by_id)
+            worker.analysis_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        # No clips to process → extract never called, completion still emits
+        mock_extract.assert_not_called()
+        assert completions == [True]
+
+    def test_empty_clip_list_emits_completion_and_returns(self, qapp_fixture):
+        from ui.workers.embedding_worker import EmbeddingAnalysisWorker
+
+        completions = []
+        with patch(
+            "core.analysis.embeddings.extract_clip_embeddings_batch"
+        ) as mock_extract, patch("core.analysis.embeddings.unload_model") as mock_unload:
+            worker = EmbeddingAnalysisWorker([])
+            worker.analysis_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        # Early return — neither extract nor unload called
+        mock_extract.assert_not_called()
+        mock_unload.assert_not_called()
+        assert completions == [True]
+
+
+class TestEmbeddingWorkerHappyPath:
+    def test_processes_clips_and_sets_embedding_fields(
+        self, qapp_fixture, clip_with_thumb, sources_by_id
+    ):
+        from ui.workers.embedding_worker import EmbeddingAnalysisWorker
+
+        mock_vector = [0.1] * 768
+        ready_ids: list[str] = []
+        progress_events: list[tuple[int, int]] = []
+        completions: list[bool] = []
+
+        with patch(
+            "core.analysis.embeddings.extract_clip_embeddings_batch",
+            return_value=[mock_vector],
+        ), patch("core.analysis.embeddings.unload_model") as mock_unload:
+            worker = EmbeddingAnalysisWorker(
+                [clip_with_thumb], sources_by_id=sources_by_id
+            )
+            worker.embedding_ready.connect(lambda cid: ready_ids.append(cid))
+            worker.progress.connect(lambda c, t: progress_events.append((c, t)))
+            worker.analysis_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        # Clip fields mutated in place
+        assert clip_with_thumb.embedding == mock_vector
+        assert clip_with_thumb.embedding_model == "dinov2-vit-b-14"
+
+        # Signals emitted
+        assert ready_ids == ["c1"]
+        assert progress_events == [(1, 1)]
+        assert completions == [True]
+
+        # Always-unload pattern — unload is always called in finally
+        mock_unload.assert_called_once()
+
+    def test_chunking_emits_progress_between_chunks(
+        self, qapp_fixture, sources_by_id, tmp_path
+    ):
+        """With chunk_size=2 and 4 clips, progress fires twice (after each chunk)."""
+        from ui.workers.embedding_worker import EmbeddingAnalysisWorker
+
+        thumb = tmp_path / "t.jpg"
+        thumb.write_bytes(b"\x00")
+        clips = []
+        for i in range(4):
+            c = make_test_clip(f"c{i}")
+            c.thumbnail_path = thumb
+            clips.append(c)
+
+        progress_events = []
+        with patch(
+            "core.analysis.embeddings.extract_clip_embeddings_batch",
+            side_effect=lambda paths: [[0.1] * 768 for _ in paths],
+        ), patch("core.analysis.embeddings.unload_model"):
+            worker = EmbeddingAnalysisWorker(
+                clips, sources_by_id=sources_by_id, chunk_size=2
+            )
+            worker.progress.connect(lambda c, t: progress_events.append((c, t)))
+            worker.run()
+
+        # 4 clips, chunk_size=2 → 2 chunks, 2 progress events (2/4 and 4/4)
+        assert progress_events == [(2, 4), (4, 4)]
+        # All clips got embeddings
+        for clip in clips:
+            assert clip.embedding == [0.1] * 768
+
+
+class TestEmbeddingWorkerCancellation:
+    def test_cancellation_between_chunks_stops_processing(
+        self, qapp_fixture, sources_by_id, tmp_path
+    ):
+        from ui.workers.embedding_worker import EmbeddingAnalysisWorker
+
+        thumb = tmp_path / "t.jpg"
+        thumb.write_bytes(b"\x00")
+        clips = []
+        for i in range(4):
+            c = make_test_clip(f"c{i}")
+            c.thumbnail_path = thumb
+            clips.append(c)
+
+        call_count = {"n": 0}
+
+        def cancel_after_first_chunk(paths):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                worker.cancel()
+            return [[0.1] * 768 for _ in paths]
+
+        completions: list[bool] = []
+        with patch(
+            "core.analysis.embeddings.extract_clip_embeddings_batch",
+            side_effect=cancel_after_first_chunk,
+        ), patch("core.analysis.embeddings.unload_model"):
+            worker = EmbeddingAnalysisWorker(
+                clips, sources_by_id=sources_by_id, chunk_size=2
+            )
+            worker.analysis_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        # First chunk's two clips got embeddings
+        assert clips[0].embedding == [0.1] * 768
+        assert clips[1].embedding == [0.1] * 768
+        # Second chunk never ran
+        assert clips[2].embedding is None
+        assert clips[3].embedding is None
+        # Completion signal still fires so the pipeline advances
+        assert completions == [True]
+
+
+class TestEmbeddingWorkerErrorPath:
+    def test_chunk_exception_emits_error_breaks_loop_preserves_prior_chunks(
+        self, qapp_fixture, sources_by_id, tmp_path
+    ):
+        from ui.workers.embedding_worker import EmbeddingAnalysisWorker
+
+        thumb = tmp_path / "t.jpg"
+        thumb.write_bytes(b"\x00")
+        clips = []
+        for i in range(4):
+            c = make_test_clip(f"c{i}")
+            c.thumbnail_path = thumb
+            clips.append(c)
+
+        call_count = {"n": 0}
+
+        def fail_on_second_chunk(paths):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("Simulated OOM")
+            return [[0.1] * 768 for _ in paths]
+
+        errors: list[str] = []
+        completions: list[bool] = []
+        with patch(
+            "core.analysis.embeddings.extract_clip_embeddings_batch",
+            side_effect=fail_on_second_chunk,
+        ), patch("core.analysis.embeddings.unload_model") as mock_unload:
+            worker = EmbeddingAnalysisWorker(
+                clips, sources_by_id=sources_by_id, chunk_size=2
+            )
+            worker.error.connect(lambda msg: errors.append(msg))
+            worker.analysis_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        # First chunk succeeded
+        assert clips[0].embedding == [0.1] * 768
+        assert clips[1].embedding == [0.1] * 768
+        # Second chunk failed — no embeddings written
+        assert clips[2].embedding is None
+        assert clips[3].embedding is None
+        # Error signaled exactly once
+        assert len(errors) == 1
+        assert "Simulated OOM" in errors[0]
+        # Completion still emits so the pipeline advances
+        assert completions == [True]
+        # Model is still unloaded in finally
+        mock_unload.assert_called_once()
+
+
+class TestEmbeddingWorkerSourcesByIdIsIgnored:
+    """sources_by_id is accepted for launch-site API parity but never read."""
+
+    def test_worker_runs_with_none_sources_by_id(
+        self, qapp_fixture, clip_with_thumb
+    ):
+        from ui.workers.embedding_worker import EmbeddingAnalysisWorker
+
+        with patch(
+            "core.analysis.embeddings.extract_clip_embeddings_batch",
+            return_value=[[0.1] * 768],
+        ), patch("core.analysis.embeddings.unload_model"):
+            worker = EmbeddingAnalysisWorker([clip_with_thumb], sources_by_id=None)
+            worker.run()
+
+        assert clip_with_thumb.embedding == [0.1] * 768
+
+
+# Qt application fixture (needed since the worker is a QThread subclass)
+@pytest.fixture(scope="module")
+def qapp_fixture():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app

--- a/tests/test_embeddings_dispatch.py
+++ b/tests/test_embeddings_dispatch.py
@@ -1,0 +1,107 @@
+"""Tests for embedding analysis dispatch and pipeline completion handler.
+
+These tests target MainWindow's _launch_analysis_worker branch, the
+_launch_embeddings_worker factory, and the guard-flag-protected
+_on_pipeline_embeddings_finished handler. They don't exercise a real
+QThread — the worker is instantiated but its .start() is mocked so we
+can inspect the signal wiring.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class TestDispatchBranch:
+    def test_dispatch_routes_embeddings_to_launcher(self, qapp):
+        """_launch_analysis_worker('embeddings', clips) calls _launch_embeddings_worker."""
+        from ui.main_window import MainWindow
+
+        mw = MainWindow.__new__(MainWindow)  # bypass full __init__
+        mw.progress_bar = MagicMock()
+        mw.status_bar = MagicMock()
+
+        launcher_calls = []
+        mw._launch_embeddings_worker = lambda clips: launcher_calls.append(clips)
+
+        mw._launch_analysis_worker("embeddings", ["clip-a", "clip-b"])
+
+        assert launcher_calls == [["clip-a", "clip-b"]]
+
+
+class TestLauncherSignalWiring:
+    def test_launcher_creates_worker_and_connects_signals(self, qapp):
+        """_launch_embeddings_worker instantiates EmbeddingAnalysisWorker and wires up signals."""
+        from ui.main_window import MainWindow
+
+        mw = MainWindow.__new__(MainWindow)
+        mw._embeddings_finished_handled = False
+
+        # Patch the class in main_window's namespace so instantiation
+        # returns our mock instead of a real QThread.
+        fake_worker = MagicMock()
+        with patch("ui.main_window.EmbeddingAnalysisWorker", return_value=fake_worker):
+            mw._launch_embeddings_worker(["clip-a"])
+
+        # Worker constructed with the clips
+        assert mw._embeddings_worker is fake_worker
+        # Required signal connections
+        fake_worker.progress.connect.assert_called()
+        fake_worker.embedding_ready.connect.assert_called()
+        fake_worker.analysis_completed.connect.assert_called()
+        fake_worker.error.connect.assert_called()
+        # Lifecycle cleanup connected
+        assert fake_worker.finished.connect.call_count >= 2
+        # Worker started
+        fake_worker.start.assert_called_once()
+        # Guard flag reset
+        assert mw._embeddings_finished_handled is False
+
+
+class TestPipelineCompletionHandler:
+    def test_guard_flag_prevents_double_invocation(self, qapp):
+        """Qt finished/analysis_completed signal can fire twice; the guard flag prevents
+        the pipeline-advance handler from firing twice."""
+        from ui.main_window import MainWindow
+
+        mw = MainWindow.__new__(MainWindow)
+        mw._embeddings_finished_handled = False
+
+        calls = []
+        mw._on_analysis_phase_worker_finished = lambda op_key: calls.append(op_key)
+
+        # First call advances the pipeline
+        mw._on_pipeline_embeddings_finished()
+        assert calls == ["embeddings"]
+        assert mw._embeddings_finished_handled is True
+
+        # Second call (duplicate signal) is suppressed
+        mw._on_pipeline_embeddings_finished()
+        assert calls == ["embeddings"]  # unchanged
+
+    def test_error_handler_logs_and_shows_status_message(self, qapp):
+        from ui.main_window import MainWindow
+
+        mw = MainWindow.__new__(MainWindow)
+        status_bar = MagicMock()
+        mw.statusBar = lambda: status_bar
+
+        mw._on_embeddings_error("boom")
+
+        status_bar.showMessage.assert_called_once()
+        msg = status_bar.showMessage.call_args[0][0]
+        assert "boom" in msg
+        assert "Embedding" in msg

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -86,6 +86,7 @@ from ui.workers.classification_worker import ClassificationWorker
 from ui.workers.object_detection_worker import ObjectDetectionWorker
 from ui.workers.face_detection_worker import FaceDetectionWorker
 from ui.workers.gaze_worker import GazeAnalysisWorker
+from ui.workers.embedding_worker import EmbeddingAnalysisWorker
 from ui.workers.description_worker import DescriptionWorker
 from ui.workers.custom_query_worker import CustomQueryWorker
 from ui.workers.export_worker import ExportBundleWorker
@@ -3312,6 +3313,8 @@ class MainWindow(QMainWindow):
             self._launch_custom_query_worker(clips)
         elif op_key == "gaze":
             self._launch_gaze_worker(clips)
+        elif op_key == "embeddings":
+            self._launch_embeddings_worker(clips)
         else:
             logger.warning(f"Unknown analysis operation: {op_key}")
             self._on_analysis_phase_worker_finished(op_key)
@@ -3413,6 +3416,27 @@ class MainWindow(QMainWindow):
         self._gaze_worker.finished.connect(self._gaze_worker.deleteLater)
         self._gaze_worker.finished.connect(lambda: setattr(self, '_gaze_worker', None))
         self._gaze_worker.start()
+
+    def _launch_embeddings_worker(self, clips: list):
+        """Launch DINOv2 embedding extraction worker.
+
+        The pipeline has already filtered this operation via
+        _filter_available_analysis_operations (which calls check_feature_ready
+        for torch+transformers), so no additional dependency guard is needed
+        here — if the user declined install, this launcher is never reached.
+        """
+        self._embeddings_finished_handled = False
+        logger.info(f"Creating EmbeddingAnalysisWorker (pipeline) for {len(clips)} clips...")
+        self._embeddings_worker = EmbeddingAnalysisWorker(clips)
+        self._embeddings_worker.progress.connect(self._on_embeddings_progress)
+        self._embeddings_worker.embedding_ready.connect(self._on_embedding_ready)
+        self._embeddings_worker.analysis_completed.connect(
+            self._on_pipeline_embeddings_finished, Qt.UniqueConnection
+        )
+        self._embeddings_worker.error.connect(self._on_embeddings_error)
+        self._embeddings_worker.finished.connect(self._embeddings_worker.deleteLater)
+        self._embeddings_worker.finished.connect(lambda: setattr(self, '_embeddings_worker', None))
+        self._embeddings_worker.start()
 
     def _launch_text_extraction_worker(self, clips: list):
         """Launch text extraction worker."""
@@ -7334,6 +7358,40 @@ class MainWindow(QMainWindow):
                 self.clip_details_sidebar.refresh_gaze_if_showing(clip_id)
             self._mark_dirty()
             logger.debug(f"Clip {clip_id}: gaze={category} (yaw={yaw:.1f}, pitch={pitch:.1f})")
+
+    @Slot(int, int)
+    def _on_embeddings_progress(self, current: int, total: int):
+        """Handle embedding extraction progress updates."""
+        if total > 0:
+            if current == 0:
+                self.status_bar.showMessage(
+                    "Generating Embeddings: loading DINOv2 model (first run, ~450 MB)..."
+                )
+            else:
+                self.status_bar.showMessage(f"Generating embeddings: {current}/{total} clips...")
+            self.progress_bar.setValue(int(current / total * 100))
+
+    @Slot(str)
+    def _on_embedding_ready(self, clip_id: str):
+        """Handle embedding attached to a clip. No per-clip UI indicator yet."""
+        clip = self.clips_by_id.get(clip_id)
+        if clip:
+            self._mark_dirty()
+            logger.debug(f"Clip {clip_id}: embedding populated")
+
+    @Slot()
+    def _on_pipeline_embeddings_finished(self):
+        """Advance the pipeline once embeddings analysis completes."""
+        if self._embeddings_finished_handled:
+            return
+        self._embeddings_finished_handled = True
+        self._on_analysis_phase_worker_finished("embeddings")
+
+    @Slot(str)
+    def _on_embeddings_error(self, msg: str):
+        """Handle embedding analysis errors — log and ensure pipeline advances."""
+        logger.error("Embedding analysis error: %s", msg)
+        self.statusBar().showMessage(f"Embedding analysis failed: {msg}", 5000)
 
     @Slot(int, int)
     def _on_object_detection_progress(self, current: int, total: int):

--- a/ui/workers/__init__.py
+++ b/ui/workers/__init__.py
@@ -5,6 +5,7 @@ from .cinematography_worker import CinematographyWorker
 from .classification_worker import ClassificationWorker
 from .color_worker import ColorAnalysisWorker
 from .description_worker import DescriptionWorker
+from .embedding_worker import EmbeddingAnalysisWorker
 from .frame_extraction_worker import FrameExtractionWorker
 from .gaze_worker import GazeAnalysisWorker
 from .object_detection_worker import ObjectDetectionWorker
@@ -19,6 +20,7 @@ __all__ = [
     "ClassificationWorker",
     "ColorAnalysisWorker",
     "DescriptionWorker",
+    "EmbeddingAnalysisWorker",
     "FrameExtractionWorker",
     "GazeAnalysisWorker",
     "ObjectDetectionWorker",

--- a/ui/workers/embedding_worker.py
+++ b/ui/workers/embedding_worker.py
@@ -1,0 +1,148 @@
+"""Background worker for DINOv2 visual embedding extraction.
+
+Extracts 768-dimensional embeddings from each clip's thumbnail and writes
+them to ``clip.embedding`` and ``clip.embedding_model`` in place. Processes
+in chunks so progress updates and cancellation checks happen between chunks
+rather than only at the start and end of the whole run.
+
+Mirrors the shape of ``ui/workers/gaze_worker.py`` — including the always-
+load-then-unload model lifecycle in ``finally``. No ``_model_lock`` race
+avoidance here; sequential phase ordering guarantees no concurrent embeddings
+consumer is active during this worker's run.
+"""
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from models.clip import Clip, Source
+
+from PySide6.QtCore import Signal, Slot
+
+from ui.workers.base import CancellableWorker
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CHUNK_SIZE = 16
+
+
+class EmbeddingAnalysisWorker(CancellableWorker):
+    """Background worker for DINOv2 visual embedding extraction.
+
+    Filters clips to those that need embeddings, processes them in chunks
+    (so progress and cancellation are responsive), mutates each clip's
+    ``embedding`` and ``embedding_model`` fields in place.
+
+    Signals:
+        progress: Emitted with (current, total) after each chunk completes.
+        embedding_ready: Emitted with clip_id for each clip that gets
+            an embedding attached.
+        analysis_completed: Emitted exactly once when the worker finishes
+            (success, cancellation, or error — the pipeline can always
+            advance on this signal).
+        error: Emitted with an error message string on chunk-level failure
+            (inherited from CancellableWorker).
+    """
+
+    progress = Signal(int, int)  # current, total
+    embedding_ready = Signal(str)  # clip_id
+    analysis_completed = Signal()
+
+    def __init__(
+        self,
+        clips: list["Clip"],
+        sources_by_id: Optional[dict[str, "Source"]] = None,
+        skip_existing: bool = True,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        parent=None,
+    ):
+        """
+        Args:
+            clips: Clips to process.
+            sources_by_id: Accepted for launch-site API parity with other
+                workers (e.g., GazeAnalysisWorker). Never read inside this
+                worker — embeddings only need each clip's thumbnail_path.
+            skip_existing: If True (default), clips that already have an
+                embedding are skipped.
+            chunk_size: Clips per chunk. Smaller = more responsive progress
+                and cancellation; larger = slightly less overhead.
+            parent: Qt parent.
+        """
+        super().__init__(parent)
+        self._clips = clips
+        # sources_by_id intentionally stored but not used — see docstring
+        self._sources_by_id = sources_by_id
+        self._skip_existing = skip_existing
+        self._chunk_size = max(1, chunk_size)
+
+    @Slot()
+    def run(self):
+        """Execute embedding extraction on the filtered clip set."""
+        self._log_start()
+
+        # Filter clips: skip those already analyzed, skip those without a thumbnail.
+        clips_to_process: list[tuple["Clip", Path]] = []
+        for clip in self._clips:
+            if self._skip_existing and clip.embedding is not None:
+                continue
+            thumb_path = getattr(clip, "thumbnail_path", None)
+            if not thumb_path:
+                logger.warning(
+                    "Skipping clip %s: no thumbnail_path", clip.id
+                )
+                continue
+            clips_to_process.append((clip, Path(thumb_path)))
+
+        total = len(clips_to_process)
+        if total == 0:
+            logger.info("No clips to process for embedding extraction")
+            self.analysis_completed.emit()
+            self._log_complete()
+            return
+
+        logger.info("Starting embedding extraction: %d clips", total)
+
+        # Import lazily so tests can patch without torch present
+        from core.analysis.embeddings import (
+            _EMBEDDING_MODEL_TAG,
+            extract_clip_embeddings_batch,
+            unload_model,
+        )
+
+        # Always-unload pattern (matches gaze_worker.py). Sequential phase
+        # ordering guarantees no concurrent embeddings consumer is active,
+        # so we don't need a TOCTOU-safe check — just unload in `finally`.
+        processed = 0
+        try:
+            for chunk_start in range(0, total, self._chunk_size):
+                if self.is_cancelled():
+                    self._log_cancelled()
+                    break
+
+                chunk = clips_to_process[chunk_start : chunk_start + self._chunk_size]
+                thumbnail_paths = [thumb for _clip, thumb in chunk]
+
+                try:
+                    vectors = extract_clip_embeddings_batch(thumbnail_paths)
+                except Exception as exc:  # noqa: BLE001 — treat as fatal for this run
+                    logger.exception("Embedding extraction failed on chunk")
+                    self.error.emit(f"Embedding extraction failed: {exc}")
+                    break
+
+                # Map vectors back to clips 1:1 by index within this chunk.
+                for (clip, _thumb), vec in zip(chunk, vectors):
+                    clip.embedding = vec
+                    clip.embedding_model = _EMBEDDING_MODEL_TAG
+                    self.embedding_ready.emit(clip.id)
+
+                processed += len(chunk)
+                self.progress.emit(processed, total)
+        finally:
+            # Always unload when we're done — matches gaze_worker.py.
+            try:
+                unload_model()
+            except Exception:
+                logger.debug("unload_model() raised during cleanup; ignoring")
+            self.analysis_completed.emit()
+            self._log_complete()


### PR DESCRIPTION
## Summary

Adds **Generate Embeddings** as a first-class checkbox in the Analyze tab, alongside other analysis operations like Extract Colors, Classify Shots, and Detect Gaze. Before this, embeddings were only computed as a side effect of running `similarity_chain` / `staccato`, with no UI affordance to compute them directly — which made the new [Free Association sequencer](https://github.com/dvschultz/algorithmic-filmmaking/pull/87) (and other embedding-using algorithms) harder to get good results from on a fresh project.

## Design

See [`docs/plans/2026-04-13-001-feat-embeddings-analysis-operation-plan.md`](docs/plans/2026-04-13-001-feat-embeddings-analysis-operation-plan.md) for full context.

Most of the plumbing already existed:
- `core/cost_estimates.py` already had `TIME_PER_CLIP`, `OPERATION_LABELS`, `METADATA_CHECKS` entries for `embeddings`
- `core/feature_registry.py` already had `FEATURE_DEPS["embeddings"]` (torch + transformers)
- `core/analysis/embeddings.py` already exposed `extract_clip_embeddings_batch` and the model tag
- `models/clip.py` already had `embedding` + `embedding_model` fields with serialization

The gap was just: register the operation, write a worker, dispatch it. The gaze worker pattern maps almost 1:1.

## What changed

- **Unit 1** — Registered `embeddings` in `core/analysis_operations.py` as `sequential` phase, opt-in default
- **Unit 2** — Added `ui/workers/embedding_worker.py`, mirroring `gaze_worker.py`. Chunked batch processing with always-unload in `finally`, chunk-level errors abort with `error()` signal but preserve partial results
- **Unit 3** — Wired dispatch in `ui/main_window.py` with the usual four `@Slot()` handlers and the documented guard-flag pattern to prevent duplicate Qt signal delivery
- **Unit 4** — Added the `embeddings` branch to `core/analysis_availability.py` so the checkbox disables when every clip already has an embedding (needed by the existing picker dialog test), and added a user-guide section

## Key correctness properties

- ✅ Skip-existing: clips with `embedding is not None` are not re-processed
- ✅ Chunk-level exceptions emit `error()` exactly once; partial results from prior chunks are preserved; `analysis_completed` still fires so the pipeline advances
- ✅ Guard flag prevents duplicate `analysis_completed` delivery (documented codebase bug pattern from `qthread-destroyed-duplicate-signal-delivery-20260124.md`)
- ✅ Always-unload pattern matches gaze exactly — sequential phase ordering means no TOCTOU concerns
- ✅ The existing `_auto_compute_embeddings` fallback (used by similarity_chain / staccato / free_association) is unchanged and still works — it skips clips that already have embeddings, so users who run this operation first get a no-op from the fallback

## Test plan

- [x] `tests/test_analysis_operations.py` — 5 new tests covering registration, phase, opt-in default, label, cloud_capable
- [x] `tests/test_embedding_worker.py` — 8 tests covering filtering, happy path, chunking, cancellation between chunks, chunk-level error path, sources_by_id ignored, empty list early return
- [x] `tests/test_embeddings_dispatch.py` — 4 tests covering dispatch branch, launcher signal wiring, guard-flag duplicate-invocation suppression, error-handler status message
- [x] `tests/test_analysis_availability.py` — 1 new test covering the completeness check
- [x] `tests/test_analysis_picker_dialog.py` — updated the fully-analyzed fixture to populate `clip.embedding`

**Full suite:** 1790 passed, 2 pre-existing unrelated failures (`test_export_bundle_*` — missing USB volume, confirmed on `main`).

## Smoke test before merge

- [ ] Open the app with a project that has clips (and their thumbnails)
- [ ] Go to the Analyze tab, click Run Analysis, select **Generate Embeddings**
- [ ] Confirm the cost gate shows an Embeddings line
- [ ] Click through — first run downloads ~450 MB of DINOv2 weights
- [ ] Verify clips get `embedding` populated (via tooltip, or save + inspect JSON)
- [ ] Go to the Sequence tab and confirm Human Centipede (`similarity_chain`) runs without an auto-compute prompt
- [ ] Save the project, reload, confirm embeddings survive (already covered by existing tests but worth a spot-check)

## Follow-up

Per a deferred question raised in the plan review: once both this PR and #87 land, consider updating `algorithm_config.py` so `free_association` lists `embeddings` in its `required_analysis` — then the cost gate prompts the user to run embeddings first. Currently Free Association falls back to random shortlisting when embeddings are missing; declaring the dependency would make the prompt explicit and UX better.