### PR TITLE
fix(sequencer): Free Association declares embeddings as required

### DIFF
--- a/tests/test_sequence_clip_rationale.py
+++ b/tests/test_sequence_clip_rationale.py
@@ -110,8 +110,8 @@ def test_free_association_registered_in_algorithm_config():
     config = get_algorithm_config("free_association")
     assert config["label"] == "Free Association"
     assert config["is_dialog"] is True
-    assert config["required_analysis"] == ["describe"]
-    # embeddings is NOT required — the core module falls back to random
-    # sampling when embeddings are missing, so gating on them would contradict
-    # graceful degradation
-    assert "embeddings" not in config["required_analysis"]
+    # Both analyses are declared so the cost gate prompts the user to run
+    # them before sequencing. The core module still gracefully falls back
+    # to random sampling if embeddings happen to be missing — the
+    # declaration is UX scaffolding, not a hard dependency.
+    assert set(config["required_analysis"]) == {"describe", "embeddings"}

--- a/ui/algorithm_config.py
+++ b/ui/algorithm_config.py
@@ -111,7 +111,10 @@ ALGORITHM_CONFIG = {
         "label": "Free Association",
         "description": "Build a sequence one clip at a time with an LLM collaborator",
         "allow_duplicates": False,
-        "required_analysis": ["describe"],
+        # Embeddings power the local candidate shortlist — without them the
+        # sequencer falls back to random sampling, which degrades proposal
+        # quality. Declaring them here prompts the user via the cost gate.
+        "required_analysis": ["describe", "embeddings"],
         "is_dialog": True,
         "categories": ["connect", "text"],
     },


### PR DESCRIPTION
## Summary

Declares `embeddings` in `free_association`'s `required_analysis` alongside `describe`. Now that users can run embeddings directly from the Analyze tab (via #88), we can prompt them to do so via the cost gate before opening the Free Association dialog — rather than silently degrading to random candidate shortlisting.

## Why this is safe

The core module's random-sample fallback in `shortlist_candidates()` is **not removed**. If for some reason a clip ends up in the pool without an embedding at runtime (e.g., analysis was partial, a single clip had no thumbnail), the sequencer still works. The `required_analysis` declaration is UX scaffolding — it makes the embedding prerequisite explicit at the cost-gate level rather than letting users discover degraded output after the fact.

## Follow-up context

This was flagged during the plan reviews for both #87 and #88 as a worthwhile follow-up once both features were live. Both are now merged to main.

## Test plan

- [x] Updated `test_free_association_registered_in_algorithm_config` to assert `{"describe", "embeddings"}`
- [x] All 31 tests in the affected files pass
- [ ] Manual smoke test: open a fresh project, go to Sequence tab, click Free Association — cost gate should prompt to run Embeddings (and Describe) if they haven't run yet