### PR TITLE
feat + crash fixes: custom query badges, emoji crash, MLX read-only FS

### DIFF
--- a/core/transcription.py
+++ b/core/transcription.py
@@ -12,6 +12,7 @@ Backend selection:
 - "groq": force cloud transcription via Groq API
 """
 
+import contextlib
 import logging
 import os
 import platform
@@ -39,6 +40,36 @@ _mlx_model = None
 _mlx_model_name = None
 _mlx_whisper_available = None
 _mlx_model_lock = threading.Lock()
+
+
+def _mlx_workdir() -> Path:
+    """Writable parent directory for lightning-whisper-mlx's ``./mlx_models/`` cache.
+
+    The library hardcodes a relative path, so the process CWD must be a
+    writable directory at both load and transcribe time. In frozen macOS
+    builds CWD defaults to ``/`` (read-only), so we redirect to the model
+    cache dir under Application Support.
+    """
+    from core.settings import load_settings
+    workdir = load_settings().model_cache_dir / "mlx_whisper"
+    workdir.mkdir(parents=True, exist_ok=True)
+    return workdir
+
+
+@contextlib.contextmanager
+def _chdir_for_mlx():
+    """Temporarily chdir to the MLX workdir so ``./mlx_models/`` resolves to a writable path."""
+    previous = os.getcwd()
+    try:
+        os.chdir(_mlx_workdir())
+        yield
+    finally:
+        try:
+            os.chdir(previous)
+        except OSError:
+            # Previous CWD may have disappeared (e.g., temp dir cleanup);
+            # fall back to the workdir rather than leaking CWD errors.
+            os.chdir(_mlx_workdir())
 
 
 def _has_audio_stream(path: Path) -> Optional[bool]:
@@ -326,7 +357,11 @@ def get_mlx_model(model_name: str = "small.en"):
         logger.info(f"Loading MLX Whisper model: {mlx_name}")
 
         try:
-            _mlx_model = LightningWhisperMLX(model=mlx_name, batch_size=12)
+            # lightning-whisper-mlx reads/writes ``./mlx_models/`` relative to
+            # CWD — chdir into a writable dir so downloads don't fail with
+            # "Read-only file system" when the frozen app is launched from /.
+            with _chdir_for_mlx():
+                _mlx_model = LightningWhisperMLX(model=mlx_name, batch_size=12)
             _mlx_model_name = mlx_name
             logger.info(f"MLX Whisper model loaded: {mlx_name}")
         except Exception as e:
@@ -453,7 +488,9 @@ def _transcribe_video_mlx(
         if progress_callback:
             progress_callback(0.3, "Transcribing with MLX Whisper...")
 
-        result = mlx_model.transcribe(audio_path=str(tmp_path))
+        # MLX transcribe also resolves ``./mlx_models/<name>`` relative to CWD.
+        with _chdir_for_mlx():
+            result = mlx_model.transcribe(audio_path=str(tmp_path))
 
         if progress_callback:
             progress_callback(0.8, "Processing segments...")
@@ -532,7 +569,8 @@ def transcribe_clip(
 
         if resolved == "mlx-whisper":
             mlx_model = get_mlx_model(model_name)
-            result = mlx_model.transcribe(audio_path=str(tmp_path))
+            with _chdir_for_mlx():
+                result = mlx_model.transcribe(audio_path=str(tmp_path))
             return _parse_mlx_result(result)
 
         # faster-whisper backend

--- a/docs/plans/2026-04-20-001-feat-custom-query-clip-badges-plan.md
+++ b/docs/plans/2026-04-20-001-feat-custom-query-clip-badges-plan.md
@@ -1,0 +1,136 @@
+---
+title: "feat: Show custom query text on matching clip cards"
+type: feat
+status: active
+date: 2026-04-20
+---
+
+# feat: Show custom query text on matching clip cards
+
+## Overview
+
+Replace the generic "Query Match" / "Query No Match" badge on Analyze-tab clip cards with one green badge per matching query, labeled with the actual query text. Non-matching clips show no badge. The clip detail sidebar keeps its current display.
+
+## Problem Frame
+
+The current Analyze-tab clip card shows "Query Match" or "Query No Match" after a Custom Query analysis. This tells you *something* matched but not *what*, and non-match badges add noise without carrying useful information. Running multiple queries compounds the problem — the badge doesn't distinguish which query matched.
+
+## Requirements Trace
+
+- R1. On each Analyze-tab clip card, show one badge per custom query that matched (query text as the label, green background).
+- R2. Clips with no matching queries show no badge (the "Query No Match" badge is removed).
+- R3. If a clip matches multiple queries, show each as a separate badge side-by-side (not comma-separated).
+- R4. Badge visual style matches the Collect tab's CUT/ANALYZED badges — same padding, radius, font size, `badge_analyzed` color tokens.
+- R5. The clip detail sidebar's custom query display is unchanged.
+- R6. Tooltip still shows the full per-query result summary (YES/NO, confidence, model) so users can see non-match results by hovering.
+
+## Scope Boundaries
+
+- No changes to `ui/clip_details_sidebar.py`
+- No changes to the custom query data model (`Clip.custom_queries`)
+- No changes to how custom query analysis runs
+- Badge on the clip browser in the **Analyze** tab only — not introducing custom query badges elsewhere
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `ui/clip_browser.py:47-55` — `get_latest_custom_query_results()` collapses the append-only history to the latest result per query. Keep as-is.
+- `ui/clip_browser.py:231-233` — current `self.custom_query_label` (single QLabel) added to `info_layout`. Will be replaced with a flow container for multiple badges.
+- `ui/clip_browser.py:637-655` — `_update_custom_query_badge()`. Current logic: any_match → "Query Match" green, else → "Query No Match" orange. Replace with: iterate matching queries, emit one badge each; hide container if zero matches.
+- `ui/clip_browser.py:618-635` — `_custom_query_tooltip()` builds the hover summary. Reuse on each badge and/or the container.
+- `ui/source_thumbnail.py:130-148` — reference style for the preferred badge design (`badge_style` string with `TypeScale.XS`, `Spacing.XXS`/`Spacing.SM` padding, `Radii.SM`, `badge_analyzed` text/background). The clip browser should match this.
+
+### Institutional Learnings
+
+None directly relevant — this is a small UI polish change.
+
+## Key Technical Decisions
+
+- **Replace the single QLabel with a flow container** (`QHBoxLayout` holding N badge QLabels). Each badge is one matched query.
+- **Reuse Collect-tab badge styling** by factoring the style string used in `source_thumbnail._update_badge()` — or inline the same declaration in clip_browser. Keep tokens (`TypeScale.XS`, `Radii.SM`, `Spacing.XXS`/`SM`, `theme().badge_analyzed`) identical so the two surfaces stay visually consistent.
+- **Truncate long queries** in the badge text to keep cards from ballooning. Full query text remains in the tooltip. Threshold to be decided during implementation based on card width (not critical for v1).
+- **Hide the container entirely when zero matches** — matches R2 and avoids empty whitespace.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Multi-match layout: separate badges side-by-side (user confirmed).
+- Styling source: Collect tab's CUT/ANALYZED badges (user confirmed).
+
+### Deferred to Implementation
+
+- Badge truncation threshold: the right max-chars depends on observed card width and font metrics. Pick a value when implementing and refine if it clips common queries.
+- Whether long-running queries wrap or horizontally scroll when many matches exist: start with flow-wrap or hidden overflow; revisit if a clip commonly matches 5+ queries.
+
+## Implementation Units
+
+- [ ] **Unit 1: Replace single badge with flow container of per-query badges**
+
+  **Goal:** Swap `self.custom_query_label` for a badge container that shows one green badge per matching query, hides when zero matches, and uses Collect-tab badge styling.
+
+  **Requirements:** R1, R2, R3, R4, R6
+
+  **Dependencies:** None
+
+  **Files:**
+  - Modify: `ui/clip_browser.py` — `ClipThumbnail.__init__` (widget creation, ~line 231), `_update_custom_query_badge()` (~line 637)
+  - Test: `tests/test_custom_query_ui.py` (extend existing tests)
+
+  **Approach:**
+  - Replace the single `self.custom_query_label = QLabel()` with `self.custom_query_container = QWidget()` + `QHBoxLayout` (right-aligned, matching current label alignment).
+  - In `_update_custom_query_badge()`:
+    - Clear existing badge widgets from the container
+    - From `get_latest_custom_query_results()`, filter to entries where `bool(result.get("match"))` is True
+    - If zero: hide the container, clear tooltip, return
+    - For each matching result: create a QLabel with the query text, apply the Collect-tab badge style (`TypeScale.XS`, `Radii.SM`, `Spacing.XXS`/`Spacing.SM` padding, `badge_analyzed` text/background), set per-badge tooltip (reuse `_custom_query_tooltip()` or a scoped variant for the specific query), add to layout
+    - Show the container
+  - Keep `_custom_query_tooltip()` for hover-over-container and/or per-badge hover — on hover the user still needs to see non-match results, so applying it to the container is fine; it's not lost just because no non-match badge renders.
+
+  **Patterns to follow:**
+  - Style declaration mirrors `ui/source_thumbnail.py:_update_badge()` exactly (tokens and order) so the two surfaces look identical.
+  - Widget cleanup pattern: see `ui/source_browser.py` for how existing widgets are removed from a layout before re-adding (avoid memory leaks in repeated updates).
+
+  **Test scenarios:**
+  - Happy path: clip with custom_queries `[{"query": "dog", "match": True}]` → container visible with 1 badge showing "dog", green background
+  - Happy path: clip with two matching queries `[{"query": "dog", "match": True}, {"query": "animal", "match": True}]` → container shows 2 badges side-by-side
+  - Happy path: clip with mixed results `[{"query": "dog", "match": True}, {"query": "car", "match": False}]` → container shows 1 badge ("dog") only
+  - Edge case: clip with all non-match queries `[{"query": "car", "match": False}]` → container hidden, no badges rendered
+  - Edge case: clip with no custom_queries → container hidden (regression of existing behavior)
+  - Edge case: clip with empty custom_queries list → container hidden
+  - Edge case: clip with query where "match" key is missing or None → treated as non-match, not rendered
+  - Edge case: repeated `_update_custom_query_badge()` calls (clip selected, re-selected) do not leak widgets — badge count equals current match count after each call
+  - Integration: badge tooltip on hover still shows the full YES/NO summary including non-matches (so users can discover hidden non-matches without opening the sidebar)
+  - Integration: clip details sidebar's custom query display is unaffected by this change (assert sidebar renders the same text before/after the update)
+
+  **Verification:**
+  - Running a custom query "dog" on a set of clips displays a green "dog" badge on matching clip cards and no badge on non-matching ones.
+  - Running a second custom query "car" alongside adds a second badge only where that clip matched "car".
+  - The Analyze tab and Collect tab badges are visually consistent (same padding, radius, font size, color tokens).
+
+## System-Wide Impact
+
+- **Interaction graph:** Only the Analyze-tab clip card badge render changes. No observer/callback changes, no data model changes.
+- **Error propagation:** `get_latest_custom_query_results()` already handles malformed entries by skipping them; no new error paths.
+- **State lifecycle risks:** Re-rendering the badge container must clean up the previous badge widgets to avoid memory leaks across repeated updates (scroll, filter change, re-analysis). Covered by the repeat-update test scenario.
+- **API surface parity:** Clip details sidebar and any other clip-visualization surfaces remain unchanged.
+- **Unchanged invariants:** `Clip.custom_queries` schema, `_custom_query_tooltip()` content, sidebar rendering, analysis pipeline.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Multiple badges overflow narrow cards | Start with simple horizontal flow; if overflow is visible in practice, add wrapping or truncate per-badge text (planning-time decision deferred to implementation). |
+| Memory leak from re-adding badge widgets on every update | Explicitly remove/deleteLater existing children before re-adding; covered by test scenario. |
+| Visual drift between Collect and Analyze badges over time | Factoring: consider a shared `badge_style()` helper (optional, not required for v1). |
+
+## Documentation / Operational Notes
+
+- `docs/user-guide/analysis.md` mentions Custom Query — update the description if it references the "Query Match" label wording (check during implementation; may be untouched).
+- No changelog entry needed (lightweight UI polish).
+
+## Sources & References
+
+- Related code: `ui/clip_browser.py` (target), `ui/source_thumbnail.py` (style reference), `models/clip.py` (Clip.custom_queries data model), `tests/test_custom_query_ui.py` (existing tests)
+- User-provided screenshots describing current state and preferred design

--- a/tests/test_custom_query_ui.py
+++ b/tests/test_custom_query_ui.py
@@ -66,18 +66,21 @@ def test_clip_browser_filters_by_selected_custom_queries_with_and_logic(qapp, so
     latest_no_match_thumb = browser._thumbnail_by_id["c3"]
     none_thumb = browser._thumbnail_by_id["c4"]
 
-    assert both_thumb.custom_query_label.text() == "Query Match"
-    assert both_thumb.custom_query_label.isHidden() is False
-    assert "YES: blue car" in both_thumb.custom_query_label.toolTip()
-    assert "YES: person running" in both_thumb.custom_query_label.toolTip()
-    assert "NO: blue car" not in both_thumb.custom_query_label.toolTip()
+    # Clip with two matching queries shows two separate badges, one per query
+    assert both_thumb.custom_query_container.isHidden() is False
+    both_labels = sorted(badge.text() for badge in both_thumb._custom_query_badges)
+    assert both_labels == ["blue car", "person running"]
+    assert "YES: blue car" in both_thumb.custom_query_container.toolTip()
+    assert "YES: person running" in both_thumb.custom_query_container.toolTip()
+    # Tooltip retains non-match history even when hidden from badges
+    assert "NO: blue car" not in both_thumb.custom_query_container.toolTip()
 
-    assert latest_no_match_thumb.custom_query_label.text() == "Query No Match"
-    assert latest_no_match_thumb.custom_query_label.isHidden() is False
-    assert "NO: blue car" in latest_no_match_thumb.custom_query_label.toolTip()
-    assert "YES: blue car" not in latest_no_match_thumb.custom_query_label.toolTip()
+    # Clip whose latest result is a no-match shows no badge and hides the container
+    assert latest_no_match_thumb.custom_query_container.isHidden() is True
+    assert latest_no_match_thumb._custom_query_badges == []
 
-    assert none_thumb.custom_query_label.isHidden() is True
+    # Clip with no custom queries hides the container
+    assert none_thumb.custom_query_container.isHidden() is True
 
     assert sorted(browser._custom_query_filter_actions) == ["blue car", "person running"]
 
@@ -151,6 +154,66 @@ def test_custom_query_ready_updates_tabs_sidebar_and_dirty_state(source):
     assert cut_calls == [(clip.id, clip.custom_queries)]
     assert sidebar_calls == [(clip.id, clip.custom_queries)]
     assert dirty_calls == [True]
+
+
+def test_clip_thumbnail_custom_query_badges_edge_cases(qapp, source):
+    """Badge container hides on non-matches and cleanly re-renders on updates."""
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+
+    # Missing match key → treated as no-match, container hidden
+    clip_missing = make_test_clip("c-missing")
+    clip_missing.custom_queries = [
+        {"query": "blue car", "confidence": 0.5, "model": "qwen3-vl-4b"},
+    ]
+
+    # Empty queries list → container hidden
+    clip_empty = make_test_clip("c-empty")
+    clip_empty.custom_queries = []
+
+    browser.add_clip(clip_missing, source)
+    browser.add_clip(clip_empty, source)
+    qapp.processEvents()
+
+    missing_thumb = browser._thumbnail_by_id["c-missing"]
+    empty_thumb = browser._thumbnail_by_id["c-empty"]
+
+    assert missing_thumb.custom_query_container.isHidden() is True
+    assert missing_thumb._custom_query_badges == []
+    assert empty_thumb.custom_query_container.isHidden() is True
+
+    # Repeat-update scenario: updating a thumbnail's custom_queries should not
+    # leak badge widgets across re-renders. Start with two matches, then
+    # reduce to one, and verify the badge count tracks the match count.
+    clip = make_test_clip("c-repeat")
+    clip.custom_queries = [
+        {"query": "dog", "match": True, "confidence": 0.9, "model": "m"},
+        {"query": "cat", "match": True, "confidence": 0.85, "model": "m"},
+    ]
+    browser.add_clip(clip, source)
+    qapp.processEvents()
+
+    thumb = browser._thumbnail_by_id["c-repeat"]
+    assert len(thumb._custom_query_badges) == 2
+
+    # Reduce to one matching query and re-update
+    clip.custom_queries = [
+        {"query": "dog", "match": True, "confidence": 0.9, "model": "m"},
+    ]
+    thumb._update_custom_query_badge()
+    qapp.processEvents()
+    assert len(thumb._custom_query_badges) == 1
+    assert thumb._custom_query_badges[0].text() == "dog"
+
+    # Reduce to zero — container should hide
+    clip.custom_queries = [
+        {"query": "dog", "match": False, "confidence": 0.1, "model": "m"},
+    ]
+    thumb._update_custom_query_badge()
+    qapp.processEvents()
+    assert thumb._custom_query_badges == []
+    assert thumb.custom_query_container.isHidden() is True
 
 
 def test_clip_details_sidebar_allows_editing_custom_queries(qapp, source):

--- a/tests/test_dependency_manager_progress.py
+++ b/tests/test_dependency_manager_progress.py
@@ -282,6 +282,12 @@ def test_install_for_feature_batches_missing_packages_and_validates_runtime(monk
         "core.feature_registry._validate_feature_runtime",
         lambda name: validated.append(name),
     )
+    # Exercise the full reinstall batch — the in-process-loaded-packages filter
+    # is tested separately.
+    monkeypatch.setattr(
+        "core.feature_registry._filter_already_loaded_packages",
+        lambda names: list(names),
+    )
 
     assert install_for_feature("describe_local_cpu", _on_progress) is True
     assert package_batches == [["torch>=1.0", "torchvision>=1.0", "transformers>=1.0", "tokenizers>=1.0"]]
@@ -308,6 +314,10 @@ def test_install_for_feature_reinstalls_broken_runtime_even_when_packages_exist(
     monkeypatch.setattr("core.dependency_manager.get_pip_specifier", lambda name: f"{name}>=1.0")
     monkeypatch.setattr("core.dependency_manager.install_packages", _fake_install)
     monkeypatch.setattr("core.dependency_manager.install_native_packages", _fake_install)
+    monkeypatch.setattr(
+        "core.feature_registry._filter_already_loaded_packages",
+        lambda names: list(names),
+    )
 
     assert install_for_feature("shot_classify") is True
     assert validations == ["shot_classify", "shot_classify"]
@@ -403,6 +413,10 @@ def test_install_for_feature_repairs_full_runtime_stack_when_only_subset_is_miss
     monkeypatch.setattr(
         "core.dependency_manager.install_native_packages", fake_installer,
     )
+    monkeypatch.setattr(
+        "core.feature_registry._filter_already_loaded_packages",
+        lambda names: list(names),
+    )
 
     assert install_for_feature(feature_name) is True
     assert cleared == [expected_packages]
@@ -427,3 +441,48 @@ def test_install_for_feature_repairs_full_runtime_stack_when_only_subset_is_miss
 def test_runtime_validated_analysis_features_force_full_repair(feature_name):
     """Runtime-validated analysis features should prefer a full repair install."""
     assert requires_full_package_repair(feature_name, ["package:anything"]) is True
+
+
+def test_filter_already_loaded_packages_skips_loaded_c_extensions(monkeypatch):
+    """Packages whose top-level module is in sys.modules are filtered out."""
+    from core.feature_registry import _filter_already_loaded_packages
+
+    # Simulate torch loaded, ultralytics not loaded
+    fake_modules = {"torch": object()}
+    monkeypatch.setattr("core.feature_registry.sys.modules", fake_modules)
+
+    result = _filter_already_loaded_packages(["torch", "ultralytics"])
+    assert result == ["ultralytics"]
+
+
+def test_filter_already_loaded_packages_strips_version_specifiers(monkeypatch):
+    """Filter handles pip-style version constraints on the package name."""
+    from core.feature_registry import _filter_already_loaded_packages
+
+    fake_modules = {"torch": object()}
+    monkeypatch.setattr("core.feature_registry.sys.modules", fake_modules)
+
+    result = _filter_already_loaded_packages(["torch>=2.4,<2.7", "ultralytics>=8.4.0"])
+    assert result == ["ultralytics>=8.4.0"]
+
+
+def test_filter_already_loaded_packages_ignores_safe_packages(monkeypatch):
+    """Packages not on the unsafe list are never filtered even if loaded."""
+    from core.feature_registry import _filter_already_loaded_packages
+
+    # "certifi" is loaded but not on the unsafe-to-reload list
+    fake_modules = {"certifi": object()}
+    monkeypatch.setattr("core.feature_registry.sys.modules", fake_modules)
+
+    result = _filter_already_loaded_packages(["certifi"])
+    assert result == ["certifi"]
+
+
+def test_filter_already_loaded_packages_with_none_loaded(monkeypatch):
+    """With no unsafe packages loaded, the full list passes through."""
+    from core.feature_registry import _filter_already_loaded_packages
+
+    monkeypatch.setattr("core.feature_registry.sys.modules", {})
+
+    result = _filter_already_loaded_packages(["torch", "ultralytics"])
+    assert result == ["torch", "ultralytics"]

--- a/ui/algorithm_config.py
+++ b/ui/algorithm_config.py
@@ -2,13 +2,17 @@
 
 Used by sequence_tab.py (labels, descriptions, allow_duplicates) and
 sorting_card_grid.py (icons, labels, descriptions, categories).
+
+Icons are currently empty strings. Rendering emoji glyphs via QLabel on
+macOS can hit a CoreText sbix→ImageIO crash (EXC_BAD_ACCESS at 0xbad4007
+inside CopyEmojiImage); SVG icons will replace this field in a later pass.
 """
 
 CATEGORY_ORDER = ["All", "Arrange", "Find", "Connect", "Audio", "Text"]
 
 ALGORITHM_CONFIG = {
     "color": {
-        "icon": "\U0001f3a8",
+        "icon": "",
         "label": "Chromatics",
         "description": "Arrange clips along a color gradient or cycle through the spectrum",
         "allow_duplicates": False,
@@ -16,7 +20,7 @@ ALGORITHM_CONFIG = {
         "categories": ["arrange"],
     },
     "duration": {
-        "icon": "\u23f1\ufe0f",
+        "icon": "",
         "label": "Tempo Shift",
         "description": "Order clips from shortest to longest (or reverse)",
         "allow_duplicates": False,
@@ -24,7 +28,7 @@ ALGORITHM_CONFIG = {
         "categories": ["arrange"],
     },
     "brightness": {
-        "icon": "\U0001f317",
+        "icon": "",
         "label": "Into the Dark",
         "description": "Arrange clips from light to shadow, or shadow to light",
         "allow_duplicates": False,
@@ -32,7 +36,7 @@ ALGORITHM_CONFIG = {
         "categories": ["arrange"],
     },
     "volume": {
-        "icon": "\U0001f50a",
+        "icon": "",
         "label": "Crescendo",
         "description": "Build from silence to thunder, or thunder to silence",
         "allow_duplicates": False,
@@ -40,7 +44,7 @@ ALGORITHM_CONFIG = {
         "categories": ["arrange", "audio"],
     },
     "shuffle": {
-        "icon": "\U0001f3b2",
+        "icon": "",
         "label": "Hatchet Job",
         "description": "Randomly shuffle clips into a new order",
         "allow_duplicates": False,
@@ -49,7 +53,7 @@ ALGORITHM_CONFIG = {
         "categories": ["arrange"],
     },
     "sequential": {
-        "icon": "\U0001f4cb",
+        "icon": "",
         "label": "Time Capsule",
         "description": "Keep clips in their original order",
         "allow_duplicates": False,
@@ -57,7 +61,7 @@ ALGORITHM_CONFIG = {
         "categories": ["arrange"],
     },
     "shot_type": {
-        "icon": "\U0001f3ac",
+        "icon": "",
         "label": "Focal Ladder",
         "description": "Arrange clips by camera shot scale",
         "allow_duplicates": False,
@@ -65,7 +69,7 @@ ALGORITHM_CONFIG = {
         "categories": ["arrange"],
     },
     "proximity": {
-        "icon": "\U0001f52d",
+        "icon": "",
         "label": "Up Close and Personal",
         "description": "Glide from distant vistas to intimate close-ups",
         "allow_duplicates": False,
@@ -73,7 +77,7 @@ ALGORITHM_CONFIG = {
         "categories": ["arrange"],
     },
     "similarity_chain": {
-        "icon": "\U0001f517",
+        "icon": "",
         "label": "Human Centipede",
         "description": "Chain clips together by visual similarity",
         "allow_duplicates": False,
@@ -81,7 +85,7 @@ ALGORITHM_CONFIG = {
         "categories": ["connect"],
     },
     "match_cut": {
-        "icon": "\u2702\ufe0f",
+        "icon": "",
         "label": "Match Cut",
         "description": "Find hidden connections between clips at cut points",
         "allow_duplicates": False,
@@ -89,7 +93,7 @@ ALGORITHM_CONFIG = {
         "categories": ["connect"],
     },
     "exquisite_corpus": {
-        "icon": "\U0001f4dd",
+        "icon": "",
         "label": "Exquisite Corpus",
         "description": "Generate a poem from on-screen text",
         "allow_duplicates": True,
@@ -98,7 +102,7 @@ ALGORITHM_CONFIG = {
         "categories": ["text"],
     },
     "storyteller": {
-        "icon": "\U0001f4d6",
+        "icon": "",
         "label": "Storyteller",
         "description": "Create a narrative from clip descriptions",
         "allow_duplicates": False,
@@ -107,7 +111,7 @@ ALGORITHM_CONFIG = {
         "categories": ["text"],
     },
     "free_association": {
-        "icon": "\U0001f4ad",  # thought balloon
+        "icon": "",
         "label": "Free Association",
         "description": "Build a sequence one clip at a time with an LLM collaborator",
         "allow_duplicates": False,
@@ -119,7 +123,7 @@ ALGORITHM_CONFIG = {
         "categories": ["connect", "text"],
     },
     "reference_guided": {
-        "icon": "\U0001f3af",
+        "icon": "",
         "label": "Reference Guide",
         "description": "Match your clips to a reference video's structure",
         "allow_duplicates": True,
@@ -128,7 +132,7 @@ ALGORITHM_CONFIG = {
         "categories": ["connect", "audio"],
     },
     "signature_style": {
-        "icon": "\u270d\ufe0f",
+        "icon": "",
         "label": "Signature Style",
         "description": "Interpret a drawing as an editing guide",
         "allow_duplicates": True,
@@ -137,7 +141,7 @@ ALGORITHM_CONFIG = {
         "categories": ["connect"],
     },
     "rose_hobart": {
-        "icon": "\U0001f464",
+        "icon": "",
         "label": "Rose Hobart",
         "description": "Isolate clips featuring a specific person",
         "allow_duplicates": False,
@@ -146,7 +150,7 @@ ALGORITHM_CONFIG = {
         "categories": ["find"],
     },
     "staccato": {
-        "icon": "\U0001f3b5",
+        "icon": "",
         "label": "Staccato",
         "description": "Cut clips to the rhythm of a music track",
         "allow_duplicates": True,
@@ -155,7 +159,7 @@ ALGORITHM_CONFIG = {
         "categories": ["audio"],
     },
     "gaze_sort": {
-        "icon": "\U0001f441",
+        "icon": "",
         "label": "Gaze Sort",
         "description": "Arrange clips by gaze direction",
         "allow_duplicates": False,
@@ -163,7 +167,7 @@ ALGORITHM_CONFIG = {
         "categories": ["arrange", "find"],
     },
     "gaze_consistency": {
-        "icon": "\U0001f440",
+        "icon": "",
         "label": "Gaze Consistency",
         "description": "Group clips by matching gaze direction",
         "allow_duplicates": False,
@@ -171,7 +175,7 @@ ALGORITHM_CONFIG = {
         "categories": ["find"],
     },
     "eyes_without_a_face": {
-        "icon": "\U0001f441\ufe0f\u200d\U0001f5e8\ufe0f",
+        "icon": "",
         "label": "Eyes Without a Face",
         "description": "Eyeline matching, gaze filtering, and rotation sequencing",
         "allow_duplicates": False,

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -228,9 +228,15 @@ class ClipThumbnail(QFrame):
         else:
             self.gaze_label.setVisible(False)
 
-        self.custom_query_label = QLabel()
-        self.custom_query_label.setAlignment(Qt.AlignRight)
-        info_layout.addWidget(self.custom_query_label)
+        # Container for one badge per matching custom query (flows right-aligned)
+        self.custom_query_container = QWidget()
+        self.custom_query_container.setStyleSheet("background: transparent; border: none;")
+        custom_query_layout = QHBoxLayout(self.custom_query_container)
+        custom_query_layout.setContentsMargins(0, 0, 0, 0)
+        custom_query_layout.setSpacing(Spacing.XXS)
+        custom_query_layout.addStretch()
+        self._custom_query_badges: list[QLabel] = []
+        info_layout.addWidget(self.custom_query_container)
         self._update_custom_query_badge()
         info_layout.addWidget(self.gaze_label)
         info_layout.addWidget(self.shot_type_label)
@@ -635,24 +641,46 @@ class ClipThumbnail(QFrame):
         return "\n".join(lines)
 
     def _update_custom_query_badge(self):
-        """Update the custom query badge based on stored results."""
+        """Render one badge per matching custom query; hide the container when none match."""
+        # Clear existing badge widgets to avoid leaks on repeated updates.
+        for badge in self._custom_query_badges:
+            badge.deleteLater()
+        self._custom_query_badges = []
+
         latest_results = get_latest_custom_query_results(self.clip.custom_queries)
-        if not latest_results:
-            self.custom_query_label.setVisible(False)
-            self.custom_query_label.setToolTip("")
+        matching = [
+            result for result in latest_results.values()
+            if bool(result.get("match"))
+        ]
+
+        if not matching:
+            self.custom_query_container.setVisible(False)
+            self.custom_query_container.setToolTip("")
             return
 
-        any_match = any(bool(result.get("match")) for result in latest_results.values())
-        background = theme().accent_green if any_match else theme().accent_orange
-        text = "Query Match" if any_match else "Query No Match"
-
-        self.custom_query_label.setText(text)
-        self.custom_query_label.setToolTip(self._custom_query_tooltip())
-        self.custom_query_label.setStyleSheet(
-            f"font-size: {TypeScale.XS}px; color: {theme().text_inverted}; background-color: {background}; "
-            f"border-radius: {Radii.SM}px; padding: {Spacing.XXS}px {Spacing.XS}px;"
+        # Style matches Collect-tab CUT/ANALYZED badges (ui/source_thumbnail.py).
+        badge_style = (
+            f"font-size: {TypeScale.XS}px; "
+            f"color: {theme().badge_analyzed_text}; "
+            f"background-color: {theme().badge_analyzed}; "
+            f"border-radius: {Radii.SM}px; "
+            f"padding: {Spacing.XXS}px {Spacing.SM}px;"
         )
-        self.custom_query_label.setVisible(True)
+        tooltip = self._custom_query_tooltip()
+        layout = self.custom_query_container.layout()
+        for result in matching:
+            query = str(result.get("query") or "").strip()
+            if not query:
+                continue
+            badge = QLabel(query)
+            badge.setAlignment(Qt.AlignCenter)
+            badge.setStyleSheet(badge_style)
+            badge.setToolTip(tooltip)
+            layout.addWidget(badge)
+            self._custom_query_badges.append(badge)
+
+        self.custom_query_container.setToolTip(tooltip)
+        self.custom_query_container.setVisible(bool(self._custom_query_badges))
 
 
 class ClipBrowser(QWidget):

--- a/ui/tabs/sequence_tab.py
+++ b/ui/tabs/sequence_tab.py
@@ -439,7 +439,7 @@ class SequenceTab(BaseTab):
             estimates: List of OperationEstimate from cost engine
         """
         config = get_algorithm_config(algorithm)
-        self._confirm_algo_label.setText(f"{config['icon']}  {config['label']}")
+        self._confirm_algo_label.setText(config['label'])
         self._confirm_clips_label.setText(f"{len(clips)} clips selected")
         self._confirm_cost_panel.set_estimates(estimates)
         self._update_confirm_warnings(estimates)

--- a/ui/widgets/sorting_card.py
+++ b/ui/widgets/sorting_card.py
@@ -63,13 +63,17 @@ class SortingCard(QFrame):
         layout.setContentsMargins(Spacing.LG, Spacing.LG, Spacing.LG, Spacing.LG)
         layout.setSpacing(Spacing.SM)
 
-        # Icon
-        self.icon_label = QLabel(self._icon)
-        icon_font = QFont()
-        icon_font.setPointSize(TypeScale.XXXL)
-        self.icon_label.setFont(icon_font)
-        self.icon_label.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.icon_label)
+        # Icon — skipped when empty. Rendering emoji glyphs via QLabel on
+        # macOS can hit a CoreText sbix→ImageIO crash (EXC_BAD_ACCESS at
+        # 0xbad4007 inside CopyEmojiImage); keeping the icon slot empty until
+        # we ship proper SVG icons avoids that path.
+        self.icon_label = QLabel(self._icon) if self._icon else None
+        if self.icon_label is not None:
+            icon_font = QFont()
+            icon_font.setPointSize(TypeScale.XXXL)
+            self.icon_label.setFont(icon_font)
+            self.icon_label.setAlignment(Qt.AlignCenter)
+            layout.addWidget(self.icon_label)
 
         # Title
         self.title_label = QLabel(self._title)
@@ -167,7 +171,8 @@ class SortingCard(QFrame):
 
         sec_color = theme().text_muted if not self._enabled else theme().text_secondary
 
-        self.icon_label.setStyleSheet(f"color: {color}; background: transparent;")
+        if self.icon_label is not None:
+            self.icon_label.setStyleSheet(f"color: {color}; background: transparent;")
         self.title_label.setStyleSheet(f"color: {color}; background: transparent;")
         self.desc_label.setStyleSheet(f"color: {sec_color}; background: transparent;")
 


### PR DESCRIPTION
## Summary
- **feat(analyze):** show query text on matching clip badges (one badge per matching custom query, Collect-tab styling)
- **fix(ui):** remove emoji from sequencer cards — rendering emoji via QLabel on macOS can hit CoreText `CopyEmojiImage` → `EXC_BAD_ACCESS 0xbad4007` in Qt paint
- **fix(transcription):** chdir MLX Whisper to writable cache dir — `lightning-whisper-mlx` hardcodes `./mlx_models/` relative to CWD, which fails on frozen macOS apps (CWD is `/`, read-only)

## Test plan
- [x] Unit + integration tests pass (1871 tests)
- [ ] Verify custom query badges render correctly per matching query (Analyze tab)
- [ ] Verify sequencer cards render without emoji (no crash on long sessions)
- [ ] Verify MLX Whisper transcription works after clearing model cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)