### PR TITLE
feat: Comprehensive clip filter sidebar for Cut and Analyze tabs

### DIFF
--- a/core/analysis/classification.py
+++ b/core/analysis/classification.py
@@ -21,6 +21,25 @@ _labels: Optional[list[str]] = None
 _preprocess = None
 
 
+def load_imagenet_class_list() -> list[str]:
+    """Return the cached ImageNet 1000-class label list.
+
+    Reads `<model_cache_dir>/imagenet_classes.txt` if it exists; otherwise
+    returns an empty list (caller can fall back gracefully — the filter
+    sidebar disables its typeahead when the vocab is empty). Does not
+    trigger a download; that happens lazily on first classification run.
+    """
+    cache_dir = _get_model_cache_dir()
+    labels_path = cache_dir / "imagenet_classes.txt"
+    if not labels_path.exists():
+        return []
+    try:
+        with open(labels_path, "r") as f:
+            return [line.strip() for line in f.readlines() if line.strip()]
+    except OSError:
+        return []
+
+
 def ensure_image_classification_runtime_available():
     """Validate that the local image-classification runtime imports cleanly."""
     try:

--- a/core/filter_state.py
+++ b/core/filter_state.py
@@ -60,6 +60,12 @@ class FilterState(QObject):
         "has_analysis_ops",
         "enabled_filter",
         "tag_note_search",
+        # Unit 6 additions — objects / ImageNet / YOLO
+        "imagenet_labels",
+        "imagenet_mode",
+        "yolo_labels",
+        "yolo_total_count",
+        "yolo_per_label_rules",
     )
 
     def __init__(self, parent: Optional[QObject] = None):
@@ -92,6 +98,12 @@ class FilterState(QObject):
         object.__setattr__(self, "has_analysis_ops", set())
         object.__setattr__(self, "enabled_filter", None)
         object.__setattr__(self, "tag_note_search", "")
+        # Unit 6 fields
+        object.__setattr__(self, "imagenet_labels", set())
+        object.__setattr__(self, "imagenet_mode", "any")  # "any" | "all"
+        object.__setattr__(self, "yolo_labels", set())
+        object.__setattr__(self, "yolo_total_count", None)  # (op, int) | None
+        object.__setattr__(self, "yolo_per_label_rules", [])  # list[(label, op, int)]
 
     # ── Dirty-tracking field assignment ─────────────────────────────
 
@@ -214,6 +226,32 @@ class FilterState(QObject):
 
             if "tag_note_search" in filters:
                 self.tag_note_search = (filters["tag_note_search"] or "").strip()
+
+            # Unit 6 fields
+            if "imagenet_labels" in filters:
+                self.imagenet_labels = _coerce_str_set(filters["imagenet_labels"])
+            if "imagenet_mode" in filters:
+                value = filters["imagenet_mode"]
+                if value in {"any", "all"}:
+                    self.imagenet_mode = value
+            if "yolo_labels" in filters:
+                self.yolo_labels = _coerce_str_set(filters["yolo_labels"])
+            if "yolo_total_count" in filters:
+                value = filters["yolo_total_count"]
+                if value is None:
+                    self.yolo_total_count = None
+                elif isinstance(value, (list, tuple)) and len(value) == 2:
+                    self.yolo_total_count = (str(value[0]), int(value[1]))
+            if "yolo_per_label_rules" in filters:
+                value = filters["yolo_per_label_rules"]
+                if not value:
+                    self.yolo_per_label_rules = []
+                else:
+                    rules: list[tuple[str, str, int]] = []
+                    for rule in value:
+                        if isinstance(rule, (list, tuple)) and len(rule) == 3:
+                            rules.append((str(rule[0]), str(rule[1]), int(rule[2])))
+                    self.yolo_per_label_rules = rules
         finally:
             self._end_batch()
 
@@ -253,6 +291,16 @@ class FilterState(QObject):
             "has_analysis_ops": sorted(self.has_analysis_ops) if self.has_analysis_ops else None,
             "enabled_filter": self.enabled_filter,
             "tag_note_search": self.tag_note_search or None,
+            # Unit 6 fields
+            "imagenet_labels": sorted(self.imagenet_labels) if self.imagenet_labels else None,
+            "imagenet_mode": self.imagenet_mode if self.imagenet_labels else None,
+            "yolo_labels": sorted(self.yolo_labels) if self.yolo_labels else None,
+            "yolo_total_count": list(self.yolo_total_count) if self.yolo_total_count else None,
+            "yolo_per_label_rules": (
+                [list(r) for r in self.yolo_per_label_rules]
+                if self.yolo_per_label_rules
+                else None
+            ),
         }
 
     def has_active(self) -> bool:
@@ -281,6 +329,11 @@ class FilterState(QObject):
             or bool(self.has_analysis_ops)
             or self.enabled_filter is not None
             or bool(self.tag_note_search)
+            # Unit 6 fields
+            or bool(self.imagenet_labels)
+            or bool(self.yolo_labels)
+            or self.yolo_total_count is not None
+            or bool(self.yolo_per_label_rules)
         )
 
     def clear_all(self) -> None:
@@ -312,6 +365,12 @@ class FilterState(QObject):
             self.has_analysis_ops = set()
             self.enabled_filter = None
             self.tag_note_search = ""
+            # Unit 6 fields
+            self.imagenet_labels = set()
+            self.imagenet_mode = "any"
+            self.yolo_labels = set()
+            self.yolo_total_count = None
+            self.yolo_per_label_rules = []
         finally:
             self._end_batch()
 
@@ -357,6 +416,17 @@ def _emit_enum(value: set[str]):
     if len(value) == 1:
         return next(iter(value))
     return sorted(value, key=str.lower)
+
+
+def _coerce_str_set(value: Any) -> set[str]:
+    """Normalize string-set inputs (ImageNet labels, YOLO labels) to a set[str]."""
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        return {value} if value.strip() else set()
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return {str(v).strip() for v in value if str(v).strip()}
+    return set()
 
 
 def _coerce_tribool(value: Any) -> Optional[bool]:

--- a/core/filter_state.py
+++ b/core/filter_state.py
@@ -6,8 +6,12 @@ tabs point at — they share filter values by default. Later units (FilterSideba
 subscribe to :py:attr:`changed` to know when to re-render their widgets.
 
 The public ``apply_dict`` / ``to_dict`` contract mirrors today's
-``ClipBrowser.apply_filters`` / ``get_active_filters`` dict shape exactly so
-existing tests and any agent tools depending on those keys keep working.
+``ClipBrowser.apply_filters`` / ``get_active_filters`` dict shape, with Unit 4
+extending four enum fields (``shot_type``, ``color_palette``, ``aspect_ratio``,
+``gaze_filter``) from single-select to multi-select. Internally these are
+``set[str]``; ``apply_dict`` coerces string / list / tuple / set / None inputs,
+and ``to_dict`` emits ``None`` (no selection), the single string (one value)
+or a sorted list (multiple values) for backward-compat with existing callers.
 """
 
 from typing import Any, Iterable, Optional
@@ -16,6 +20,7 @@ from PySide6.QtCore import QObject, Signal
 
 
 _ENUM_ALL = "All"
+_ENUM_FIELDS = ("shot_type", "color_palette", "aspect_ratio", "gaze_filter")
 
 
 class FilterState(QObject):
@@ -50,14 +55,15 @@ class FilterState(QObject):
         super().__init__(parent)
         self._batching = False
         self._dirty_during_batch = False
-        object.__setattr__(self, "shot_type", _ENUM_ALL)
-        object.__setattr__(self, "color_palette", _ENUM_ALL)
+        # Multi-select enum fields — empty set means "All" (no filter)
+        object.__setattr__(self, "shot_type", set())
+        object.__setattr__(self, "color_palette", set())
+        object.__setattr__(self, "aspect_ratio", set())
+        object.__setattr__(self, "gaze_filter", set())
         object.__setattr__(self, "search_query", "")
         object.__setattr__(self, "selected_custom_queries", set())
         object.__setattr__(self, "min_duration", None)
         object.__setattr__(self, "max_duration", None)
-        object.__setattr__(self, "aspect_ratio", _ENUM_ALL)
-        object.__setattr__(self, "gaze_filter", None)
         object.__setattr__(self, "object_search", "")
         object.__setattr__(self, "description_search", "")
         object.__setattr__(self, "min_brightness", None)
@@ -69,6 +75,8 @@ class FilterState(QObject):
 
     def __setattr__(self, name: str, value: Any) -> None:
         if name in self._FIELD_NAMES and hasattr(self, name):
+            if name in _ENUM_FIELDS:
+                value = _coerce_enum_set(value)
             current = getattr(self, name)
             if current == value:
                 return
@@ -102,7 +110,9 @@ class FilterState(QObject):
 
         Accepts the exact dict shape produced by :py:meth:`to_dict` plus the
         backward-compat keys used by the pre-refactor ``ClipBrowser.apply_filters``.
-        Unknown keys are ignored.
+        Unknown keys are ignored. Enum fields accept a string (single-select
+        backward compat), a list/tuple/set (multi-select), or ``None`` / ``"All"``
+        (clear).
         """
         self._begin_batch()
         try:
@@ -111,16 +121,13 @@ class FilterState(QObject):
                 self.max_duration = filters.get("max_duration")
 
             if "aspect_ratio" in filters:
-                value = filters["aspect_ratio"]
-                self.aspect_ratio = value if value else _ENUM_ALL
+                self.aspect_ratio = filters["aspect_ratio"]
 
             if "shot_type" in filters:
-                value = filters["shot_type"]
-                self.shot_type = value if value else _ENUM_ALL
+                self.shot_type = filters["shot_type"]
 
             if "color_palette" in filters:
-                value = filters["color_palette"]
-                self.color_palette = value if value else _ENUM_ALL
+                self.color_palette = filters["color_palette"]
 
             if "search_query" in filters:
                 value = filters["search_query"] or ""
@@ -130,7 +137,7 @@ class FilterState(QObject):
                 self.selected_custom_queries = _coerce_custom_query(filters["custom_query"])
 
             if "gaze" in filters:
-                self.gaze_filter = filters["gaze"] or None
+                self.gaze_filter = filters["gaze"]
 
             if "object_search" in filters:
                 self.object_search = (filters["object_search"] or "").strip()
@@ -148,10 +155,15 @@ class FilterState(QObject):
             self._end_batch()
 
     def to_dict(self) -> dict:
-        """Return the active-filters dict matching ``ClipBrowser.get_active_filters``."""
+        """Return the active-filters dict matching ``ClipBrowser.get_active_filters``.
+
+        Enum fields emit ``None`` (no selection), the single string (one value)
+        or a sorted list (multiple values) for backward-compat with callers
+        that expect a string for single-select filters.
+        """
         return {
-            "shot_type": self.shot_type if self.shot_type != _ENUM_ALL else None,
-            "color_palette": self.color_palette if self.color_palette != _ENUM_ALL else None,
+            "shot_type": _emit_enum(self.shot_type),
+            "color_palette": _emit_enum(self.color_palette),
             "search_query": self.search_query if self.search_query else None,
             "custom_query": (
                 sorted(self.selected_custom_queries, key=str.lower)
@@ -160,8 +172,8 @@ class FilterState(QObject):
             ),
             "min_duration": self.min_duration,
             "max_duration": self.max_duration,
-            "aspect_ratio": self.aspect_ratio if self.aspect_ratio != _ENUM_ALL else None,
-            "gaze": self.gaze_filter,
+            "aspect_ratio": _emit_enum(self.aspect_ratio),
+            "gaze": _emit_enum(self.gaze_filter),
             "object_search": self.object_search if self.object_search else None,
             "description_search": self.description_search if self.description_search else None,
             "min_brightness": self.min_brightness,
@@ -171,14 +183,14 @@ class FilterState(QObject):
 
     def has_active(self) -> bool:
         return (
-            self.shot_type != _ENUM_ALL
-            or self.color_palette != _ENUM_ALL
+            bool(self.shot_type)
+            or bool(self.color_palette)
+            or bool(self.aspect_ratio)
+            or bool(self.gaze_filter)
             or bool(self.search_query)
             or bool(self.selected_custom_queries)
             or self.min_duration is not None
             or self.max_duration is not None
-            or self.aspect_ratio != _ENUM_ALL
-            or self.gaze_filter is not None
             or bool(self.object_search)
             or bool(self.description_search)
             or self.min_brightness is not None
@@ -190,14 +202,14 @@ class FilterState(QObject):
         """Reset every field to its default. Emits :py:attr:`changed` at most once."""
         self._begin_batch()
         try:
-            self.shot_type = _ENUM_ALL
-            self.color_palette = _ENUM_ALL
+            self.shot_type = set()
+            self.color_palette = set()
+            self.aspect_ratio = set()
+            self.gaze_filter = set()
             self.search_query = ""
             self.selected_custom_queries = set()
             self.min_duration = None
             self.max_duration = None
-            self.aspect_ratio = _ENUM_ALL
-            self.gaze_filter = None
             self.object_search = ""
             self.description_search = ""
             self.min_brightness = None
@@ -218,3 +230,34 @@ def _coerce_custom_query(value: Any) -> set[str]:
     if isinstance(value, (list, tuple, set, frozenset)):
         return {str(v).strip() for v in value if str(v).strip()}
     return set()
+
+
+def _coerce_enum_set(value: Any) -> set[str]:
+    """Normalize enum-field inputs to a ``set[str]``.
+
+    Accepts ``None`` / empty / ``"All"`` (clears), a single string (one-item
+    set), or any iterable of strings (drops ``"All"`` sentinel and empties).
+    """
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        if value == _ENUM_ALL or not value.strip():
+            return set()
+        return {value}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        result: set[str] = set()
+        for item in value:
+            s = str(item).strip()
+            if s and s != _ENUM_ALL:
+                result.add(s)
+        return result
+    return set()
+
+
+def _emit_enum(value: set[str]):
+    """Shape an enum set for ``to_dict`` output (backward-compat with callers)."""
+    if not value:
+        return None
+    if len(value) == 1:
+        return next(iter(value))
+    return sorted(value, key=str.lower)

--- a/core/filter_state.py
+++ b/core/filter_state.py
@@ -1,0 +1,220 @@
+"""Shared clip-filter state for the Cut and Analyze tab browsers.
+
+``FilterState`` owns the values that drive :py:meth:`ClipBrowser._matches_filter`.
+In Unit 1 of the filter-sidebar plan, it's a single source of truth that both
+tabs point at — they share filter values by default. Later units (FilterSidebar)
+subscribe to :py:attr:`changed` to know when to re-render their widgets.
+
+The public ``apply_dict`` / ``to_dict`` contract mirrors today's
+``ClipBrowser.apply_filters`` / ``get_active_filters`` dict shape exactly so
+existing tests and any agent tools depending on those keys keep working.
+"""
+
+from typing import Any, Iterable, Optional
+
+from PySide6.QtCore import QObject, Signal
+
+
+_ENUM_ALL = "All"
+
+
+class FilterState(QObject):
+    """Shared filter state for clip browsers.
+
+    Fields mirror the pre-refactor ``ClipBrowser`` filter attributes one-for-one.
+    Assigning a field only emits :py:attr:`changed` if the value actually differs
+    from the current value. :py:meth:`apply_dict` and :py:meth:`clear_all` batch
+    multiple field changes into a single ``changed`` emission.
+    """
+
+    changed = Signal()
+
+    _FIELD_NAMES: tuple[str, ...] = (
+        "shot_type",
+        "color_palette",
+        "search_query",
+        "selected_custom_queries",
+        "min_duration",
+        "max_duration",
+        "aspect_ratio",
+        "gaze_filter",
+        "object_search",
+        "description_search",
+        "min_brightness",
+        "max_brightness",
+        "similarity_anchor_id",
+        "similarity_scores",
+    )
+
+    def __init__(self, parent: Optional[QObject] = None):
+        super().__init__(parent)
+        self._batching = False
+        self._dirty_during_batch = False
+        object.__setattr__(self, "shot_type", _ENUM_ALL)
+        object.__setattr__(self, "color_palette", _ENUM_ALL)
+        object.__setattr__(self, "search_query", "")
+        object.__setattr__(self, "selected_custom_queries", set())
+        object.__setattr__(self, "min_duration", None)
+        object.__setattr__(self, "max_duration", None)
+        object.__setattr__(self, "aspect_ratio", _ENUM_ALL)
+        object.__setattr__(self, "gaze_filter", None)
+        object.__setattr__(self, "object_search", "")
+        object.__setattr__(self, "description_search", "")
+        object.__setattr__(self, "min_brightness", None)
+        object.__setattr__(self, "max_brightness", None)
+        object.__setattr__(self, "similarity_anchor_id", None)
+        object.__setattr__(self, "similarity_scores", {})
+
+    # ── Dirty-tracking field assignment ─────────────────────────────
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in self._FIELD_NAMES and hasattr(self, name):
+            current = getattr(self, name)
+            if current == value:
+                return
+            object.__setattr__(self, name, value)
+            self._mark_dirty()
+            return
+        object.__setattr__(self, name, value)
+
+    def _mark_dirty(self) -> None:
+        if self._batching:
+            self._dirty_during_batch = True
+            return
+        self.changed.emit()
+
+    # ── Batched mutation helpers ────────────────────────────────────
+
+    def _begin_batch(self) -> None:
+        self._batching = True
+        self._dirty_during_batch = False
+
+    def _end_batch(self) -> None:
+        self._batching = False
+        if self._dirty_during_batch:
+            self._dirty_during_batch = False
+            self.changed.emit()
+
+    # ── Public API mirroring ClipBrowser.apply_filters / get_active_filters ──
+
+    def apply_dict(self, filters: dict) -> None:
+        """Apply many filters at once; emits :py:attr:`changed` at most once.
+
+        Accepts the exact dict shape produced by :py:meth:`to_dict` plus the
+        backward-compat keys used by the pre-refactor ``ClipBrowser.apply_filters``.
+        Unknown keys are ignored.
+        """
+        self._begin_batch()
+        try:
+            if "min_duration" in filters or "max_duration" in filters:
+                self.min_duration = filters.get("min_duration")
+                self.max_duration = filters.get("max_duration")
+
+            if "aspect_ratio" in filters:
+                value = filters["aspect_ratio"]
+                self.aspect_ratio = value if value else _ENUM_ALL
+
+            if "shot_type" in filters:
+                value = filters["shot_type"]
+                self.shot_type = value if value else _ENUM_ALL
+
+            if "color_palette" in filters:
+                value = filters["color_palette"]
+                self.color_palette = value if value else _ENUM_ALL
+
+            if "search_query" in filters:
+                value = filters["search_query"] or ""
+                self.search_query = value.lower().strip()
+
+            if "custom_query" in filters:
+                self.selected_custom_queries = _coerce_custom_query(filters["custom_query"])
+
+            if "gaze" in filters:
+                self.gaze_filter = filters["gaze"] or None
+
+            if "object_search" in filters:
+                self.object_search = (filters["object_search"] or "").strip()
+
+            if "description_search" in filters:
+                self.description_search = (filters["description_search"] or "").strip()
+
+            if "min_brightness" in filters or "max_brightness" in filters:
+                self.min_brightness = filters.get("min_brightness")
+                self.max_brightness = filters.get("max_brightness")
+
+            if "similarity_anchor" in filters:
+                self.similarity_anchor_id = filters["similarity_anchor"]
+        finally:
+            self._end_batch()
+
+    def to_dict(self) -> dict:
+        """Return the active-filters dict matching ``ClipBrowser.get_active_filters``."""
+        return {
+            "shot_type": self.shot_type if self.shot_type != _ENUM_ALL else None,
+            "color_palette": self.color_palette if self.color_palette != _ENUM_ALL else None,
+            "search_query": self.search_query if self.search_query else None,
+            "custom_query": (
+                sorted(self.selected_custom_queries, key=str.lower)
+                if self.selected_custom_queries
+                else None
+            ),
+            "min_duration": self.min_duration,
+            "max_duration": self.max_duration,
+            "aspect_ratio": self.aspect_ratio if self.aspect_ratio != _ENUM_ALL else None,
+            "gaze": self.gaze_filter,
+            "object_search": self.object_search if self.object_search else None,
+            "description_search": self.description_search if self.description_search else None,
+            "min_brightness": self.min_brightness,
+            "max_brightness": self.max_brightness,
+            "similarity_anchor": self.similarity_anchor_id,
+        }
+
+    def has_active(self) -> bool:
+        return (
+            self.shot_type != _ENUM_ALL
+            or self.color_palette != _ENUM_ALL
+            or bool(self.search_query)
+            or bool(self.selected_custom_queries)
+            or self.min_duration is not None
+            or self.max_duration is not None
+            or self.aspect_ratio != _ENUM_ALL
+            or self.gaze_filter is not None
+            or bool(self.object_search)
+            or bool(self.description_search)
+            or self.min_brightness is not None
+            or self.max_brightness is not None
+            or self.similarity_anchor_id is not None
+        )
+
+    def clear_all(self) -> None:
+        """Reset every field to its default. Emits :py:attr:`changed` at most once."""
+        self._begin_batch()
+        try:
+            self.shot_type = _ENUM_ALL
+            self.color_palette = _ENUM_ALL
+            self.search_query = ""
+            self.selected_custom_queries = set()
+            self.min_duration = None
+            self.max_duration = None
+            self.aspect_ratio = _ENUM_ALL
+            self.gaze_filter = None
+            self.object_search = ""
+            self.description_search = ""
+            self.min_brightness = None
+            self.max_brightness = None
+            self.similarity_anchor_id = None
+            self.similarity_scores = {}
+        finally:
+            self._end_batch()
+
+
+def _coerce_custom_query(value: Any) -> set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        if value in {"All", "Match", "No Match"}:
+            return set()
+        return {value}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return {str(v).strip() for v in value if str(v).strip()}
+    return set()

--- a/core/filter_state.py
+++ b/core/filter_state.py
@@ -49,6 +49,17 @@ class FilterState(QObject):
         "max_brightness",
         "similarity_anchor_id",
         "similarity_scores",
+        # Unit 5 additions
+        "person_count",
+        "has_audio",
+        "has_transcript",
+        "has_on_screen_text",
+        "on_screen_text_search",
+        "min_volume",
+        "max_volume",
+        "has_analysis_ops",
+        "enabled_filter",
+        "tag_note_search",
     )
 
     def __init__(self, parent: Optional[QObject] = None):
@@ -70,6 +81,17 @@ class FilterState(QObject):
         object.__setattr__(self, "max_brightness", None)
         object.__setattr__(self, "similarity_anchor_id", None)
         object.__setattr__(self, "similarity_scores", {})
+        # Unit 5 fields
+        object.__setattr__(self, "person_count", None)  # (op, int) | None
+        object.__setattr__(self, "has_audio", None)  # True / False / None (don't care)
+        object.__setattr__(self, "has_transcript", None)
+        object.__setattr__(self, "has_on_screen_text", None)
+        object.__setattr__(self, "on_screen_text_search", "")
+        object.__setattr__(self, "min_volume", None)
+        object.__setattr__(self, "max_volume", None)
+        object.__setattr__(self, "has_analysis_ops", set())
+        object.__setattr__(self, "enabled_filter", None)
+        object.__setattr__(self, "tag_note_search", "")
 
     # ── Dirty-tracking field assignment ─────────────────────────────
 
@@ -151,6 +173,47 @@ class FilterState(QObject):
 
             if "similarity_anchor" in filters:
                 self.similarity_anchor_id = filters["similarity_anchor"]
+
+            # Unit 5 fields
+            if "person_count" in filters:
+                value = filters["person_count"]
+                if value is None:
+                    self.person_count = None
+                elif isinstance(value, (list, tuple)) and len(value) == 2:
+                    self.person_count = (str(value[0]), int(value[1]))
+                else:
+                    self.person_count = None
+
+            if "has_audio" in filters:
+                self.has_audio = _coerce_tribool(filters["has_audio"])
+            if "has_transcript" in filters:
+                self.has_transcript = _coerce_tribool(filters["has_transcript"])
+            if "has_on_screen_text" in filters:
+                self.has_on_screen_text = _coerce_tribool(filters["has_on_screen_text"])
+
+            if "on_screen_text_search" in filters:
+                self.on_screen_text_search = (filters["on_screen_text_search"] or "").strip()
+
+            if "min_volume" in filters or "max_volume" in filters:
+                self.min_volume = filters.get("min_volume")
+                self.max_volume = filters.get("max_volume")
+
+            if "has_analysis_ops" in filters:
+                value = filters["has_analysis_ops"]
+                if value is None:
+                    self.has_analysis_ops = set()
+                elif isinstance(value, str):
+                    self.has_analysis_ops = {value} if value else set()
+                elif isinstance(value, (list, tuple, set, frozenset)):
+                    self.has_analysis_ops = {str(v) for v in value if str(v).strip()}
+                else:
+                    self.has_analysis_ops = set()
+
+            if "enabled_filter" in filters:
+                self.enabled_filter = _coerce_tribool(filters["enabled_filter"])
+
+            if "tag_note_search" in filters:
+                self.tag_note_search = (filters["tag_note_search"] or "").strip()
         finally:
             self._end_batch()
 
@@ -179,6 +242,17 @@ class FilterState(QObject):
             "min_brightness": self.min_brightness,
             "max_brightness": self.max_brightness,
             "similarity_anchor": self.similarity_anchor_id,
+            # Unit 5 fields
+            "person_count": list(self.person_count) if self.person_count else None,
+            "has_audio": self.has_audio,
+            "has_transcript": self.has_transcript,
+            "has_on_screen_text": self.has_on_screen_text,
+            "on_screen_text_search": self.on_screen_text_search or None,
+            "min_volume": self.min_volume,
+            "max_volume": self.max_volume,
+            "has_analysis_ops": sorted(self.has_analysis_ops) if self.has_analysis_ops else None,
+            "enabled_filter": self.enabled_filter,
+            "tag_note_search": self.tag_note_search or None,
         }
 
     def has_active(self) -> bool:
@@ -196,6 +270,17 @@ class FilterState(QObject):
             or self.min_brightness is not None
             or self.max_brightness is not None
             or self.similarity_anchor_id is not None
+            # Unit 5 fields
+            or self.person_count is not None
+            or self.has_audio is not None
+            or self.has_transcript is not None
+            or self.has_on_screen_text is not None
+            or bool(self.on_screen_text_search)
+            or self.min_volume is not None
+            or self.max_volume is not None
+            or bool(self.has_analysis_ops)
+            or self.enabled_filter is not None
+            or bool(self.tag_note_search)
         )
 
     def clear_all(self) -> None:
@@ -216,6 +301,17 @@ class FilterState(QObject):
             self.max_brightness = None
             self.similarity_anchor_id = None
             self.similarity_scores = {}
+            # Unit 5 fields
+            self.person_count = None
+            self.has_audio = None
+            self.has_transcript = None
+            self.has_on_screen_text = None
+            self.on_screen_text_search = ""
+            self.min_volume = None
+            self.max_volume = None
+            self.has_analysis_ops = set()
+            self.enabled_filter = None
+            self.tag_note_search = ""
         finally:
             self._end_batch()
 
@@ -261,3 +357,19 @@ def _emit_enum(value: set[str]):
     if len(value) == 1:
         return next(iter(value))
     return sorted(value, key=str.lower)
+
+
+def _coerce_tribool(value: Any) -> Optional[bool]:
+    """Normalize has_audio / has_transcript / has_on_screen_text / enabled_filter inputs."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.lower()
+        if lowered in {"yes", "true", "1"}:
+            return True
+        if lowered in {"no", "false", "0"}:
+            return False
+        return None
+    return None

--- a/core/settings.py
+++ b/core/settings.py
@@ -472,6 +472,12 @@ class Settings:
     # Sequence tab - remembered category filter
     sequence_selected_category: str = "All"
 
+    # Cut / Analyze filter sidebar — visibility per tab and per-section expand
+    # state. See docs/plans/2026-04-21-001-feat-comprehensive-clip-filter-system-plan.md.
+    cut_filter_sidebar_visible: bool = True
+    analyze_filter_sidebar_visible: bool = True
+    filter_sidebar_section_expanded: dict = field(default_factory=dict)
+
     # Analysis Parallelism Settings
     color_analysis_parallelism: int = 4  # 1-8, I/O-bound image loading
     description_parallelism: int = 3  # 1-5, cloud API I/O-bound

--- a/tests/test_chip_group.py
+++ b/tests/test_chip_group.py
@@ -1,0 +1,106 @@
+"""Tests for ChipGroup widget."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_toggle_chip_updates_selection(qapp):
+    from ui.widgets.chip_group import ChipGroup
+    group = ChipGroup()
+    group.set_options([("a", "A"), ("b", "B")])
+
+    emissions: list[set] = []
+    group.selection_changed.connect(lambda s: emissions.append(set(s)))
+
+    # Simulate user toggling chip "a"
+    group._buttons["a"].setChecked(True)
+    qapp.processEvents()
+
+    assert group.selected_values() == {"a"}
+    assert emissions[-1] == {"a"}
+
+
+def test_set_selected_checks_chips_without_loop(qapp):
+    from ui.widgets.chip_group import ChipGroup
+    group = ChipGroup()
+    group.set_options([("a", "A"), ("b", "B"), ("c", "C")])
+
+    emissions: list[set] = []
+    group.selection_changed.connect(lambda s: emissions.append(set(s)))
+
+    group.set_selected({"a", "b"})
+    qapp.processEvents()
+
+    assert group.selected_values() == {"a", "b"}
+    assert emissions == [{"a", "b"}]
+    assert group._buttons["a"].isChecked()
+    assert group._buttons["b"].isChecked()
+    assert not group._buttons["c"].isChecked()
+
+
+def test_set_selected_unknown_values_silently_skipped(qapp):
+    from ui.widgets.chip_group import ChipGroup
+    group = ChipGroup()
+    group.set_options([("a", "A")])
+
+    emissions: list[set] = []
+    group.selection_changed.connect(lambda s: emissions.append(set(s)))
+
+    group.set_selected({"nonexistent"})
+    qapp.processEvents()
+    # No valid match → no state change → no emission
+    assert group.selected_values() == set()
+    assert emissions == []
+
+
+def test_clear_selection_emits_only_when_selection_existed(qapp):
+    from ui.widgets.chip_group import ChipGroup
+    group = ChipGroup()
+    group.set_options([("a", "A"), ("b", "B")])
+
+    emissions: list[set] = []
+    group.selection_changed.connect(lambda s: emissions.append(set(s)))
+
+    group.clear_selection()
+    qapp.processEvents()
+    assert emissions == []  # nothing was selected
+
+    group.set_selected({"a"})
+    qapp.processEvents()
+    group.clear_selection()
+    qapp.processEvents()
+    assert emissions[-1] == set()
+
+
+def test_set_options_after_selection_clears_selection(qapp):
+    from ui.widgets.chip_group import ChipGroup
+    group = ChipGroup()
+    group.set_options([("a", "A")])
+    group.set_selected({"a"})
+    qapp.processEvents()
+    assert group.selected_values() == {"a"}
+
+    group.set_options([("x", "X"), ("y", "Y")])
+    qapp.processEvents()
+    assert group.selected_values() == set()
+
+
+def test_theme_refresh_does_not_crash(qapp):
+    from ui.widgets.chip_group import ChipGroup
+    from ui.theme import theme
+    group = ChipGroup()
+    group.set_options([("a", "A")])
+    # Just trigger the refresh; assert stylesheet non-empty
+    group._refresh_theme()
+    assert "ChipGroup QPushButton" in group.styleSheet()

--- a/tests/test_collapsible_section.py
+++ b/tests/test_collapsible_section.py
@@ -1,0 +1,90 @@
+"""Tests for CollapsibleSection widget."""
+
+import os
+
+import pytest
+
+from PySide6.QtWidgets import QLabel
+
+
+@pytest.fixture
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_constructs_expanded_by_default(qapp):
+    from ui.widgets.collapsible_section import CollapsibleSection
+    section = CollapsibleSection("Shot properties")
+    assert section.expanded is True
+
+
+def test_set_expanded_toggles_content_visibility(qapp):
+    from ui.widgets.collapsible_section import CollapsibleSection
+    section = CollapsibleSection("Shot")
+    content = QLabel("x")
+    section.setContentWidget(content)
+    section.show()
+    qapp.processEvents()
+
+    section.set_expanded(False)
+    assert section.expanded is False
+
+    section.set_expanded(True)
+    assert section.expanded is True
+
+
+def test_set_expanded_same_state_is_noop_and_no_signal(qapp):
+    from ui.widgets.collapsible_section import CollapsibleSection
+    section = CollapsibleSection("Shot")
+
+    emissions: list[bool] = []
+    section.expanded_changed.connect(lambda v: emissions.append(v))
+
+    section.set_expanded(True)  # already expanded
+    qapp.processEvents()
+    assert emissions == []
+
+    section.set_expanded(False)
+    qapp.processEvents()
+    assert emissions == [False]
+
+    section.set_expanded(False)  # already collapsed
+    qapp.processEvents()
+    assert emissions == [False]
+
+
+def test_set_content_widget_replaces_previous(qapp):
+    from ui.widgets.collapsible_section import CollapsibleSection
+    section = CollapsibleSection("X")
+    first = QLabel("first")
+    second = QLabel("second")
+    section.setContentWidget(first)
+    section.setContentWidget(second)
+    # first should have been reparented away
+    assert first.parent() is not section
+
+
+def test_show_clear_indicator_triggers_callback(qapp):
+    from ui.widgets.collapsible_section import CollapsibleSection
+    section = CollapsibleSection("X")
+    calls = []
+    section.show_clear_indicator(True, on_click=lambda: calls.append(1))
+    section._clear_btn.click()
+    qapp.processEvents()
+    assert calls == [1]
+
+    section.show_clear_indicator(False)
+    # after hiding, stored callback stays but clicking hidden button is a no-op path
+    section._clear_btn.click()
+    qapp.processEvents()
+    # Clicking a hidden/invisible button doesn't fire in offscreen reliably,
+    # but the callback replacement path works: reset and verify
+    section.show_clear_indicator(True, on_click=None)
+    section._clear_btn.click()
+    qapp.processEvents()
+    assert calls == [1]

--- a/tests/test_count_operator.py
+++ b/tests/test_count_operator.py
@@ -1,0 +1,91 @@
+"""Tests for CountOperator widget."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_default_state_is_inactive(qapp):
+    from ui.widgets.count_operator import CountOperator
+    widget = CountOperator()
+    assert widget.value() is None
+
+
+def test_set_value_activates_and_emits(qapp):
+    from ui.widgets.count_operator import CountOperator
+    widget = CountOperator()
+
+    emitted: list[tuple] = []
+    widget.value_changed.connect(lambda op, n: emitted.append((op, n)))
+
+    widget.set_value(">", 5)
+    qapp.processEvents()
+
+    assert widget.value() == (">", 5)
+    assert emitted == [(">", 5)]
+
+
+def test_clear_resets_and_emits_none(qapp):
+    from ui.widgets.count_operator import CountOperator
+    widget = CountOperator()
+    widget.set_value(">", 3)
+
+    emitted: list[tuple] = []
+    widget.value_changed.connect(lambda op, n: emitted.append((op, n)))
+
+    widget.clear()
+    qapp.processEvents()
+
+    assert widget.value() is None
+    assert emitted == [(None, None)]
+
+
+def test_clear_when_already_inactive_is_noop(qapp):
+    from ui.widgets.count_operator import CountOperator
+    widget = CountOperator()
+    emitted: list[tuple] = []
+    widget.value_changed.connect(lambda op, n: emitted.append((op, n)))
+
+    widget.clear()
+    qapp.processEvents()
+    assert emitted == []
+
+
+def test_set_value_with_none_clears(qapp):
+    from ui.widgets.count_operator import CountOperator
+    widget = CountOperator()
+    widget.set_value(">", 2)
+
+    widget.set_value(None, None)
+    assert widget.value() is None
+
+
+def test_invalid_operator_coerces_to_default(qapp):
+    from ui.widgets.count_operator import CountOperator
+    widget = CountOperator()
+    widget.set_value("??", 1)
+    assert widget.value() == (">", 1)
+
+
+def test_user_edit_via_spinbox_activates(qapp):
+    from ui.widgets.count_operator import CountOperator
+    widget = CountOperator()
+    emitted: list[tuple] = []
+    widget.value_changed.connect(lambda op, n: emitted.append((op, n)))
+
+    # Simulate user changing the spin value
+    widget._spin.setValue(4)
+    qapp.processEvents()
+
+    assert widget.value() == (">", 4)
+    assert emitted[-1] == (">", 4)

--- a/tests/test_filter_sidebar.py
+++ b/tests/test_filter_sidebar.py
@@ -1,0 +1,153 @@
+"""Tests for FilterSidebar scaffold."""
+
+import os
+
+import pytest
+
+from PySide6.QtWidgets import QLabel
+
+
+@pytest.fixture
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_constructs_with_all_nine_sections(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar, SECTIONS
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+
+    for key, _title in SECTIONS:
+        assert sidebar.section(key) is not None, f"missing section {key}"
+    assert len(SECTIONS) == 9
+
+
+def test_binds_to_provided_filter_state(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+    assert sidebar.filter_state is fs
+
+
+def test_section_expanded_state_persistence(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar, SECTIONS
+
+    fs = FilterState()
+    # Provide initial expand state
+    initial = {SECTIONS[0][0]: False, SECTIONS[1][0]: True}
+    sidebar = FilterSidebar(fs, section_expanded_state=initial)
+
+    assert sidebar.section(SECTIONS[0][0]).expanded is False
+    assert sidebar.section(SECTIONS[1][0]).expanded is True
+
+    # Missing keys default to True
+    assert sidebar.section(SECTIONS[2][0]).expanded is True
+
+
+def test_section_expanded_changed_emits(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar, SECTION_SHOT
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+
+    events: list[tuple[str, bool]] = []
+    sidebar.section_expanded_changed.connect(
+        lambda key, exp: events.append((key, exp))
+    )
+
+    sidebar.section(SECTION_SHOT).set_expanded(False)
+    qapp.processEvents()
+
+    assert events == [(SECTION_SHOT, False)]
+
+
+def test_section_expanded_state_snapshot(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar, SECTION_SHOT, SECTION_VISUAL
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+    sidebar.section(SECTION_SHOT).set_expanded(False)
+    sidebar.section(SECTION_VISUAL).set_expanded(False)
+
+    snapshot = sidebar.section_expanded_state()
+    assert snapshot[SECTION_SHOT] is False
+    assert snapshot[SECTION_VISUAL] is False
+
+
+def test_set_section_content_installs_widget(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar, SECTION_SHOT
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+
+    widget = QLabel("my content")
+    sidebar.set_section_content(SECTION_SHOT, widget)
+    # Content widget should now be a child of the section
+    section = sidebar.section(SECTION_SHOT)
+    assert widget.parent() is section._content_frame
+
+
+def test_set_section_content_raises_for_unknown_key(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+
+    with pytest.raises(KeyError):
+        sidebar.set_section_content("nonexistent", QLabel("x"))
+
+
+def test_visibility_requested_on_hide_click(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+
+    events: list[bool] = []
+    sidebar.visibility_requested.connect(lambda v: events.append(v))
+
+    # Find the hide button (single QPushButton in the header) and click it
+    from PySide6.QtWidgets import QPushButton
+    hide_btn = sidebar.findChild(QPushButton, "FilterSidebarHideBtn")
+    assert hide_btn is not None
+    hide_btn.click()
+    qapp.processEvents()
+
+    assert events == [False]
+
+
+def test_shared_filter_state_between_two_sidebars(qapp):
+    """Two sidebars pointing at one FilterState observe the same mutations."""
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar_a = FilterSidebar(fs)
+    sidebar_b = FilterSidebar(fs)
+
+    events_a: list[str] = []
+    events_b: list[str] = []
+    fs.changed.connect(lambda: events_a.append(fs.shot_type))
+    fs.changed.connect(lambda: events_b.append(fs.shot_type))
+
+    fs.shot_type = "Close-up"
+    qapp.processEvents()
+
+    assert events_a == ["Close-up"]
+    assert events_b == ["Close-up"]
+    assert sidebar_a.filter_state is sidebar_b.filter_state

--- a/tests/test_filter_sidebar.py
+++ b/tests/test_filter_sidebar.py
@@ -151,3 +151,57 @@ def test_shared_filter_state_between_two_sidebars(qapp):
     assert events_a == [{"Close-up"}]
     assert events_b == [{"Close-up"}]
     assert sidebar_a.filter_state is sidebar_b.filter_state
+
+
+def test_chip_toggle_updates_filter_state(qapp):
+    """Toggling a chip in the sidebar writes through to FilterState."""
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+    group = sidebar._chip_groups["shot_type"]
+    # Toggle the first chip on
+    first_value = next(iter(group._buttons.keys()))
+    group._buttons[first_value].setChecked(True)
+    qapp.processEvents()
+
+    assert fs.shot_type == {first_value}
+
+
+def test_state_change_updates_chip_selection(qapp):
+    """Mutating FilterState updates the sidebar's chip selection (round-trip)."""
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+    group = sidebar._chip_groups["shot_type"]
+    first_value = next(iter(group._buttons.keys()))
+
+    fs.shot_type = first_value
+    qapp.processEvents()
+
+    assert group.selected_values() == {first_value}
+
+
+def test_state_sync_does_not_loop(qapp):
+    """State→UI→state round-trip must not cause a cascade."""
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+
+    emissions: list[int] = []
+    fs.changed.connect(lambda: emissions.append(1))
+
+    group = sidebar._chip_groups["gaze_filter"]
+    first_value = next(iter(group._buttons.keys()))
+
+    # Simulate user chip click
+    group._buttons[first_value].setChecked(True)
+    qapp.processEvents()
+
+    # Only one emission expected
+    assert len(emissions) == 1

--- a/tests/test_filter_sidebar.py
+++ b/tests/test_filter_sidebar.py
@@ -185,6 +185,54 @@ def test_state_change_updates_chip_selection(qapp):
     assert group.selected_values() == {first_value}
 
 
+def test_person_count_control_writes_to_state(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+    sidebar._person_count_control.set_value(">", 2)
+    qapp.processEvents()
+
+    assert fs.person_count == (">", 2)
+
+
+def test_has_audio_tribool(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+    yes_btn, no_btn, any_btn = sidebar._tribool_groups["has_audio"]
+
+    yes_btn.setChecked(True)
+    qapp.processEvents()
+    assert fs.has_audio is True
+
+    no_btn.setChecked(True)
+    qapp.processEvents()
+    assert fs.has_audio is False
+
+    any_btn.setChecked(True)
+    qapp.processEvents()
+    assert fs.has_audio is None
+
+
+def test_has_analysis_ops_chips(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.filter_sidebar import FilterSidebar
+
+    fs = FilterState()
+    sidebar = FilterSidebar(fs)
+    ops_group = sidebar._chip_groups["has_analysis_ops"]
+    # Pick any operation key
+    first_key = next(iter(ops_group._buttons.keys()))
+    ops_group._buttons[first_key].setChecked(True)
+    qapp.processEvents()
+
+    assert first_key in fs.has_analysis_ops
+
+
 def test_state_sync_does_not_loop(qapp):
     """State→UI→state round-trip must not cause a cascade."""
     from core.filter_state import FilterState

--- a/tests/test_filter_sidebar.py
+++ b/tests/test_filter_sidebar.py
@@ -140,14 +140,14 @@ def test_shared_filter_state_between_two_sidebars(qapp):
     sidebar_a = FilterSidebar(fs)
     sidebar_b = FilterSidebar(fs)
 
-    events_a: list[str] = []
-    events_b: list[str] = []
-    fs.changed.connect(lambda: events_a.append(fs.shot_type))
-    fs.changed.connect(lambda: events_b.append(fs.shot_type))
+    events_a: list[set] = []
+    events_b: list[set] = []
+    fs.changed.connect(lambda: events_a.append(set(fs.shot_type)))
+    fs.changed.connect(lambda: events_b.append(set(fs.shot_type)))
 
     fs.shot_type = "Close-up"
     qapp.processEvents()
 
-    assert events_a == ["Close-up"]
-    assert events_b == ["Close-up"]
+    assert events_a == [{"Close-up"}]
+    assert events_b == [{"Close-up"}]
     assert sidebar_a.filter_state is sidebar_b.filter_state

--- a/tests/test_filter_state.py
+++ b/tests/test_filter_state.py
@@ -18,14 +18,15 @@ def qapp():
 def test_defaults(qapp):
     from core.filter_state import FilterState
     fs = FilterState()
-    assert fs.shot_type == "All"
-    assert fs.color_palette == "All"
-    assert fs.aspect_ratio == "All"
+    # Enum fields are empty sets (= no filter)
+    assert fs.shot_type == set()
+    assert fs.color_palette == set()
+    assert fs.aspect_ratio == set()
+    assert fs.gaze_filter == set()
     assert fs.search_query == ""
     assert fs.selected_custom_queries == set()
     assert fs.min_duration is None
     assert fs.max_duration is None
-    assert fs.gaze_filter is None
     assert fs.object_search == ""
     assert fs.description_search == ""
     assert fs.min_brightness is None
@@ -33,6 +34,29 @@ def test_defaults(qapp):
     assert fs.similarity_anchor_id is None
     assert fs.similarity_scores == {}
     assert fs.has_active() is False
+
+
+def test_enum_assignment_coerces_string_to_set(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.shot_type = "Close-up"
+    assert fs.shot_type == {"Close-up"}
+
+    fs.shot_type = None
+    assert fs.shot_type == set()
+
+    fs.shot_type = "All"  # Sentinel clears
+    assert fs.shot_type == set()
+
+
+def test_enum_assignment_accepts_list_and_set(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.shot_type = ["Close-up", "Extreme CU"]
+    assert fs.shot_type == {"Close-up", "Extreme CU"}
+
+    fs.shot_type = {"Wide Shot"}
+    assert fs.shot_type == {"Wide Shot"}
 
 
 def test_assignment_emits_once(qapp):
@@ -55,6 +79,9 @@ def test_assignment_same_value_no_emit(qapp):
     fs.shot_type = "Close-up"
     assert emissions == []
 
+    fs.shot_type = {"Close-up"}
+    assert emissions == []
+
 
 def test_apply_dict_batches_emissions(qapp):
     from core.filter_state import FilterState
@@ -68,12 +95,29 @@ def test_apply_dict_batches_emissions(qapp):
         "min_duration": 2.0,
         "max_duration": 5.0,
     })
-    # 4 fields changed, single emission
     assert len(emissions) == 1
-    assert fs.shot_type == "Close-up"
-    assert fs.color_palette == "Warm"
+    assert fs.shot_type == {"Close-up"}
+    assert fs.color_palette == {"Warm"}
     assert fs.min_duration == 2.0
     assert fs.max_duration == 5.0
+
+
+def test_apply_dict_multi_select_list(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.apply_dict({"shot_type": ["Close-up", "Extreme CU"]})
+    assert fs.shot_type == {"Close-up", "Extreme CU"}
+
+
+def test_apply_dict_backward_compat_string(qapp):
+    """String input to an enum field behaves like a single-item set."""
+    from core.filter_state import FilterState
+    fs_a = FilterState()
+    fs_b = FilterState()
+    fs_a.apply_dict({"shot_type": "Close-up"})
+    fs_b.apply_dict({"shot_type": ["Close-up"]})
+    assert fs_a.shot_type == fs_b.shot_type
+    assert fs_a.to_dict() == fs_b.to_dict()
 
 
 def test_apply_dict_empty_is_noop(qapp):
@@ -91,7 +135,7 @@ def test_apply_dict_none_clears_enum_fields(qapp):
     fs = FilterState()
     fs.shot_type = "Close-up"
     fs.apply_dict({"shot_type": None})
-    assert fs.shot_type == "All"
+    assert fs.shot_type == set()
 
 
 def test_apply_dict_custom_query_coercions(qapp):
@@ -107,7 +151,6 @@ def test_apply_dict_custom_query_coercions(qapp):
     fs.apply_dict({"custom_query": None})
     assert fs.selected_custom_queries == set()
 
-    # Legacy sentinel strings from the pre-refactor API are treated as "clear"
     fs.apply_dict({"custom_query": "All"})
     assert fs.selected_custom_queries == set()
 
@@ -122,11 +165,38 @@ def test_apply_dict_search_query_lowercased_and_trimmed(qapp):
     assert fs.search_query == "hello"
 
 
+def test_to_dict_single_value_emitted_as_string(qapp):
+    """Backward compat: single-value enums emit a plain string."""
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.shot_type = "Close-up"
+    out = fs.to_dict()
+    assert out["shot_type"] == "Close-up"
+
+
+def test_to_dict_multi_value_emitted_as_sorted_list(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.shot_type = {"Extreme CU", "Close-up"}
+    out = fs.to_dict()
+    assert out["shot_type"] == ["Close-up", "Extreme CU"]
+
+
+def test_to_dict_empty_enum_emits_none(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    out = fs.to_dict()
+    assert out["shot_type"] is None
+    assert out["color_palette"] is None
+    assert out["aspect_ratio"] is None
+    assert out["gaze"] is None
+
+
 def test_to_dict_round_trip(qapp):
     from core.filter_state import FilterState
     fs = FilterState()
     fs.apply_dict({
-        "shot_type": "Close-up",
+        "shot_type": ["Close-up", "Extreme CU"],
         "color_palette": "Warm",
         "min_duration": 2.0,
         "max_duration": 5.0,
@@ -139,7 +209,7 @@ def test_to_dict_round_trip(qapp):
         "custom_query": ["blue car", "person"],
     })
     out = fs.to_dict()
-    assert out["shot_type"] == "Close-up"
+    assert out["shot_type"] == ["Close-up", "Extreme CU"]
     assert out["color_palette"] == "Warm"
     assert out["min_duration"] == 2.0
     assert out["aspect_ratio"] == "16:9"
@@ -148,23 +218,9 @@ def test_to_dict_round_trip(qapp):
     assert out["min_brightness"] == 0.2
     assert sorted(out["custom_query"]) == ["blue car", "person"]
 
-    # Round-trip: applying to_dict to a fresh state yields identical output
     fs2 = FilterState()
     fs2.apply_dict(out)
     assert fs2.to_dict() == out
-
-
-def test_to_dict_defaults_are_none_for_inactive(qapp):
-    from core.filter_state import FilterState
-    fs = FilterState()
-    out = fs.to_dict()
-    assert out["shot_type"] is None
-    assert out["color_palette"] is None
-    assert out["aspect_ratio"] is None
-    assert out["search_query"] is None
-    assert out["custom_query"] is None
-    assert out["object_search"] is None
-    assert out["description_search"] is None
 
 
 def test_has_active_reflects_any_field(qapp):
@@ -181,7 +237,7 @@ def test_clear_all_resets_and_emits_once(qapp):
     from core.filter_state import FilterState
     fs = FilterState()
     fs.apply_dict({
-        "shot_type": "Close-up",
+        "shot_type": ["Close-up", "Extreme CU"],
         "min_brightness": 0.5,
         "custom_query": ["a"],
     })
@@ -205,14 +261,13 @@ def test_clear_all_on_empty_is_noop(qapp):
 
 
 def test_shared_instance_between_consumers(qapp):
-    """Two consumers sharing one FilterState both see the same mutations."""
     from core.filter_state import FilterState
     fs = FilterState()
-    consumer_a: list[str] = []
-    consumer_b: list[str] = []
-    fs.changed.connect(lambda: consumer_a.append(fs.shot_type))
-    fs.changed.connect(lambda: consumer_b.append(fs.shot_type))
+    consumer_a: list[set] = []
+    consumer_b: list[set] = []
+    fs.changed.connect(lambda: consumer_a.append(set(fs.shot_type)))
+    fs.changed.connect(lambda: consumer_b.append(set(fs.shot_type)))
 
     fs.shot_type = "Close-up"
-    assert consumer_a == ["Close-up"]
-    assert consumer_b == ["Close-up"]
+    assert consumer_a == [{"Close-up"}]
+    assert consumer_b == [{"Close-up"}]

--- a/tests/test_filter_state.py
+++ b/tests/test_filter_state.py
@@ -1,0 +1,218 @@
+"""Tests for core.filter_state.FilterState."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_defaults(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    assert fs.shot_type == "All"
+    assert fs.color_palette == "All"
+    assert fs.aspect_ratio == "All"
+    assert fs.search_query == ""
+    assert fs.selected_custom_queries == set()
+    assert fs.min_duration is None
+    assert fs.max_duration is None
+    assert fs.gaze_filter is None
+    assert fs.object_search == ""
+    assert fs.description_search == ""
+    assert fs.min_brightness is None
+    assert fs.max_brightness is None
+    assert fs.similarity_anchor_id is None
+    assert fs.similarity_scores == {}
+    assert fs.has_active() is False
+
+
+def test_assignment_emits_once(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    emissions: list[int] = []
+    fs.changed.connect(lambda: emissions.append(1))
+
+    fs.shot_type = "Close-up"
+    assert len(emissions) == 1
+
+
+def test_assignment_same_value_no_emit(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.shot_type = "Close-up"
+    emissions: list[int] = []
+    fs.changed.connect(lambda: emissions.append(1))
+
+    fs.shot_type = "Close-up"
+    assert emissions == []
+
+
+def test_apply_dict_batches_emissions(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    emissions: list[int] = []
+    fs.changed.connect(lambda: emissions.append(1))
+
+    fs.apply_dict({
+        "shot_type": "Close-up",
+        "color_palette": "Warm",
+        "min_duration": 2.0,
+        "max_duration": 5.0,
+    })
+    # 4 fields changed, single emission
+    assert len(emissions) == 1
+    assert fs.shot_type == "Close-up"
+    assert fs.color_palette == "Warm"
+    assert fs.min_duration == 2.0
+    assert fs.max_duration == 5.0
+
+
+def test_apply_dict_empty_is_noop(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    emissions: list[int] = []
+    fs.changed.connect(lambda: emissions.append(1))
+
+    fs.apply_dict({})
+    assert emissions == []
+
+
+def test_apply_dict_none_clears_enum_fields(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.shot_type = "Close-up"
+    fs.apply_dict({"shot_type": None})
+    assert fs.shot_type == "All"
+
+
+def test_apply_dict_custom_query_coercions(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+
+    fs.apply_dict({"custom_query": "blue car"})
+    assert fs.selected_custom_queries == {"blue car"}
+
+    fs.apply_dict({"custom_query": ["a", "b"]})
+    assert fs.selected_custom_queries == {"a", "b"}
+
+    fs.apply_dict({"custom_query": None})
+    assert fs.selected_custom_queries == set()
+
+    # Legacy sentinel strings from the pre-refactor API are treated as "clear"
+    fs.apply_dict({"custom_query": "All"})
+    assert fs.selected_custom_queries == set()
+
+    fs.apply_dict({"custom_query": ("x", " y ", "")})
+    assert fs.selected_custom_queries == {"x", "y"}
+
+
+def test_apply_dict_search_query_lowercased_and_trimmed(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.apply_dict({"search_query": "  Hello  "})
+    assert fs.search_query == "hello"
+
+
+def test_to_dict_round_trip(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.apply_dict({
+        "shot_type": "Close-up",
+        "color_palette": "Warm",
+        "min_duration": 2.0,
+        "max_duration": 5.0,
+        "aspect_ratio": "16:9",
+        "gaze": "at_camera",
+        "object_search": "dog",
+        "description_search": "sunset",
+        "min_brightness": 0.2,
+        "max_brightness": 0.9,
+        "custom_query": ["blue car", "person"],
+    })
+    out = fs.to_dict()
+    assert out["shot_type"] == "Close-up"
+    assert out["color_palette"] == "Warm"
+    assert out["min_duration"] == 2.0
+    assert out["aspect_ratio"] == "16:9"
+    assert out["gaze"] == "at_camera"
+    assert out["object_search"] == "dog"
+    assert out["min_brightness"] == 0.2
+    assert sorted(out["custom_query"]) == ["blue car", "person"]
+
+    # Round-trip: applying to_dict to a fresh state yields identical output
+    fs2 = FilterState()
+    fs2.apply_dict(out)
+    assert fs2.to_dict() == out
+
+
+def test_to_dict_defaults_are_none_for_inactive(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    out = fs.to_dict()
+    assert out["shot_type"] is None
+    assert out["color_palette"] is None
+    assert out["aspect_ratio"] is None
+    assert out["search_query"] is None
+    assert out["custom_query"] is None
+    assert out["object_search"] is None
+    assert out["description_search"] is None
+
+
+def test_has_active_reflects_any_field(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    assert fs.has_active() is False
+    fs.gaze_filter = "at_camera"
+    assert fs.has_active() is True
+    fs.gaze_filter = None
+    assert fs.has_active() is False
+
+
+def test_clear_all_resets_and_emits_once(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    fs.apply_dict({
+        "shot_type": "Close-up",
+        "min_brightness": 0.5,
+        "custom_query": ["a"],
+    })
+
+    emissions: list[int] = []
+    fs.changed.connect(lambda: emissions.append(1))
+
+    fs.clear_all()
+    assert emissions == [1]
+    assert fs.has_active() is False
+
+
+def test_clear_all_on_empty_is_noop(qapp):
+    from core.filter_state import FilterState
+    fs = FilterState()
+    emissions: list[int] = []
+    fs.changed.connect(lambda: emissions.append(1))
+
+    fs.clear_all()
+    assert emissions == []
+
+
+def test_shared_instance_between_consumers(qapp):
+    """Two consumers sharing one FilterState both see the same mutations."""
+    from core.filter_state import FilterState
+    fs = FilterState()
+    consumer_a: list[str] = []
+    consumer_b: list[str] = []
+    fs.changed.connect(lambda: consumer_a.append(fs.shot_type))
+    fs.changed.connect(lambda: consumer_b.append(fs.shot_type))
+
+    fs.shot_type = "Close-up"
+    assert consumer_a == ["Close-up"]
+    assert consumer_b == ["Close-up"]

--- a/tests/test_typeahead_input.py
+++ b/tests/test_typeahead_input.py
@@ -1,0 +1,106 @@
+"""Tests for TypeaheadInput widget."""
+
+import os
+
+import pytest
+
+
+@pytest.fixture
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def test_commits_vocabulary_match_via_return(qapp):
+    from ui.widgets.typeahead_input import TypeaheadInput
+    widget = TypeaheadInput()
+    widget.set_vocabulary(["dog", "cat", "bird"])
+
+    emitted: list[str] = []
+    widget.value_selected.connect(lambda v: emitted.append(v))
+
+    widget._line.setText("dog")
+    widget._line.returnPressed.emit()
+    qapp.processEvents()
+
+    assert emitted == ["dog"]
+    assert widget._line.text() == ""
+
+
+def test_case_insensitive_match_emits_canonical(qapp):
+    from ui.widgets.typeahead_input import TypeaheadInput
+    widget = TypeaheadInput()
+    widget.set_vocabulary(["dog", "cat"])
+
+    emitted: list[str] = []
+    widget.value_selected.connect(lambda v: emitted.append(v))
+
+    widget._line.setText("DOG")
+    widget._line.returnPressed.emit()
+    qapp.processEvents()
+    assert emitted == ["dog"]
+
+
+def test_non_vocabulary_match_does_not_emit(qapp):
+    from ui.widgets.typeahead_input import TypeaheadInput
+    widget = TypeaheadInput()
+    widget.set_vocabulary(["dog", "cat"])
+
+    emitted: list[str] = []
+    widget.value_selected.connect(lambda v: emitted.append(v))
+
+    widget._line.setText("nonexistent")
+    widget._line.returnPressed.emit()
+    qapp.processEvents()
+    assert emitted == []
+    # Input retains text so the user can see what they typed
+    assert widget._line.text() == "nonexistent"
+
+
+def test_empty_input_does_not_emit(qapp):
+    from ui.widgets.typeahead_input import TypeaheadInput
+    widget = TypeaheadInput()
+    widget.set_vocabulary(["dog"])
+
+    emitted: list[str] = []
+    widget.value_selected.connect(lambda v: emitted.append(v))
+
+    widget._line.setText("")
+    widget._line.returnPressed.emit()
+    qapp.processEvents()
+    assert emitted == []
+
+
+def test_empty_vocabulary_never_emits(qapp):
+    from ui.widgets.typeahead_input import TypeaheadInput
+    widget = TypeaheadInput()
+    widget.set_vocabulary([])
+
+    emitted: list[str] = []
+    widget.value_selected.connect(lambda v: emitted.append(v))
+
+    widget._line.setText("anything")
+    widget._line.returnPressed.emit()
+    qapp.processEvents()
+    assert emitted == []
+
+
+def test_set_vocabulary_updates_completer(qapp):
+    from ui.widgets.typeahead_input import TypeaheadInput
+    widget = TypeaheadInput()
+    widget.set_vocabulary(["dog"])
+    assert widget._model.stringList() == ["dog"]
+    widget.set_vocabulary(["cat", "bird"])
+    assert widget._model.stringList() == ["cat", "bird"]
+
+
+def test_clear_input(qapp):
+    from ui.widgets.typeahead_input import TypeaheadInput
+    widget = TypeaheadInput()
+    widget._line.setText("hello")
+    widget.clear_input()
+    assert widget._line.text() == ""

--- a/tests/test_unit5_filters.py
+++ b/tests/test_unit5_filters.py
@@ -1,0 +1,160 @@
+"""Tests for Unit 5 filter predicates (person count, has_audio, volume, etc.)."""
+
+import os
+
+import pytest
+
+from models.clip import Source
+from pathlib import Path
+from tests.conftest import make_test_clip
+
+
+@pytest.fixture
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.fixture
+def browser_with_clips(qapp):
+    from ui.clip_browser import ClipBrowser
+    browser = ClipBrowser()
+    src = Source(
+        id="src",
+        file_path=Path("/video.mp4"),
+        duration_seconds=60.0,
+        fps=30.0,
+        width=1920,
+        height=1080,
+    )
+    return browser, src
+
+
+def _add(browser, src, clip_id, **kwargs):
+    clip = make_test_clip(clip_id)
+    for k, v in kwargs.items():
+        setattr(clip, k, v)
+    browser.add_clip(clip, src)
+    return clip
+
+
+def test_person_count_greater_than(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", person_count=0)
+    _add(browser, src, "c2", person_count=1)
+    _add(browser, src, "c3", person_count=3)
+    qapp.processEvents()
+
+    browser.apply_filters({"person_count": (">", 1)})
+    qapp.processEvents()
+
+    assert browser.get_visible_clip_count() == 1  # only c3
+
+
+def test_person_count_equal(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", person_count=1)
+    _add(browser, src, "c2", person_count=2)
+    _add(browser, src, "c3", person_count=1)
+    qapp.processEvents()
+
+    browser.apply_filters({"person_count": ("=", 1)})
+    qapp.processEvents()
+
+    assert browser.get_visible_clip_count() == 2
+
+
+def test_person_count_less_than_treats_none_as_zero(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1")  # person_count=None → treated as 0
+    _add(browser, src, "c2", person_count=2)
+    qapp.processEvents()
+
+    browser.apply_filters({"person_count": ("<", 1)})
+    qapp.processEvents()
+
+    assert browser.get_visible_clip_count() == 1  # only c1
+
+
+def test_has_transcript_yes(browser_with_clips, qapp):
+    from core.transcription import TranscriptSegment
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", transcript=[])
+    _add(browser, src, "c2", transcript=[TranscriptSegment(text="hi", start_time=0.0, end_time=1.0)])
+    qapp.processEvents()
+
+    browser.apply_filters({"has_transcript": True})
+    qapp.processEvents()
+
+    # Only c2 has a non-empty transcript
+    assert browser.get_visible_clip_count() == 1
+
+
+def test_has_on_screen_text_no(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", extracted_texts=None)
+    _add(browser, src, "c2", extracted_texts=[{"text": "hello"}])
+    qapp.processEvents()
+
+    browser.apply_filters({"has_on_screen_text": False})
+    qapp.processEvents()
+
+    assert browser.get_visible_clip_count() == 1  # only c1
+
+
+def test_volume_range(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", rms_volume=-40.0)
+    _add(browser, src, "c2", rms_volume=-20.0)
+    _add(browser, src, "c3", rms_volume=-10.0)
+    qapp.processEvents()
+
+    browser.apply_filters({"min_volume": -30.0, "max_volume": -15.0})
+    qapp.processEvents()
+
+    assert browser.get_visible_clip_count() == 1  # only c2
+
+
+def test_enabled_filter_yes(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", disabled=False)
+    _add(browser, src, "c2", disabled=True)
+    qapp.processEvents()
+
+    browser.apply_filters({"enabled_filter": True})
+    qapp.processEvents()
+
+    assert browser.get_visible_clip_count() == 1
+
+
+def test_tag_note_search(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", tags=["important"])
+    _add(browser, src, "c2", notes="not great")
+    _add(browser, src, "c3")
+    qapp.processEvents()
+
+    browser.apply_filters({"tag_note_search": "important"})
+    qapp.processEvents()
+    assert browser.get_visible_clip_count() == 1
+
+    browser.apply_filters({"tag_note_search": "great"})
+    qapp.processEvents()
+    assert browser.get_visible_clip_count() == 1
+
+
+def test_has_analysis_ops_describe(browser_with_clips, qapp):
+    """When 'describe' is selected, only clips with a description pass."""
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", description="a scene description")
+    _add(browser, src, "c2")  # no description
+    qapp.processEvents()
+
+    browser.apply_filters({"has_analysis_ops": ["describe"]})
+    qapp.processEvents()
+
+    assert browser.get_visible_clip_count() == 1

--- a/tests/test_unit6_filters.py
+++ b/tests/test_unit6_filters.py
@@ -1,0 +1,159 @@
+"""Tests for Unit 6 filter predicates (ImageNet, YOLO)."""
+
+import os
+
+import pytest
+
+from pathlib import Path
+
+from models.clip import Source
+from tests.conftest import make_test_clip
+
+
+@pytest.fixture
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PySide6.QtWidgets import QApplication
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.fixture
+def browser_with_clips(qapp):
+    from ui.clip_browser import ClipBrowser
+    browser = ClipBrowser()
+    src = Source(
+        id="src", file_path=Path("/v.mp4"), duration_seconds=60.0,
+        fps=30.0, width=1920, height=1080,
+    )
+    return browser, src
+
+
+def _add(browser, src, cid, **kwargs):
+    clip = make_test_clip(cid)
+    for k, v in kwargs.items():
+        setattr(clip, k, v)
+    browser.add_clip(clip, src)
+    return clip
+
+
+def test_imagenet_any(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", object_labels=["dog", "ball"])
+    _add(browser, src, "c2", object_labels=["cat"])
+    _add(browser, src, "c3", object_labels=[])
+    qapp.processEvents()
+
+    browser.apply_filters({
+        "imagenet_labels": ["dog", "cat"],
+        "imagenet_mode": "any",
+    })
+    qapp.processEvents()
+    assert browser.get_visible_clip_count() == 2  # c1 + c2
+
+
+def test_imagenet_all(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", object_labels=["dog", "ball"])
+    _add(browser, src, "c2", object_labels=["dog", "cat", "ball"])
+    _add(browser, src, "c3", object_labels=["dog"])
+    qapp.processEvents()
+
+    browser.apply_filters({
+        "imagenet_labels": ["dog", "ball"],
+        "imagenet_mode": "all",
+    })
+    qapp.processEvents()
+    assert browser.get_visible_clip_count() == 2  # c1 + c2
+
+
+def test_yolo_labels(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    _add(browser, src, "c1", detected_objects=[{"label": "person", "confidence": 0.9, "bbox": [0, 0, 100, 100]}])
+    _add(browser, src, "c2", detected_objects=[{"label": "car", "confidence": 0.8, "bbox": [0, 0, 100, 100]}])
+    _add(browser, src, "c3", detected_objects=[])
+    qapp.processEvents()
+
+    browser.apply_filters({"yolo_labels": ["person"]})
+    qapp.processEvents()
+    assert browser.get_visible_clip_count() == 1
+
+
+def test_yolo_total_count_gt(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    det = lambda label: {"label": label, "confidence": 0.9, "bbox": [0, 0, 10, 10]}
+    _add(browser, src, "c1", detected_objects=[det("person")])
+    _add(browser, src, "c2", detected_objects=[det("person"), det("person"), det("car")])
+    _add(browser, src, "c3", detected_objects=[])
+    qapp.processEvents()
+
+    browser.apply_filters({"yolo_total_count": (">", 2)})
+    qapp.processEvents()
+    assert browser.get_visible_clip_count() == 1  # c2 has 3 detections
+
+
+def test_yolo_per_label_rules(browser_with_clips, qapp):
+    browser, src = browser_with_clips
+    det = lambda label: {"label": label, "confidence": 0.9, "bbox": [0, 0, 10, 10]}
+    _add(browser, src, "c1", detected_objects=[det("person")])
+    _add(browser, src, "c2", detected_objects=[det("person"), det("person"), det("car")])
+    _add(browser, src, "c3", detected_objects=[det("car"), det("car")])
+    qapp.processEvents()
+
+    # Rule: exactly 1 person
+    browser.apply_filters({"yolo_per_label_rules": [["person", "=", 1]]})
+    qapp.processEvents()
+    assert browser.get_visible_clip_count() == 1  # only c1
+
+    # Rule: > 0 car AND > 1 person
+    browser.apply_filters({
+        "yolo_per_label_rules": [["car", ">", 0], ["person", ">", 1]],
+    })
+    qapp.processEvents()
+    assert browser.get_visible_clip_count() == 1  # only c2
+
+
+def test_active_filter_chips_renders(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.active_filter_chips import ActiveFilterChips
+    fs = FilterState()
+    bar = ActiveFilterChips(fs)
+    # Empty state: hidden
+    assert bar.isVisible() is False or len(bar._chips) == 0
+
+    fs.shot_type = "Close-up"
+    qapp.processEvents()
+    assert len(bar._chips) == 1
+
+
+def test_active_filter_chip_clear_removes_filter(qapp):
+    from core.filter_state import FilterState
+    from ui.widgets.active_filter_chips import ActiveFilterChips
+
+    fs = FilterState()
+    fs.shot_type = "Close-up"
+    bar = ActiveFilterChips(fs)
+    qapp.processEvents()
+    assert len(bar._chips) == 1
+
+    bar._chips[0].click()
+    qapp.processEvents()
+    assert fs.shot_type == set()
+
+
+def test_reset_button_clears_everything(qapp):
+    from core.filter_state import FilterState
+
+    fs = FilterState()
+    fs.apply_dict({
+        "shot_type": ["Close-up"],
+        "person_count": (">", 1),
+        "has_audio": True,
+        "imagenet_labels": ["dog"],
+    })
+    assert fs.has_active() is True
+
+    fs.clear_all()
+    assert fs.has_active() is False

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import numpy as np
 
+from core.filter_state import FilterState
+
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -703,42 +705,150 @@ class ClipBrowser(QWidget):
         "9:16": (0.5625, 0.53, 0.59),   # 0.5625 ± 5%
     }
 
+    # ── Filter-state proxy properties ───────────────────────────────
+    # Each pair delegates to `self._filter_state.<field>`. Having these
+    # named with underscores preserves backward compat with tests that
+    # assign `browser._gaze_filter = "at_camera"` directly.
+
+    @property
+    def _current_filter(self) -> str:
+        return self._filter_state.shot_type
+
+    @_current_filter.setter
+    def _current_filter(self, value: str) -> None:
+        self._filter_state.shot_type = value if value else "All"
+
+    @property
+    def _current_color_filter(self) -> str:
+        return self._filter_state.color_palette
+
+    @_current_color_filter.setter
+    def _current_color_filter(self, value: str) -> None:
+        self._filter_state.color_palette = value if value else "All"
+
+    @property
+    def _current_search_query(self) -> str:
+        return self._filter_state.search_query
+
+    @_current_search_query.setter
+    def _current_search_query(self, value: str) -> None:
+        self._filter_state.search_query = value or ""
+
+    @property
+    def _selected_custom_queries(self) -> set:
+        return self._filter_state.selected_custom_queries
+
+    @_selected_custom_queries.setter
+    def _selected_custom_queries(self, value) -> None:
+        self._filter_state.selected_custom_queries = set(value) if value else set()
+
+    @property
+    def _min_duration(self):
+        return self._filter_state.min_duration
+
+    @_min_duration.setter
+    def _min_duration(self, value) -> None:
+        self._filter_state.min_duration = value
+
+    @property
+    def _max_duration(self):
+        return self._filter_state.max_duration
+
+    @_max_duration.setter
+    def _max_duration(self, value) -> None:
+        self._filter_state.max_duration = value
+
+    @property
+    def _aspect_ratio_filter(self) -> str:
+        return self._filter_state.aspect_ratio
+
+    @_aspect_ratio_filter.setter
+    def _aspect_ratio_filter(self, value: str) -> None:
+        self._filter_state.aspect_ratio = value if value else "All"
+
+    @property
+    def _gaze_filter(self):
+        return self._filter_state.gaze_filter
+
+    @_gaze_filter.setter
+    def _gaze_filter(self, value) -> None:
+        self._filter_state.gaze_filter = value
+
+    @property
+    def _object_search(self) -> str:
+        return self._filter_state.object_search
+
+    @_object_search.setter
+    def _object_search(self, value: str) -> None:
+        self._filter_state.object_search = value or ""
+
+    @property
+    def _description_search(self) -> str:
+        return self._filter_state.description_search
+
+    @_description_search.setter
+    def _description_search(self, value: str) -> None:
+        self._filter_state.description_search = value or ""
+
+    @property
+    def _min_brightness(self):
+        return self._filter_state.min_brightness
+
+    @_min_brightness.setter
+    def _min_brightness(self, value) -> None:
+        self._filter_state.min_brightness = value
+
+    @property
+    def _max_brightness(self):
+        return self._filter_state.max_brightness
+
+    @_max_brightness.setter
+    def _max_brightness(self, value) -> None:
+        self._filter_state.max_brightness = value
+
+    @property
+    def _similarity_anchor_id(self):
+        return self._filter_state.similarity_anchor_id
+
+    @_similarity_anchor_id.setter
+    def _similarity_anchor_id(self, value) -> None:
+        self._filter_state.similarity_anchor_id = value
+
+    @property
+    def _similarity_scores(self) -> dict:
+        return self._filter_state.similarity_scores
+
+    @_similarity_scores.setter
+    def _similarity_scores(self, value) -> None:
+        self._filter_state.similarity_scores = dict(value) if value else {}
+
     @property
     def COLUMNS(self) -> int:
         """Calculate number of columns based on available width."""
         return self._calculate_columns()
 
-    def __init__(self):
+    def __init__(self, filter_state: Optional[FilterState] = None):
         super().__init__()
         self.thumbnails: list[ClipThumbnail] = []
         self._thumbnail_by_id: dict[str, ClipThumbnail] = {}  # O(1) lookup by clip_id
         self.selected_clips: set[str] = set()  # clip ids
         self._drag_enabled = False
         self._source_lookup: dict[str, Source] = {}  # clip_id -> Source
-        self._current_filter = "All"  # Current shot type filter
-        self._current_color_filter = "All"  # Current color palette filter
-        self._current_search_query = ""  # Current transcript search query
-        self._selected_custom_queries: set[str] = set()
+
+        # Shared filter state — all filter values live here. Proxy properties
+        # on this class (e.g., `_current_filter`, `_gaze_filter`) read/write
+        # through `_filter_state` so existing tests that mutate private attrs
+        # directly keep working while the shared-state migration (Unit 1 of
+        # `docs/plans/2026-04-21-001-feat-comprehensive-clip-filter-system-plan.md`)
+        # is introduced. Both tabs' browsers share one `FilterState` instance
+        # when MainWindow injects it here.
+        self._filter_state = filter_state if filter_state is not None else FilterState()
+
         self._custom_query_filter_actions: dict[str, QAction] = {}
         self._updating_custom_query_filter_menu = False
         self._last_column_count = 0  # Track columns to detect changes on resize
 
-        # Duration and aspect ratio filters
-        self._min_duration: Optional[float] = None
-        self._max_duration: Optional[float] = None
-        self._aspect_ratio_filter: str = "All"  # "All", "16:9", "4:3", "9:16"
         self._filter_panel_visible = False
-
-        # Gaze, object, description, and brightness filters
-        self._gaze_filter: Optional[str] = None  # None = all, or internal key e.g. "at_camera"
-        self._object_search: str = ""
-        self._description_search: str = ""
-        self._min_brightness: Optional[float] = None
-        self._max_brightness: Optional[float] = None
-
-        # Similarity mode state
-        self._similarity_anchor_id: Optional[str] = None
-        self._similarity_scores: dict[str, float] = {}
 
         # Source grouping state
         self._group_expanded_state: dict[str, bool] = {}  # source_id -> is_expanded

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -8,6 +8,31 @@ import numpy as np
 
 from core.filter_state import FilterState
 
+
+def _enum_str_view(value_set, *, empty):
+    """Convert a FilterState enum set to a backward-compat string/list view.
+
+    Used by ``ClipBrowser`` proxy properties so existing callers that read
+    ``browser._gaze_filter`` / ``browser._current_filter`` still get a string
+    for single-select state and ``empty`` (``"All"`` or ``None``) for the
+    no-filter case.
+    """
+    if not value_set:
+        return empty
+    if len(value_set) == 1:
+        return next(iter(value_set))
+    return sorted(value_set, key=str.lower)
+
+
+def _combo_text_for_enum(value_set, *, fallback):
+    """Single-string representation of a multi-select enum for legacy QComboBox."""
+    if not value_set:
+        return fallback
+    if len(value_set) == 1:
+        return next(iter(value_set))
+    return fallback
+
+
 from PySide6.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -711,20 +736,20 @@ class ClipBrowser(QWidget):
     # assign `browser._gaze_filter = "at_camera"` directly.
 
     @property
-    def _current_filter(self) -> str:
-        return self._filter_state.shot_type
+    def _current_filter(self):
+        return _enum_str_view(self._filter_state.shot_type, empty="All")
 
     @_current_filter.setter
-    def _current_filter(self, value: str) -> None:
-        self._filter_state.shot_type = value if value else "All"
+    def _current_filter(self, value) -> None:
+        self._filter_state.shot_type = value
 
     @property
-    def _current_color_filter(self) -> str:
-        return self._filter_state.color_palette
+    def _current_color_filter(self):
+        return _enum_str_view(self._filter_state.color_palette, empty="All")
 
     @_current_color_filter.setter
-    def _current_color_filter(self, value: str) -> None:
-        self._filter_state.color_palette = value if value else "All"
+    def _current_color_filter(self, value) -> None:
+        self._filter_state.color_palette = value
 
     @property
     def _current_search_query(self) -> str:
@@ -759,16 +784,16 @@ class ClipBrowser(QWidget):
         self._filter_state.max_duration = value
 
     @property
-    def _aspect_ratio_filter(self) -> str:
-        return self._filter_state.aspect_ratio
+    def _aspect_ratio_filter(self):
+        return _enum_str_view(self._filter_state.aspect_ratio, empty="All")
 
     @_aspect_ratio_filter.setter
-    def _aspect_ratio_filter(self, value: str) -> None:
-        self._filter_state.aspect_ratio = value if value else "All"
+    def _aspect_ratio_filter(self, value) -> None:
+        self._filter_state.aspect_ratio = value
 
     @property
     def _gaze_filter(self):
-        return self._filter_state.gaze_filter
+        return _enum_str_view(self._filter_state.gaze_filter, empty=None)
 
     @_gaze_filter.setter
     def _gaze_filter(self, value) -> None:
@@ -1746,21 +1771,23 @@ class ClipBrowser(QWidget):
             if thumb.clip.id not in self._similarity_scores:
                 return False
 
-        # Check shot type filter
-        if self._current_filter != "All":
+        # Check shot type filter (multi-select: match any selected value)
+        selected_shots = self._filter_state.shot_type
+        if selected_shots:
             shot_type = thumb.clip.shot_type
             if not shot_type:
                 return False
-            if get_display_name(shot_type) != self._current_filter:
+            if get_display_name(shot_type) not in selected_shots:
                 return False
 
-        # Check color palette filter
-        if self._current_color_filter != "All":
+        # Check color palette filter (multi-select)
+        selected_palettes = self._filter_state.color_palette
+        if selected_palettes:
             colors = thumb.clip.dominant_colors
             if not colors:
                 return False
             palette = classify_color_palette(colors)
-            if get_palette_display_name(palette) != self._current_color_filter:
+            if get_palette_display_name(palette) not in selected_palettes:
                 return False
 
         # Check transcript search
@@ -1785,23 +1812,29 @@ class ClipBrowser(QWidget):
             if self._max_duration is not None and duration > self._max_duration:
                 return False
 
-        # Check aspect ratio filter
-        if self._aspect_ratio_filter != "All":
+        # Check aspect ratio filter (multi-select: any selected aspect must match)
+        selected_aspects = self._filter_state.aspect_ratio
+        if selected_aspects:
             source = thumb.source
-            # Hide clips without source dimensions
             if source.width == 0 or source.height == 0:
                 return False
             aspect = source.aspect_ratio
-            if self._aspect_ratio_filter in self.ASPECT_RATIOS:
-                _, min_ratio, max_ratio = self.ASPECT_RATIOS[self._aspect_ratio_filter]
-                if not (min_ratio <= aspect <= max_ratio):
-                    return False
+            matched = False
+            for key in selected_aspects:
+                if key in self.ASPECT_RATIOS:
+                    _, min_ratio, max_ratio = self.ASPECT_RATIOS[key]
+                    if min_ratio <= aspect <= max_ratio:
+                        matched = True
+                        break
+            if not matched:
+                return False
 
-        # Check gaze direction filter
-        if self._gaze_filter is not None:
+        # Check gaze direction filter (multi-select)
+        selected_gaze = self._filter_state.gaze_filter
+        if selected_gaze:
             if not thumb.clip.gaze_category:
                 return False
-            if thumb.clip.gaze_category != self._gaze_filter:
+            if thumb.clip.gaze_category not in selected_gaze:
                 return False
 
         # Check object search filter
@@ -2179,23 +2212,27 @@ class ClipBrowser(QWidget):
             new_max = self._max_duration if self._max_duration is not None else data_max
             self.duration_slider.set_values(new_min, new_max)
 
-        # Apply aspect ratio filter
+        # Apply aspect ratio filter. Enum fields accept strings (backward compat)
+        # or list/set (multi-select). When multi-select is active, the legacy
+        # QComboBox UI can only reflect one value — show "All" as the fallback
+        # since the sidebar owns the full multi-select state from Unit 4 onward.
         if 'aspect_ratio' in filters:
-            value = filters['aspect_ratio']
-            self._aspect_ratio_filter = value if value else "All"
-            self.aspect_ratio_combo.setCurrentText(self._aspect_ratio_filter)
+            self._filter_state.aspect_ratio = filters['aspect_ratio']
+            self.aspect_ratio_combo.setCurrentText(
+                _combo_text_for_enum(self._filter_state.aspect_ratio, fallback="All")
+            )
 
-        # Apply shot type filter
         if 'shot_type' in filters:
-            value = filters['shot_type']
-            self._current_filter = value if value else "All"
-            self.filter_combo.setCurrentText(self._current_filter)
+            self._filter_state.shot_type = filters['shot_type']
+            self.filter_combo.setCurrentText(
+                _combo_text_for_enum(self._filter_state.shot_type, fallback="All")
+            )
 
-        # Apply color palette filter
         if 'color_palette' in filters:
-            value = filters['color_palette']
-            self._current_color_filter = value if value else "All"
-            self.color_filter_combo.setCurrentText(self._current_color_filter)
+            self._filter_state.color_palette = filters['color_palette']
+            self.color_filter_combo.setCurrentText(
+                _combo_text_for_enum(self._filter_state.color_palette, fallback="All")
+            )
 
         # Apply search query
         if 'search_query' in filters:
@@ -2219,21 +2256,30 @@ class ClipBrowser(QWidget):
                 }
             self._sync_custom_query_filter_options()
 
-        # Apply gaze filter — accepts internal key or display label
+        # Apply gaze filter — accepts internal key, display label, list/set
+        # (multi-select), or None/empty. Normalize to the internal key set.
         if 'gaze' in filters:
             value = filters['gaze']
-            if not value:
-                self._gaze_filter = None
-            elif value in GAZE_CATEGORY_DISPLAY:
-                # Internal key (e.g. "at_camera")
-                self._gaze_filter = value
-            elif value in _GAZE_DISPLAY_TO_KEY:
-                # Display label (e.g. "At Camera")
-                self._gaze_filter = _GAZE_DISPLAY_TO_KEY[value]
+            if value is None or value == "" or value == "All Gaze":
+                self._filter_state.gaze_filter = set()
             else:
-                self._gaze_filter = None
-            # Sync combo box to display label
-            display = GAZE_CATEGORY_DISPLAY.get(self._gaze_filter, "All Gaze")
+                if isinstance(value, str):
+                    items = [value]
+                else:
+                    items = list(value)
+                keys: set[str] = set()
+                for item in items:
+                    if item in GAZE_CATEGORY_DISPLAY:
+                        keys.add(item)
+                    elif item in _GAZE_DISPLAY_TO_KEY:
+                        keys.add(_GAZE_DISPLAY_TO_KEY[item])
+                self._filter_state.gaze_filter = keys
+            # Sync legacy combo box — shows single value or "All Gaze" fallback
+            keys = self._filter_state.gaze_filter
+            if len(keys) == 1:
+                display = GAZE_CATEGORY_DISPLAY.get(next(iter(keys)), "All Gaze")
+            else:
+                display = "All Gaze"
             self.gaze_combo.setCurrentText(display)
 
         # Apply object search filter

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -893,7 +893,11 @@ class ClipBrowser(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # Header with filter and sort dropdowns
+        # Header with non-filter controls only. Filter UI is now owned by
+        # FilterSidebar (see ui/widgets/filter_sidebar.py); the legacy
+        # filter widgets below are still instantiated for backward compat
+        # with tests that manipulate `browser.filter_combo`, etc. directly,
+        # but they are not added to any visible layout.
         header_layout = QHBoxLayout()
         header_layout.setContentsMargins(8, 8, 8, 4)
 
@@ -903,16 +907,7 @@ class ClipBrowser(QWidget):
 
         header_layout.addStretch()
 
-        # Filters toggle button
-        self.filters_btn = QPushButton("Filters")
-        self.filters_btn.setCheckable(True)
-        self.filters_btn.setToolTip("Show/hide duration and aspect ratio filters")
-        self.filters_btn.clicked.connect(self._toggle_filter_panel)
-        header_layout.addWidget(self.filters_btn)
-
-        header_layout.addSpacing(4)
-
-        # Expand/Collapse all buttons
+        # Expand/Collapse all buttons (non-filter)
         self.expand_all_btn = QPushButton("Expand All")
         self.expand_all_btn.setToolTip("Expand all source groups")
         self.expand_all_btn.clicked.connect(self.expand_all_groups)
@@ -923,63 +918,9 @@ class ClipBrowser(QWidget):
         self.collapse_all_btn.clicked.connect(self.collapse_all_groups)
         header_layout.addWidget(self.collapse_all_btn)
 
-        header_layout.addSpacing(8)
-
-        # Shot type filter dropdown
-        filter_label = QLabel("Shot:")
-        header_layout.addWidget(filter_label)
-
-        self.filter_combo = QComboBox()
-        filter_options = ["All"] + [get_display_name(st) for st in SHOT_TYPES]
-        self.filter_combo.addItems(filter_options)
-        self.filter_combo.setFixedWidth(100)
-        self.filter_combo.currentTextChanged.connect(self._on_filter_changed)
-        header_layout.addWidget(self.filter_combo)
-
-        header_layout.addSpacing(8)
-
-        # Color palette filter dropdown
-        color_label = QLabel("Color:")
-        header_layout.addWidget(color_label)
-
-        self.color_filter_combo = QComboBox()
-        color_filter_options = ["All"] + [get_palette_display_name(cp) for cp in COLOR_PALETTES]
-        self.color_filter_combo.addItems(color_filter_options)
-        self.color_filter_combo.setFixedWidth(80)
-        self.color_filter_combo.currentTextChanged.connect(self._on_color_filter_changed)
-        header_layout.addWidget(self.color_filter_combo)
-
-        header_layout.addSpacing(8)
-
-        # Transcript search input
-        search_label = QLabel("Search:")
-        header_layout.addWidget(search_label)
-
-        self.search_input = QLineEdit()
-        self.search_input.setPlaceholderText("Search transcripts...")
-        self.search_input.setFixedWidth(120)
-        self.search_input.setToolTip("Filter clips by transcript content")
-        self.search_input.textChanged.connect(self._on_search_changed)
-        header_layout.addWidget(self.search_input)
-
-        header_layout.addSpacing(8)
-
-        custom_query_label = QLabel("Custom:")
-        header_layout.addWidget(custom_query_label)
-
-        self.custom_query_filter_btn = QToolButton()
-        self.custom_query_filter_btn.setPopupMode(QToolButton.InstantPopup)
-        self.custom_query_filter_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
-        self.custom_query_filter_btn.setMinimumWidth(120)
-        self.custom_query_filter_btn.setToolTip("Filter clips by custom query matches")
-        self.custom_query_filter_menu = QMenu(self.custom_query_filter_btn)
-        self.custom_query_filter_btn.setMenu(self.custom_query_filter_menu)
-        header_layout.addWidget(self.custom_query_filter_btn)
-        self._sync_custom_query_filter_options()
-
         header_layout.addSpacing(16)
 
-        # Sort dropdown
+        # Sort dropdown (non-filter)
         sort_label = QLabel("Order:")
         header_layout.addWidget(sort_label)
 
@@ -991,10 +932,41 @@ class ClipBrowser(QWidget):
 
         layout.addLayout(header_layout)
 
-        # Filter panel (collapsible)
+        # ── Legacy filter widgets (parented but not added to visible layout) ──
+        # These instances preserve backward compat with pre-sidebar tests that
+        # read/write `browser.filter_combo`, `browser.gaze_combo`, etc.
+        self.filters_btn = QPushButton("Filters", parent=self)
+        self.filters_btn.setCheckable(True)
+        self.filters_btn.setVisible(False)
+        self.filters_btn.clicked.connect(self._toggle_filter_panel)
+
+        self.filter_combo = QComboBox(parent=self)
+        self.filter_combo.addItems(["All"] + [get_display_name(st) for st in SHOT_TYPES])
+        self.filter_combo.setVisible(False)
+        self.filter_combo.currentTextChanged.connect(self._on_filter_changed)
+
+        self.color_filter_combo = QComboBox(parent=self)
+        self.color_filter_combo.addItems(["All"] + [get_palette_display_name(cp) for cp in COLOR_PALETTES])
+        self.color_filter_combo.setVisible(False)
+        self.color_filter_combo.currentTextChanged.connect(self._on_color_filter_changed)
+
+        self.search_input = QLineEdit(parent=self)
+        self.search_input.setVisible(False)
+        self.search_input.textChanged.connect(self._on_search_changed)
+
+        self.custom_query_filter_btn = QToolButton(parent=self)
+        self.custom_query_filter_btn.setPopupMode(QToolButton.InstantPopup)
+        self.custom_query_filter_btn.setVisible(False)
+        self.custom_query_filter_menu = QMenu(self.custom_query_filter_btn)
+        self.custom_query_filter_btn.setMenu(self.custom_query_filter_menu)
+        self._sync_custom_query_filter_options()
+
+        # Legacy filter panel (slider widgets, gaze combo, etc.) — created
+        # but not added to the visible layout. Tests still access its children
+        # like `browser.gaze_combo` directly.
         self.filter_panel = self._create_filter_panel()
+        self.filter_panel.setParent(self)
         self.filter_panel.setVisible(False)
-        layout.addWidget(self.filter_panel)
 
         # Scroll area for thumbnails
         self.scroll = QScrollArea()

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -1933,6 +1933,47 @@ class ClipBrowser(QWidget):
             if needle not in tags_text and needle not in notes_text:
                 return False
 
+        # ── Unit 6 predicates: objects (ImageNet + YOLO) ────────────
+        # ImageNet labels (Any / All semantics)
+        if fs.imagenet_labels:
+            clip_labels = set(clip.object_labels or [])
+            if fs.imagenet_mode == "all":
+                if not fs.imagenet_labels.issubset(clip_labels):
+                    return False
+            else:  # "any"
+                if clip_labels.isdisjoint(fs.imagenet_labels):
+                    return False
+
+        # YOLO labels (OR within selected)
+        if fs.yolo_labels:
+            detected_labels = {d.get("label", "") for d in (clip.detected_objects or [])}
+            if detected_labels.isdisjoint(fs.yolo_labels):
+                return False
+
+        # YOLO total object count operator
+        if fs.yolo_total_count is not None:
+            op, n = fs.yolo_total_count
+            total = len(clip.detected_objects or [])
+            if op == ">" and not (total > n):
+                return False
+            if op == "=" and not (total == n):
+                return False
+            if op == "<" and not (total < n):
+                return False
+
+        # YOLO per-label count rules (AND across rules)
+        if fs.yolo_per_label_rules:
+            from collections import Counter
+            counts = Counter(d.get("label", "") for d in (clip.detected_objects or []))
+            for label, op, n in fs.yolo_per_label_rules:
+                cnt = counts.get(label, 0)
+                if op == ">" and not (cnt > n):
+                    return False
+                if op == "=" and not (cnt == n):
+                    return False
+                if op == "<" and not (cnt < n):
+                    return False
+
         return True
 
     def _create_filter_panel(self) -> QFrame:

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -1860,6 +1860,79 @@ class ClipBrowser(QWidget):
             if thumb.clip.average_brightness is None or thumb.clip.average_brightness > self._max_brightness:
                 return False
 
+        # ── Unit 5 filter predicates ────────────────────────────────
+        fs = self._filter_state
+        clip = thumb.clip
+
+        # Person count operator
+        if fs.person_count is not None:
+            op, n = fs.person_count
+            count = clip.person_count or 0
+            if op == ">" and not (count > n):
+                return False
+            if op == "=" and not (count == n):
+                return False
+            if op == "<" and not (count < n):
+                return False
+
+        # Has audio (tribool)
+        if fs.has_audio is not None:
+            has_audio = bool(clip.transcript) or clip.rms_volume is not None
+            if has_audio != fs.has_audio:
+                return False
+
+        # Has transcript
+        if fs.has_transcript is not None:
+            if bool(clip.transcript) != fs.has_transcript:
+                return False
+
+        # Has on-screen text
+        if fs.has_on_screen_text is not None:
+            if bool(clip.extracted_texts) != fs.has_on_screen_text:
+                return False
+
+        # On-screen text search
+        if fs.on_screen_text_search:
+            needle = fs.on_screen_text_search.lower()
+            haystack = " ".join(
+                (et.text if hasattr(et, "text") else str(et))
+                for et in (clip.extracted_texts or [])
+            ).lower()
+            if needle not in haystack:
+                return False
+
+        # RMS volume range
+        if fs.min_volume is not None:
+            if clip.rms_volume is None or clip.rms_volume < fs.min_volume:
+                return False
+        if fs.max_volume is not None:
+            if clip.rms_volume is None or clip.rms_volume > fs.max_volume:
+                return False
+
+        # Has-analysis-of-type — AND across selected operations
+        if fs.has_analysis_ops:
+            try:
+                from core.analysis_availability import operation_is_complete_for_clip
+                for op_key in fs.has_analysis_ops:
+                    if not operation_is_complete_for_clip(op_key, clip):
+                        return False
+            except ImportError:
+                pass
+
+        # Enabled / disabled
+        if fs.enabled_filter is not None:
+            is_enabled = not clip.disabled
+            if is_enabled != fs.enabled_filter:
+                return False
+
+        # Tag / note search
+        if fs.tag_note_search:
+            needle = fs.tag_note_search.lower()
+            tags_text = " ".join(clip.tags or []).lower()
+            notes_text = (clip.notes or "").lower()
+            if needle not in tags_text and needle not in notes_text:
+                return False
+
         return True
 
     def _create_filter_panel(self) -> QFrame:
@@ -2314,6 +2387,19 @@ class ClipBrowser(QWidget):
         self.description_search_input.blockSignals(False)
         self.brightness_slider.blockSignals(False)
 
+        # Delegate Unit 5+ keys to FilterState. The legacy keys above have
+        # already been applied (often with display↔key conversion, e.g. for
+        # gaze), so strip them before delegation to avoid clobbering.
+        _legacy_keys = {
+            "min_duration", "max_duration", "aspect_ratio", "shot_type",
+            "color_palette", "search_query", "custom_query", "gaze",
+            "object_search", "description_search", "min_brightness",
+            "max_brightness", "similarity_anchor",
+        }
+        unit5_filters = {k: v for k, v in filters.items() if k not in _legacy_keys}
+        if unit5_filters:
+            self._filter_state.apply_dict(unit5_filters)
+
         # Rebuild grid and emit signal
         self._rebuild_grid()
         self.filters_changed.emit()
@@ -2334,27 +2420,17 @@ class ClipBrowser(QWidget):
         """Return current filter state.
 
         Returns:
-            Dict with filter names and their current values
+            Dict with filter names and their current values. The exact
+            shape is determined by ``FilterState.to_dict`` — legacy keys
+            (shot_type, color_palette, search_query, custom_query,
+            min/max_duration, aspect_ratio, gaze, object_search,
+            description_search, min/max_brightness, similarity_anchor)
+            plus Unit 5 additions (person_count, has_audio,
+            has_transcript, has_on_screen_text, on_screen_text_search,
+            min/max_volume, has_analysis_ops, enabled_filter,
+            tag_note_search).
         """
-        return {
-            "shot_type": self._current_filter if self._current_filter != "All" else None,
-            "color_palette": self._current_color_filter if self._current_color_filter != "All" else None,
-            "search_query": self._current_search_query if self._current_search_query else None,
-            "custom_query": (
-                sorted(self._selected_custom_queries, key=str.lower)
-                if self._selected_custom_queries
-                else None
-            ),
-            "min_duration": self._min_duration,
-            "max_duration": self._max_duration,
-            "aspect_ratio": self._aspect_ratio_filter if self._aspect_ratio_filter != "All" else None,
-            "gaze": self._gaze_filter,
-            "object_search": self._object_search if self._object_search else None,
-            "description_search": self._description_search if self._description_search else None,
-            "min_brightness": self._min_brightness,
-            "max_brightness": self._max_brightness,
-            "similarity_anchor": self._similarity_anchor_id,
-        }
+        return self._filter_state.to_dict()
 
     def has_active_filters(self) -> bool:
         """Check if any filters are currently active.

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1075,10 +1075,16 @@ class MainWindow(QMainWindow):
         self.tab_widget = QTabWidget()
         self.tab_widget.currentChanged.connect(self._on_tab_changed)
 
+        # Shared clip-filter state — Cut and Analyze point at the same
+        # FilterState so filter values are shared across tabs by default
+        # (see docs/plans/2026-04-21-001-feat-comprehensive-clip-filter-system-plan.md).
+        from core.filter_state import FilterState
+        self._filter_state = FilterState()
+
         # Create tabs
         self.collect_tab = CollectTab()
-        self.cut_tab = CutTab()
-        self.analyze_tab = AnalyzeTab()
+        self.cut_tab = CutTab(filter_state=self._filter_state)
+        self.analyze_tab = AnalyzeTab(filter_state=self._filter_state)
         self.frames_tab = FramesTab()
         self.sequence_tab = SequenceTab()
         self.render_tab = RenderTab()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1100,6 +1100,14 @@ class MainWindow(QMainWindow):
         # Set up Analyze tab lookups (it uses references, not copies)
         self.analyze_tab.set_lookups(self.clips_by_id, self.sources_by_id)
 
+        # Restore filter-sidebar visibility from settings (per tab)
+        try:
+            self.cut_tab.set_filter_sidebar_visible(self.settings.cut_filter_sidebar_visible)
+            self.analyze_tab.set_filter_sidebar_visible(self.settings.analyze_filter_sidebar_visible)
+        except AttributeError:
+            # If settings object doesn't have the fields yet (migration), leave defaults.
+            pass
+
         # Set up Frames tab project reference
         self.frames_tab.set_project(self.project)
 

--- a/ui/tabs/analyze_tab.py
+++ b/ui/tabs/analyze_tab.py
@@ -10,12 +10,14 @@ from PySide6.QtWidgets import (
     QWidget,
     QStackedWidget,
     QComboBox,
+    QSplitter,
 )
 from PySide6.QtCore import Signal, Qt
 
 from .base_tab import BaseTab
 from ui.clip_browser import ClipBrowser
 from ui.widgets import EmptyStateWidget
+from ui.widgets.filter_sidebar import FilterSidebar
 from ui.dialogs import GlossaryDialog
 from ui.theme import UISizes
 from core.analysis_availability import compute_disabled_operations
@@ -57,6 +59,9 @@ class AnalyzeTab(BaseTab):
         self._clips_by_id: dict = {}
         self._is_analyzing = False
         self._disabled_quick_ops: set[str] = set()
+        if filter_state is None:
+            from core.filter_state import FilterState
+            filter_state = FilterState()
         self._filter_state = filter_state
         super().__init__(parent)
 
@@ -120,6 +125,14 @@ class AnalyzeTab(BaseTab):
         self.analyze_btn.clicked.connect(self._on_analyze_click)
         controls.addWidget(self.analyze_btn)
 
+        # Filter sidebar toggle
+        self.filter_toggle_btn = QPushButton("Filters")
+        self.filter_toggle_btn.setCheckable(True)
+        self.filter_toggle_btn.setChecked(True)
+        self.filter_toggle_btn.setToolTip("Show/hide filter sidebar")
+        self.filter_toggle_btn.clicked.connect(lambda checked: self.set_filter_sidebar_visible(checked))
+        controls.addWidget(self.filter_toggle_btn)
+
         controls.addSpacing(20)
 
         # Clear All button
@@ -154,12 +167,11 @@ class AnalyzeTab(BaseTab):
         return controls
 
     def _create_content_area(self) -> QWidget:
-        """Create the main content area with clip browser and video player."""
+        """Create the main content area with clip browser + filter sidebar."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # Clip browser (full width - video preview is in clip details sidebar)
         self.clip_browser = ClipBrowser(filter_state=self._filter_state)
         self.clip_browser.set_drag_enabled(True)
         self.clip_browser.clip_selected.connect(self._on_clip_selected)
@@ -167,9 +179,28 @@ class AnalyzeTab(BaseTab):
         self.clip_browser.clip_dragged_to_timeline.connect(self._on_clip_dragged)
         self.clip_browser.selection_changed.connect(self._on_browser_selection_changed)
         self.clip_browser.filters_changed.connect(self._on_filters_changed)
-        layout.addWidget(self.clip_browser)
+
+        self.filter_sidebar = FilterSidebar(self._filter_state)
+        self.filter_sidebar.visibility_requested.connect(self._on_sidebar_visibility_request)
+
+        self.content_splitter = QSplitter(Qt.Horizontal)
+        self.content_splitter.addWidget(self.clip_browser)
+        self.content_splitter.addWidget(self.filter_sidebar)
+        self.content_splitter.setStretchFactor(0, 1)
+        self.content_splitter.setStretchFactor(1, 0)
+        self.content_splitter.setSizes([800, 320])
+
+        layout.addWidget(self.content_splitter)
 
         return content
+
+    def set_filter_sidebar_visible(self, visible: bool) -> None:
+        self.filter_sidebar.setVisible(visible)
+        if hasattr(self, "filter_toggle_btn") and self.filter_toggle_btn.isChecked() != visible:
+            self.filter_toggle_btn.setChecked(visible)
+
+    def _on_sidebar_visibility_request(self, visible: bool) -> None:
+        self.set_filter_sidebar_visible(visible)
 
     def _on_quick_run_click(self):
         """Handle quick run button click - immediate single operation."""

--- a/ui/tabs/analyze_tab.py
+++ b/ui/tabs/analyze_tab.py
@@ -17,6 +17,7 @@ from PySide6.QtCore import Signal, Qt
 from .base_tab import BaseTab
 from ui.clip_browser import ClipBrowser
 from ui.widgets import EmptyStateWidget
+from ui.widgets.active_filter_chips import ActiveFilterChips
 from ui.widgets.filter_sidebar import FilterSidebar
 from ui.dialogs import GlossaryDialog
 from ui.theme import UISizes
@@ -133,6 +134,12 @@ class AnalyzeTab(BaseTab):
         self.filter_toggle_btn.clicked.connect(lambda checked: self.set_filter_sidebar_visible(checked))
         controls.addWidget(self.filter_toggle_btn)
 
+        # Reset filters
+        self.reset_filters_btn = QPushButton("Reset filters")
+        self.reset_filters_btn.setToolTip("Clear all filter values")
+        self.reset_filters_btn.clicked.connect(self._filter_state.clear_all)
+        controls.addWidget(self.reset_filters_btn)
+
         controls.addSpacing(20)
 
         # Clear All button
@@ -172,6 +179,10 @@ class AnalyzeTab(BaseTab):
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
 
+        # Active filter chips bar
+        self.active_filter_chips = ActiveFilterChips(self._filter_state)
+        layout.addWidget(self.active_filter_chips)
+
         self.clip_browser = ClipBrowser(filter_state=self._filter_state)
         self.clip_browser.set_drag_enabled(True)
         self.clip_browser.clip_selected.connect(self._on_clip_selected)
@@ -201,6 +212,16 @@ class AnalyzeTab(BaseTab):
 
     def _on_sidebar_visibility_request(self, visible: bool) -> None:
         self.set_filter_sidebar_visible(visible)
+
+    def refresh_filter_vocabularies(self) -> None:
+        """Recompute YOLO label vocabulary from current clips and push to sidebar."""
+        labels: set[str] = set()
+        for thumb in self.clip_browser.thumbnails:
+            for det in (thumb.clip.detected_objects or []):
+                label = det.get("label", "")
+                if label:
+                    labels.add(label)
+        self.filter_sidebar.refresh_yolo_vocabulary(labels)
 
     def _on_quick_run_click(self):
         """Handle quick run button click - immediate single operation."""

--- a/ui/tabs/analyze_tab.py
+++ b/ui/tabs/analyze_tab.py
@@ -49,7 +49,7 @@ class AnalyzeTab(BaseTab):
     STATE_NO_CLIPS = 0
     STATE_CLIPS = 1
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, filter_state=None):
         # Clip ID references (not copies) - resolved via MainWindow.clips_by_id
         self._clip_ids: set[str] = set()
         # Source lookup for video preview (set by MainWindow)
@@ -57,6 +57,7 @@ class AnalyzeTab(BaseTab):
         self._clips_by_id: dict = {}
         self._is_analyzing = False
         self._disabled_quick_ops: set[str] = set()
+        self._filter_state = filter_state
         super().__init__(parent)
 
     def _setup_ui(self):
@@ -159,7 +160,7 @@ class AnalyzeTab(BaseTab):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # Clip browser (full width - video preview is in clip details sidebar)
-        self.clip_browser = ClipBrowser()
+        self.clip_browser = ClipBrowser(filter_state=self._filter_state)
         self.clip_browser.set_drag_enabled(True)
         self.clip_browser.clip_selected.connect(self._on_clip_selected)
         self.clip_browser.clip_double_clicked.connect(self._on_clip_double_clicked)

--- a/ui/tabs/cut_tab.py
+++ b/ui/tabs/cut_tab.py
@@ -7,12 +7,14 @@ from PySide6.QtWidgets import (
     QPushButton,
     QWidget,
     QStackedWidget,
+    QSplitter,
 )
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Qt, Signal
 
 from .base_tab import BaseTab
 from ui.clip_browser import ClipBrowser
 from ui.widgets import EmptyStateWidget
+from ui.widgets.filter_sidebar import FilterSidebar
 
 
 class CutTab(BaseTab):
@@ -41,6 +43,9 @@ class CutTab(BaseTab):
         self._current_source = None
         self._clips = []
         self._settings = None
+        if filter_state is None:
+            from core.filter_state import FilterState
+            filter_state = FilterState()
         self._filter_state = filter_state
         super().__init__(parent)
 
@@ -91,6 +96,14 @@ class CutTab(BaseTab):
         self.analyze_btn.clicked.connect(self._on_analyze_click)
         controls.addWidget(self.analyze_btn)
 
+        # Filter sidebar toggle
+        self.filter_toggle_btn = QPushButton("Filters")
+        self.filter_toggle_btn.setCheckable(True)
+        self.filter_toggle_btn.setChecked(True)
+        self.filter_toggle_btn.setToolTip("Show/hide filter sidebar")
+        self.filter_toggle_btn.clicked.connect(self._on_filter_toggle)
+        controls.addWidget(self.filter_toggle_btn)
+
         controls.addStretch()
 
         # Selection count label
@@ -106,12 +119,12 @@ class CutTab(BaseTab):
         return controls
 
     def _create_content_area(self) -> QWidget:
-        """Create the main content area with clip browser and video player."""
+        """Create the main content area with clip browser and filter sidebar."""
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        # Clip browser (full width - video preview is in clip details sidebar)
+        # Clip browser + filter sidebar in a splitter
         self.clip_browser = ClipBrowser(filter_state=self._filter_state)
         self.clip_browser.set_drag_enabled(True)
         self.clip_browser.clip_selected.connect(self._on_clip_selected)
@@ -119,9 +132,31 @@ class CutTab(BaseTab):
         self.clip_browser.clip_dragged_to_timeline.connect(self._on_clip_dragged)
         self.clip_browser.selection_changed.connect(self._on_browser_selection_changed)
         self.clip_browser.filters_changed.connect(self._on_filters_changed)
-        layout.addWidget(self.clip_browser)
+
+        self.filter_sidebar = FilterSidebar(self._filter_state)
+        self.filter_sidebar.visibility_requested.connect(self._on_sidebar_visibility_request)
+
+        self.content_splitter = QSplitter(Qt.Horizontal)
+        self.content_splitter.addWidget(self.clip_browser)
+        self.content_splitter.addWidget(self.filter_sidebar)
+        self.content_splitter.setStretchFactor(0, 1)
+        self.content_splitter.setStretchFactor(1, 0)
+        self.content_splitter.setSizes([800, 320])
+
+        layout.addWidget(self.content_splitter)
 
         return content
+
+    def set_filter_sidebar_visible(self, visible: bool) -> None:
+        self.filter_sidebar.setVisible(visible)
+        if self.filter_toggle_btn.isChecked() != visible:
+            self.filter_toggle_btn.setChecked(visible)
+
+    def _on_filter_toggle(self, checked: bool) -> None:
+        self.filter_sidebar.setVisible(checked)
+
+    def _on_sidebar_visibility_request(self, visible: bool) -> None:
+        self.set_filter_sidebar_visible(visible)
 
     def _on_analyze_click(self):
         """Handle analyze selected button click."""

--- a/ui/tabs/cut_tab.py
+++ b/ui/tabs/cut_tab.py
@@ -14,6 +14,7 @@ from PySide6.QtCore import Qt, Signal
 from .base_tab import BaseTab
 from ui.clip_browser import ClipBrowser
 from ui.widgets import EmptyStateWidget
+from ui.widgets.active_filter_chips import ActiveFilterChips
 from ui.widgets.filter_sidebar import FilterSidebar
 
 
@@ -104,6 +105,12 @@ class CutTab(BaseTab):
         self.filter_toggle_btn.clicked.connect(self._on_filter_toggle)
         controls.addWidget(self.filter_toggle_btn)
 
+        # Reset filters
+        self.reset_filters_btn = QPushButton("Reset filters")
+        self.reset_filters_btn.setToolTip("Clear all filter values (shared state, visible on both tabs)")
+        self.reset_filters_btn.clicked.connect(self._filter_state.clear_all)
+        controls.addWidget(self.reset_filters_btn)
+
         controls.addStretch()
 
         # Selection count label
@@ -123,6 +130,10 @@ class CutTab(BaseTab):
         content = QWidget()
         layout = QVBoxLayout(content)
         layout.setContentsMargins(0, 0, 0, 0)
+
+        # Active filter chips bar (above grid)
+        self.active_filter_chips = ActiveFilterChips(self._filter_state)
+        layout.addWidget(self.active_filter_chips)
 
         # Clip browser + filter sidebar in a splitter
         self.clip_browser = ClipBrowser(filter_state=self._filter_state)
@@ -157,6 +168,16 @@ class CutTab(BaseTab):
 
     def _on_sidebar_visibility_request(self, visible: bool) -> None:
         self.set_filter_sidebar_visible(visible)
+
+    def refresh_filter_vocabularies(self) -> None:
+        """Recompute YOLO label vocabulary from current clips and push to sidebar."""
+        labels: set[str] = set()
+        for thumb in self.clip_browser.thumbnails:
+            for det in (thumb.clip.detected_objects or []):
+                label = det.get("label", "")
+                if label:
+                    labels.add(label)
+        self.filter_sidebar.refresh_yolo_vocabulary(labels)
 
     def _on_analyze_click(self):
         """Handle analyze selected button click."""

--- a/ui/tabs/cut_tab.py
+++ b/ui/tabs/cut_tab.py
@@ -36,11 +36,12 @@ class CutTab(BaseTab):
     STATE_NO_CLIPS = 1
     STATE_CLIPS = 2
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, filter_state=None):
         # References to be set by MainWindow
         self._current_source = None
         self._clips = []
         self._settings = None
+        self._filter_state = filter_state
         super().__init__(parent)
 
     def _setup_ui(self):
@@ -111,7 +112,7 @@ class CutTab(BaseTab):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # Clip browser (full width - video preview is in clip details sidebar)
-        self.clip_browser = ClipBrowser()
+        self.clip_browser = ClipBrowser(filter_state=self._filter_state)
         self.clip_browser.set_drag_enabled(True)
         self.clip_browser.clip_selected.connect(self._on_clip_selected)
         self.clip_browser.clip_double_clicked.connect(self._on_clip_double_clicked)

--- a/ui/widgets/active_filter_chips.py
+++ b/ui/widgets/active_filter_chips.py
@@ -1,0 +1,197 @@
+"""Read-only chip bar summarizing the active filters.
+
+Displays one chip per non-default filter dimension so the user can see
+what's applied even when the sidebar is hidden. Each chip has a ``×``
+that clears its specific filter. Subscribes to ``FilterState.changed``
+and rebuilds on every change.
+"""
+
+from typing import Optional
+
+from PySide6.QtCore import Signal, Slot
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QPushButton,
+    QWidget,
+)
+
+from core.filter_state import FilterState
+from ui.theme import Radii, Spacing, TypeScale, theme
+
+
+# Map of display title → list of FilterState attributes that should reset
+# to a default value when the chip is cleared.
+_FIELD_DEFAULTS = {
+    "shot_type": set(),
+    "color_palette": set(),
+    "aspect_ratio": set(),
+    "gaze_filter": set(),
+    "search_query": "",
+    "object_search": "",
+    "description_search": "",
+    "on_screen_text_search": "",
+    "tag_note_search": "",
+    "selected_custom_queries": set(),
+    "has_analysis_ops": set(),
+    "imagenet_labels": set(),
+    "yolo_labels": set(),
+    "yolo_per_label_rules": [],
+    "person_count": None,
+    "yolo_total_count": None,
+    "has_audio": None,
+    "has_transcript": None,
+    "has_on_screen_text": None,
+    "enabled_filter": None,
+    "similarity_anchor_id": None,
+    "min_duration": None,
+    "max_duration": None,
+    "min_brightness": None,
+    "max_brightness": None,
+    "min_volume": None,
+    "max_volume": None,
+}
+
+
+class ActiveFilterChips(QWidget):
+    """Compact read-only bar that mirrors the active FilterState fields."""
+
+    def __init__(self, filter_state: FilterState, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._filter_state = filter_state
+        self._chips: list[QPushButton] = []
+
+        self._layout = QHBoxLayout(self)
+        self._layout.setContentsMargins(Spacing.MD, Spacing.XXS, Spacing.MD, Spacing.XXS)
+        self._layout.setSpacing(Spacing.XS)
+        self._layout.addStretch()
+
+        self._rebuild()
+        self._filter_state.changed.connect(self._rebuild)
+        self._refresh_theme()
+        if theme().changed:
+            theme().changed.connect(self._refresh_theme)
+
+    @Slot()
+    def _rebuild(self) -> None:
+        # Clear existing chips
+        for btn in self._chips:
+            self._layout.removeWidget(btn)
+            btn.setParent(None)
+        self._chips.clear()
+
+        entries = self._compute_entries()
+        for label, clear_fields in entries:
+            btn = QPushButton(f"{label}  ×")
+            btn.setObjectName("ActiveFilterChip")
+            btn.clicked.connect(lambda _checked=False, fields=clear_fields: self._clear_fields(fields))
+            self._chips.append(btn)
+            self._layout.insertWidget(self._layout.count() - 1, btn)
+
+        self.setVisible(bool(entries))
+
+    def _clear_fields(self, fields: tuple[str, ...]) -> None:
+        for field in fields:
+            default = _FIELD_DEFAULTS.get(field)
+            setattr(self._filter_state, field, default)
+
+    def _compute_entries(self) -> list[tuple[str, tuple[str, ...]]]:
+        """Return (display_label, clear_fields) tuples for active filters."""
+        fs = self._filter_state
+        out: list[tuple[str, tuple[str, ...]]] = []
+
+        def _add_set_field(value: set, title: str, field: str):
+            if not value:
+                return
+            if len(value) <= 2:
+                out.append((f"{title}: {', '.join(sorted(value))}", (field,)))
+            else:
+                out.append((f"{title}: {len(value)} selected", (field,)))
+
+        _add_set_field(fs.shot_type, "Shot", "shot_type")
+        _add_set_field(fs.color_palette, "Color", "color_palette")
+        _add_set_field(fs.aspect_ratio, "Aspect", "aspect_ratio")
+        _add_set_field(fs.gaze_filter, "Gaze", "gaze_filter")
+        _add_set_field(fs.selected_custom_queries, "Query", "selected_custom_queries")
+        _add_set_field(fs.has_analysis_ops, "Has analysis", "has_analysis_ops")
+        _add_set_field(fs.imagenet_labels, "ImageNet", "imagenet_labels")
+        _add_set_field(fs.yolo_labels, "YOLO", "yolo_labels")
+
+        for field, title in [
+            ("search_query", "Search"),
+            ("object_search", "Object"),
+            ("description_search", "Description"),
+            ("on_screen_text_search", "Text"),
+            ("tag_note_search", "Tags/notes"),
+        ]:
+            val = getattr(fs, field)
+            if val:
+                out.append((f"{title}: {val}", (field,)))
+
+        if fs.person_count is not None:
+            op, n = fs.person_count
+            out.append((f"People {op} {n}", ("person_count",)))
+
+        if fs.yolo_total_count is not None:
+            op, n = fs.yolo_total_count
+            out.append((f"Objects {op} {n}", ("yolo_total_count",)))
+
+        for field, title in [
+            ("has_audio", "Audio"),
+            ("has_transcript", "Transcript"),
+            ("has_on_screen_text", "On-screen text"),
+            ("enabled_filter", "Enabled"),
+        ]:
+            val = getattr(fs, field)
+            if val is True:
+                out.append((f"{title}: Yes", (field,)))
+            elif val is False:
+                out.append((f"{title}: No", (field,)))
+
+        # Ranges
+        for (min_key, max_key, title) in [
+            ("min_duration", "max_duration", "Duration"),
+            ("min_brightness", "max_brightness", "Brightness"),
+            ("min_volume", "max_volume", "Volume"),
+        ]:
+            lo = getattr(fs, min_key)
+            hi = getattr(fs, max_key)
+            if lo is None and hi is None:
+                continue
+            if lo is not None and hi is not None:
+                text = f"{title}: {lo}–{hi}"
+            elif lo is not None:
+                text = f"{title}: ≥ {lo}"
+            else:
+                text = f"{title}: ≤ {hi}"
+            out.append((text, (min_key, max_key)))
+
+        if fs.yolo_per_label_rules:
+            out.append((f"Label rules: {len(fs.yolo_per_label_rules)}", ("yolo_per_label_rules",)))
+
+        if fs.similarity_anchor_id is not None:
+            out.append(("Similarity mode", ("similarity_anchor_id",)))
+
+        return out
+
+    @Slot()
+    def _refresh_theme(self) -> None:
+        c = theme()
+        self.setStyleSheet(
+            f"""
+            ActiveFilterChips {{
+                background: transparent;
+            }}
+            ActiveFilterChips #ActiveFilterChip {{
+                background: {c.badge_analyzed};
+                color: {c.badge_analyzed_text};
+                border: none;
+                border-radius: {Radii.FULL}px;
+                padding: {Spacing.XXS}px {Spacing.SM}px;
+                font-size: {TypeScale.XS}px;
+            }}
+            ActiveFilterChips #ActiveFilterChip:hover {{
+                background: {c.accent_blue};
+                color: {c.text_inverted};
+            }}
+            """
+        )

--- a/ui/widgets/chip_group.py
+++ b/ui/widgets/chip_group.py
@@ -1,0 +1,161 @@
+"""Non-exclusive multi-select chip bar.
+
+Used by FilterSidebar to expose enum-valued multi-select filters (shot type,
+aspect ratio, gaze direction, etc.). Chips are pill-shaped pushbuttons; the
+selected set is exposed via selected_values() and emitted on
+selection_changed.
+"""
+
+from typing import Optional
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QButtonGroup,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ui.theme import Radii, Spacing, TypeScale, theme
+
+
+class ChipGroup(QWidget):
+    """Multi-select chip bar backed by a non-exclusive QButtonGroup.
+
+    Signals:
+        selection_changed(set): emitted with the new selection only when
+            the selected values actually change.
+    """
+
+    selection_changed = Signal(set)
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._buttons: dict[str, QPushButton] = {}
+        self._selected: set[str] = set()
+        self._emitting = False
+
+        self._group = QButtonGroup(self)
+        self._group.setExclusive(False)
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(Spacing.XXS)
+
+        self._row = QHBoxLayout()
+        self._row.setContentsMargins(0, 0, 0, 0)
+        self._row.setSpacing(Spacing.XS)
+        self._row.addStretch()
+        outer.addLayout(self._row)
+
+        self._empty_label = QLabel("(no options)")
+        self._empty_label.setVisible(False)
+        outer.addWidget(self._empty_label)
+
+        self._refresh_theme()
+        if theme().changed:
+            theme().changed.connect(self._refresh_theme)
+
+    # ── Public API ───────────────────────────────────────────────────
+
+    def set_options(self, options: list[tuple[str, str]]) -> None:
+        """Replace chips. Clears existing selection (emits if non-empty)."""
+        # Remove existing buttons
+        for btn in list(self._buttons.values()):
+            self._group.removeButton(btn)
+            self._row.removeWidget(btn)
+            btn.setParent(None)
+        self._buttons.clear()
+
+        had_selection = bool(self._selected)
+        self._selected.clear()
+
+        # Insert new chips before the trailing stretch
+        for idx, (value, label) in enumerate(options):
+            btn = QPushButton(label)
+            btn.setCheckable(True)
+            btn.setProperty("chip_value", value)
+            btn.toggled.connect(self._on_chip_toggled)
+            self._group.addButton(btn)
+            self._buttons[value] = btn
+            self._row.insertWidget(idx, btn)
+
+        self._empty_label.setVisible(not options)
+        self._refresh_theme()
+
+        if had_selection and not self._emitting:
+            self.selection_changed.emit(set())
+
+    def set_selected(self, values: set[str]) -> None:
+        """Programmatically check chips. Only emits if the set changes."""
+        new = {v for v in values if v in self._buttons}
+        if new == self._selected:
+            return
+        self._emitting = True
+        try:
+            for value, btn in self._buttons.items():
+                btn.setChecked(value in new)
+        finally:
+            self._emitting = False
+        self._selected = new
+        self.selection_changed.emit(set(self._selected))
+
+    def selected_values(self) -> set[str]:
+        return set(self._selected)
+
+    def clear_selection(self) -> None:
+        if not self._selected:
+            return
+        self.set_selected(set())
+
+    # ── Slots ────────────────────────────────────────────────────────
+
+    @Slot(bool)
+    def _on_chip_toggled(self, checked: bool) -> None:
+        if self._emitting:
+            return
+        btn = self.sender()
+        if btn is None:
+            return
+        value = btn.property("chip_value")
+        if not isinstance(value, str):
+            return
+        if checked:
+            self._selected.add(value)
+        else:
+            self._selected.discard(value)
+        self.selection_changed.emit(set(self._selected))
+
+    # ── Theming ──────────────────────────────────────────────────────
+
+    @Slot()
+    def _refresh_theme(self) -> None:
+        c = theme()
+        self.setStyleSheet(
+            f"""
+            ChipGroup QPushButton {{
+                background-color: {c.background_tertiary};
+                color: {c.text_primary};
+                border: 1px solid {c.border_secondary};
+                border-radius: {Radii.FULL}px;
+                padding: {Spacing.XXS}px {Spacing.SM}px;
+                font-size: {TypeScale.XS}px;
+                min-height: 0;
+            }}
+            ChipGroup QPushButton:hover {{
+                border: 1px solid {c.accent_blue};
+            }}
+            ChipGroup QPushButton:checked {{
+                background-color: {c.badge_analyzed};
+                color: {c.badge_analyzed_text};
+                border: 1px solid {c.badge_analyzed};
+            }}
+            ChipGroup QLabel {{
+                color: {c.text_muted};
+                font-size: {TypeScale.SM}px;
+                font-style: italic;
+            }}
+            """
+        )

--- a/ui/widgets/collapsible_section.py
+++ b/ui/widgets/collapsible_section.py
@@ -1,0 +1,156 @@
+"""Collapsible section widget with a header toggle and content container.
+
+Used by FilterSidebar to group filters into expandable categories. The header
+is a QToolButton with a rotating chevron; the content is a QFrame whose
+visibility mirrors the expanded state.
+"""
+
+from typing import Callable, Optional
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ui.theme import Radii, Spacing, TypeScale, theme
+
+
+class CollapsibleSection(QWidget):
+    """Titled section with a toggle that shows/hides its content widget.
+
+    Signals:
+        expanded_changed(bool): emitted only when state actually changes.
+    """
+
+    expanded_changed = Signal(bool)
+
+    def __init__(self, title: str, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._title = title
+        self._expanded = True
+        self._clear_callback: Optional[Callable[[], None]] = None
+        self._setup_ui()
+        self._refresh_theme()
+
+        if theme().changed:
+            theme().changed.connect(self._refresh_theme)
+
+    def _setup_ui(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(Spacing.XXS)
+
+        # Header row
+        header = QWidget()
+        header_layout = QHBoxLayout(header)
+        header_layout.setContentsMargins(0, 0, 0, 0)
+        header_layout.setSpacing(Spacing.XS)
+
+        self._toggle_btn = QToolButton()
+        self._toggle_btn.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self._toggle_btn.setArrowType(Qt.DownArrow)
+        self._toggle_btn.setText(self._title)
+        self._toggle_btn.setCheckable(True)
+        self._toggle_btn.setChecked(True)
+        self._toggle_btn.setAutoRaise(True)
+        self._toggle_btn.clicked.connect(self._on_header_clicked)
+        header_layout.addWidget(self._toggle_btn, 1)
+
+        self._clear_btn = QPushButton("×")
+        self._clear_btn.setFixedSize(18, 18)
+        self._clear_btn.setVisible(False)
+        self._clear_btn.setToolTip("Clear this section")
+        self._clear_btn.clicked.connect(self._on_clear_clicked)
+        header_layout.addWidget(self._clear_btn)
+
+        outer.addWidget(header)
+
+        # Content frame
+        self._content_frame = QFrame()
+        content_layout = QVBoxLayout(self._content_frame)
+        content_layout.setContentsMargins(Spacing.MD, Spacing.XS, 0, Spacing.SM)
+        content_layout.setSpacing(Spacing.SM)
+        outer.addWidget(self._content_frame)
+
+    # ── Public API ───────────────────────────────────────────────────
+
+    @property
+    def expanded(self) -> bool:
+        return self._expanded
+
+    def set_expanded(self, expanded: bool) -> None:
+        if expanded == self._expanded:
+            return
+        self._expanded = expanded
+        self._toggle_btn.setChecked(expanded)
+        self._toggle_btn.setArrowType(Qt.DownArrow if expanded else Qt.RightArrow)
+        self._content_frame.setVisible(expanded)
+        self.expanded_changed.emit(expanded)
+
+    def setContentWidget(self, widget: QWidget) -> None:
+        layout = self._content_frame.layout()
+        # Remove any previous widgets
+        while layout.count():
+            item = layout.takeAt(0)
+            w = item.widget()
+            if w is not None:
+                w.setParent(None)
+        layout.addWidget(widget)
+
+    def show_clear_indicator(
+        self, visible: bool, on_click: Optional[Callable[[], None]] = None
+    ) -> None:
+        self._clear_callback = on_click
+        self._clear_btn.setVisible(visible)
+
+    # ── Slots ────────────────────────────────────────────────────────
+
+    @Slot(bool)
+    def _on_header_clicked(self, checked: bool) -> None:
+        self.set_expanded(checked)
+
+    @Slot()
+    def _on_clear_clicked(self) -> None:
+        if self._clear_callback is not None:
+            self._clear_callback()
+
+    # ── Theming ──────────────────────────────────────────────────────
+
+    @Slot()
+    def _refresh_theme(self) -> None:
+        c = theme()
+        self.setStyleSheet(
+            f"""
+            CollapsibleSection QToolButton {{
+                color: {c.text_primary};
+                background: transparent;
+                border: none;
+                font-size: {TypeScale.MD}px;
+                font-weight: 600;
+                padding: {Spacing.XS}px 0;
+                text-align: left;
+            }}
+            CollapsibleSection QToolButton:hover {{
+                color: {c.accent_blue};
+            }}
+            CollapsibleSection QPushButton {{
+                background: {c.background_tertiary};
+                color: {c.text_muted};
+                border: none;
+                border-radius: {Radii.SM}px;
+                font-size: {TypeScale.XS}px;
+                font-weight: 700;
+                padding: 0;
+            }}
+            CollapsibleSection QPushButton:hover {{
+                background: {c.accent_blue};
+                color: {c.text_inverted};
+            }}
+            """
+        )

--- a/ui/widgets/count_operator.py
+++ b/ui/widgets/count_operator.py
@@ -1,0 +1,150 @@
+"""Compound widget for discrete count filters: operator picker + int input.
+
+Used for filters like "person count > 1" or "object count = 3". Combines a
+QComboBox of operators (>, =, <) with a QSpinBox for the threshold and a
+Clear button that resets both.
+"""
+
+from typing import Optional
+
+from PySide6.QtCore import Signal, Slot
+from PySide6.QtWidgets import (
+    QComboBox,
+    QHBoxLayout,
+    QPushButton,
+    QSpinBox,
+    QWidget,
+)
+
+from ui.theme import Spacing, TypeScale, UISizes, theme
+
+
+OPERATORS = (">", "=", "<")
+
+
+class CountOperator(QWidget):
+    """Operator + integer compound. value() returns ``(op, n)`` or ``None``.
+
+    Signals:
+        value_changed(object, object): ``(op, n)`` or ``(None, None)``.
+    """
+
+    value_changed = Signal(object, object)
+
+    def __init__(
+        self,
+        min_value: int = 0,
+        max_value: int = 999,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent)
+        self._active = False
+        self._emitting_internal = False
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.XS)
+
+        self._op_combo = QComboBox()
+        self._op_combo.addItems(OPERATORS)
+        self._op_combo.setMinimumHeight(UISizes.COMBO_BOX_MIN_HEIGHT)
+        self._op_combo.setFixedWidth(56)
+        self._op_combo.setCurrentIndex(0)
+        self._op_combo.currentTextChanged.connect(self._on_user_edit)
+        layout.addWidget(self._op_combo)
+
+        self._spin = QSpinBox()
+        self._spin.setRange(min_value, max_value)
+        self._spin.setMinimumHeight(UISizes.COMBO_BOX_MIN_HEIGHT)
+        self._spin.valueChanged.connect(self._on_user_edit)
+        layout.addWidget(self._spin)
+
+        self._clear_btn = QPushButton("×")
+        self._clear_btn.setFixedWidth(24)
+        self._clear_btn.setToolTip("Clear")
+        self._clear_btn.clicked.connect(self.clear)
+        layout.addWidget(self._clear_btn)
+
+        self._refresh_theme()
+        if theme().changed:
+            theme().changed.connect(self._refresh_theme)
+
+    # ── Public API ───────────────────────────────────────────────────
+
+    def value(self) -> Optional[tuple[str, int]]:
+        if not self._active:
+            return None
+        return (self._op_combo.currentText(), self._spin.value())
+
+    def set_value(self, op: Optional[str], n: Optional[int]) -> None:
+        if op is None or n is None:
+            self.clear()
+            return
+        if op not in OPERATORS:
+            op = ">"
+        self._emitting_internal = True
+        try:
+            self._op_combo.setCurrentText(op)
+            self._spin.setValue(n)
+        finally:
+            self._emitting_internal = False
+        was_active = self._active
+        self._active = True
+        if not was_active or self.value() != (op, n):
+            self.value_changed.emit(op, n)
+
+    @Slot()
+    def clear(self) -> None:
+        was_active = self._active
+        self._active = False
+        self._emitting_internal = True
+        try:
+            self._op_combo.setCurrentIndex(0)
+            self._spin.setValue(self._spin.minimum())
+        finally:
+            self._emitting_internal = False
+        if was_active:
+            self.value_changed.emit(None, None)
+
+    # ── Slots ────────────────────────────────────────────────────────
+
+    @Slot()
+    def _on_user_edit(self, *_args) -> None:
+        if self._emitting_internal:
+            return
+        self._active = True
+        op, n = self._op_combo.currentText(), self._spin.value()
+        self.value_changed.emit(op, n)
+
+    # ── Theming ──────────────────────────────────────────────────────
+
+    @Slot()
+    def _refresh_theme(self) -> None:
+        c = theme()
+        self.setStyleSheet(
+            f"""
+            QComboBox, QSpinBox {{
+                background-color: {c.background_tertiary};
+                color: {c.text_primary};
+                border: 1px solid {c.border_secondary};
+                border-radius: 4px;
+                padding: 0 {Spacing.XS}px;
+                font-size: {TypeScale.SM}px;
+            }}
+            QComboBox:focus, QSpinBox:focus {{
+                border: 1px solid {c.border_focus};
+            }}
+            QPushButton {{
+                background: {c.background_tertiary};
+                color: {c.text_muted};
+                border: 1px solid {c.border_secondary};
+                border-radius: 4px;
+                font-size: {TypeScale.SM}px;
+            }}
+            QPushButton:hover {{
+                background: {c.accent_blue};
+                color: {c.text_inverted};
+                border: 1px solid {c.accent_blue};
+            }}
+            """
+        )

--- a/ui/widgets/filter_sidebar.py
+++ b/ui/widgets/filter_sidebar.py
@@ -15,10 +15,13 @@ from typing import Optional
 
 from PySide6.QtCore import Qt, Signal, Slot
 from PySide6.QtWidgets import (
+    QButtonGroup,
     QFrame,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QPushButton,
+    QRadioButton,
     QScrollArea,
     QVBoxLayout,
     QWidget,
@@ -27,10 +30,12 @@ from PySide6.QtWidgets import (
 from core.analysis.color import COLOR_PALETTES, get_palette_display_name
 from core.analysis.gaze import GAZE_CATEGORY_DISPLAY
 from core.analysis.shots import SHOT_TYPES, get_display_name
+from core.analysis_operations import ANALYSIS_OPERATIONS
 from core.filter_state import FilterState
 from ui.theme import Spacing, TypeScale, UISizes, theme
 from ui.widgets.chip_group import ChipGroup
 from ui.widgets.collapsible_section import CollapsibleSection
+from ui.widgets.count_operator import CountOperator
 
 
 SECTION_SHOT = "shot"
@@ -83,9 +88,13 @@ class FilterSidebar(QWidget):
         self._filter_state = filter_state
         self._sections: dict[str, CollapsibleSection] = {}
         self._chip_groups: dict[str, ChipGroup] = {}
+        # Unit 5 controls
+        self._person_count_control: Optional[CountOperator] = None
+        self._tribool_groups: dict[str, tuple[QRadioButton, QRadioButton, QRadioButton]] = {}
         self._updating_from_state = False
         self._setup_ui(section_expanded_state or {})
         self._populate_existing_filters()
+        self._populate_unit5_filters()
         self._sync_from_state()
         self._filter_state.changed.connect(self._sync_from_state)
         self._refresh_theme()
@@ -210,6 +219,109 @@ class FilterSidebar(QWidget):
         group.selection_changed.connect(on_change)
         return group
 
+    def _populate_unit5_filters(self) -> None:
+        """Wire controls for person count, tribool booleans, has-analysis chips."""
+
+        # People section — extend with person count operator
+        existing_people = self._sections[SECTION_PEOPLE].findChild(QWidget)
+        self._person_count_control = CountOperator()
+        self._person_count_control.value_changed.connect(self._on_person_count_changed)
+
+        people_container = QWidget()
+        pc_layout = QVBoxLayout(people_container)
+        pc_layout.setContentsMargins(0, 0, 0, 0)
+        pc_layout.setSpacing(Spacing.SM)
+        if existing_people is not None:
+            # Re-parent existing gaze control
+            pc_layout.addWidget(self._chip_groups["gaze_filter"].parent())
+        pc_layout.addWidget(
+            self._labelled("Person count", self._person_count_control)
+        )
+        self.set_section_content(SECTION_PEOPLE, people_container)
+
+        # Text section — has_transcript + has_on_screen_text tribools
+        text_container = QWidget()
+        text_layout = QVBoxLayout(text_container)
+        text_layout.setContentsMargins(0, 0, 0, 0)
+        text_layout.setSpacing(Spacing.SM)
+        text_layout.addWidget(
+            self._tribool_row("Has transcript", "has_transcript")
+        )
+        text_layout.addWidget(
+            self._tribool_row("Has on-screen text", "has_on_screen_text")
+        )
+        self.set_section_content(SECTION_TEXT, text_container)
+
+        # Audio section — has_audio tribool only (volume slider deferred)
+        audio_container = QWidget()
+        audio_layout = QVBoxLayout(audio_container)
+        audio_layout.setContentsMargins(0, 0, 0, 0)
+        audio_layout.setSpacing(Spacing.SM)
+        audio_layout.addWidget(self._tribool_row("Has audio", "has_audio"))
+        self.set_section_content(SECTION_AUDIO, audio_container)
+
+        # Meta section — has_analysis_ops chips + enabled tribool
+        meta_container = QWidget()
+        meta_layout = QVBoxLayout(meta_container)
+        meta_layout.setContentsMargins(0, 0, 0, 0)
+        meta_layout.setSpacing(Spacing.SM)
+
+        op_options = [(op.key, op.label) for op in ANALYSIS_OPERATIONS]
+        has_ops_chips = self._build_chip_group(
+            op_options,
+            lambda values: self._set_state("has_analysis_ops", values),
+        )
+        self._chip_groups["has_analysis_ops"] = has_ops_chips
+        meta_layout.addWidget(self._labelled("Has analysis", has_ops_chips))
+        meta_layout.addWidget(self._tribool_row("Enabled", "enabled_filter"))
+        self.set_section_content(SECTION_META, meta_container)
+
+    def _tribool_row(self, label_text: str, field_name: str) -> QWidget:
+        """Yes / No / Any radio triplet bound to a tribool FilterState field."""
+        container = QWidget()
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.SM)
+
+        label = QLabel(label_text)
+        label.setMinimumWidth(140)
+        layout.addWidget(label)
+
+        group = QButtonGroup(container)
+        yes_btn = QRadioButton("Yes")
+        no_btn = QRadioButton("No")
+        any_btn = QRadioButton("Any")
+        any_btn.setChecked(True)
+        for btn in (yes_btn, no_btn, any_btn):
+            group.addButton(btn)
+            layout.addWidget(btn)
+        layout.addStretch()
+
+        def on_toggled(_checked):
+            if self._updating_from_state:
+                return
+            if yes_btn.isChecked():
+                setattr(self._filter_state, field_name, True)
+            elif no_btn.isChecked():
+                setattr(self._filter_state, field_name, False)
+            else:
+                setattr(self._filter_state, field_name, None)
+
+        yes_btn.toggled.connect(on_toggled)
+        no_btn.toggled.connect(on_toggled)
+        any_btn.toggled.connect(on_toggled)
+
+        self._tribool_groups[field_name] = (yes_btn, no_btn, any_btn)
+        return container
+
+    def _on_person_count_changed(self, op, n):
+        if self._updating_from_state:
+            return
+        if op is None or n is None:
+            self._filter_state.person_count = None
+        else:
+            self._filter_state.person_count = (op, n)
+
     def _labelled(self, label_text: str, widget: QWidget) -> QWidget:
         container = QWidget()
         layout = QVBoxLayout(container)
@@ -229,13 +341,31 @@ class FilterSidebar(QWidget):
 
     @Slot()
     def _sync_from_state(self) -> None:
-        """State → UI. Push current FilterState values back onto the chip groups."""
+        """State → UI. Push current FilterState values back onto controls."""
         self._updating_from_state = True
         try:
             for field_name, group in self._chip_groups.items():
                 current = getattr(self._filter_state, field_name)
                 if isinstance(current, set):
                     group.set_selected(current)
+
+            # Person count operator
+            if self._person_count_control is not None:
+                pc = self._filter_state.person_count
+                if pc is None:
+                    self._person_count_control.clear()
+                else:
+                    self._person_count_control.set_value(pc[0], pc[1])
+
+            # Triboolean radio groups
+            for field_name, (yes_btn, no_btn, any_btn) in self._tribool_groups.items():
+                current = getattr(self._filter_state, field_name)
+                if current is True:
+                    yes_btn.setChecked(True)
+                elif current is False:
+                    no_btn.setChecked(True)
+                else:
+                    any_btn.setChecked(True)
         finally:
             self._updating_from_state = False
 

--- a/ui/widgets/filter_sidebar.py
+++ b/ui/widgets/filter_sidebar.py
@@ -27,6 +27,7 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from core.analysis.classification import load_imagenet_class_list
 from core.analysis.color import COLOR_PALETTES, get_palette_display_name
 from core.analysis.gaze import GAZE_CATEGORY_DISPLAY
 from core.analysis.shots import SHOT_TYPES, get_display_name
@@ -36,6 +37,7 @@ from ui.theme import Spacing, TypeScale, UISizes, theme
 from ui.widgets.chip_group import ChipGroup
 from ui.widgets.collapsible_section import CollapsibleSection
 from ui.widgets.count_operator import CountOperator
+from ui.widgets.typeahead_input import TypeaheadInput
 
 
 SECTION_SHOT = "shot"
@@ -92,9 +94,18 @@ class FilterSidebar(QWidget):
         self._person_count_control: Optional[CountOperator] = None
         self._tribool_groups: dict[str, tuple[QRadioButton, QRadioButton, QRadioButton]] = {}
         self._updating_from_state = False
+        # Unit 6 state — dynamic YOLO vocabulary
+        self._yolo_label_vocabulary: set[str] = set()
+        self._imagenet_typeahead: Optional[TypeaheadInput] = None
+        self._imagenet_chip_list: Optional[QWidget] = None
+        self._imagenet_chip_buttons: dict[str, QPushButton] = {}
+        self._imagenet_mode_any: Optional[QRadioButton] = None
+        self._imagenet_mode_all: Optional[QRadioButton] = None
+        self._yolo_total_control: Optional[CountOperator] = None
         self._setup_ui(section_expanded_state or {})
         self._populate_existing_filters()
         self._populate_unit5_filters()
+        self._populate_unit6_filters()
         self._sync_from_state()
         self._filter_state.changed.connect(self._sync_from_state)
         self._refresh_theme()
@@ -322,6 +333,161 @@ class FilterSidebar(QWidget):
         else:
             self._filter_state.person_count = (op, n)
 
+    # ── Unit 6 (ImageNet + YOLO) ─────────────────────────────────────
+
+    def _populate_unit6_filters(self) -> None:
+        """ImageNet typeahead (1000 classes) + YOLO filters."""
+        self._populate_imagenet_section()
+        self._populate_yolo_section()
+
+    def _populate_imagenet_section(self) -> None:
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.SM)
+
+        # Mode switch (Any / All)
+        mode_row = QWidget()
+        mode_layout = QHBoxLayout(mode_row)
+        mode_layout.setContentsMargins(0, 0, 0, 0)
+        mode_layout.setSpacing(Spacing.SM)
+        mode_layout.addWidget(QLabel("Match:"))
+        self._imagenet_mode_any = QRadioButton("Any selected")
+        self._imagenet_mode_all = QRadioButton("All selected")
+        self._imagenet_mode_any.setChecked(True)
+        mode_group = QButtonGroup(container)
+        mode_group.addButton(self._imagenet_mode_any)
+        mode_group.addButton(self._imagenet_mode_all)
+        mode_layout.addWidget(self._imagenet_mode_any)
+        mode_layout.addWidget(self._imagenet_mode_all)
+        mode_layout.addStretch()
+
+        def on_mode_toggled(_checked):
+            if self._updating_from_state:
+                return
+            self._filter_state.imagenet_mode = (
+                "all" if self._imagenet_mode_all.isChecked() else "any"
+            )
+
+        self._imagenet_mode_any.toggled.connect(on_mode_toggled)
+        self._imagenet_mode_all.toggled.connect(on_mode_toggled)
+        layout.addWidget(mode_row)
+
+        # Typeahead input
+        self._imagenet_typeahead = TypeaheadInput()
+        self._imagenet_typeahead.setPlaceholderText("Search ImageNet class…")
+        vocab = load_imagenet_class_list()
+        if not vocab:
+            self._imagenet_typeahead._line.setPlaceholderText(
+                "Run Classify to build vocabulary"
+            )
+            self._imagenet_typeahead.setEnabled(False)
+        else:
+            self._imagenet_typeahead.set_vocabulary(vocab)
+            self._imagenet_typeahead.value_selected.connect(
+                self._on_imagenet_value_selected
+            )
+        layout.addWidget(self._imagenet_typeahead)
+
+        # Selected-chips display
+        self._imagenet_chip_list = QWidget()
+        self._imagenet_chip_list_layout = QHBoxLayout(self._imagenet_chip_list)
+        self._imagenet_chip_list_layout.setContentsMargins(0, 0, 0, 0)
+        self._imagenet_chip_list_layout.setSpacing(Spacing.XS)
+        self._imagenet_chip_list_layout.addStretch()
+        layout.addWidget(self._imagenet_chip_list)
+
+        self.set_section_content(SECTION_IMAGENET, container)
+
+    def _on_imagenet_value_selected(self, value: str) -> None:
+        if self._updating_from_state:
+            return
+        current = set(self._filter_state.imagenet_labels)
+        if value in current:
+            return
+        current.add(value)
+        self._filter_state.imagenet_labels = current
+
+    def _rebuild_imagenet_chip_list(self) -> None:
+        """Sync the visual chip list with the current imagenet_labels set."""
+        if self._imagenet_chip_list is None:
+            return
+        layout = self._imagenet_chip_list_layout
+        # Remove existing chip buttons
+        for value, btn in list(self._imagenet_chip_buttons.items()):
+            layout.removeWidget(btn)
+            btn.setParent(None)
+        self._imagenet_chip_buttons.clear()
+
+        # Insert before trailing stretch
+        for value in sorted(self._filter_state.imagenet_labels):
+            btn = QPushButton(f"{value}  ×")
+            btn.setProperty("chip_value", value)
+
+            def on_click(_checked=False, v=value):
+                if self._updating_from_state:
+                    return
+                current = set(self._filter_state.imagenet_labels)
+                current.discard(v)
+                self._filter_state.imagenet_labels = current
+
+            btn.clicked.connect(on_click)
+            btn.setObjectName("ImageNetChipBadge")
+            self._imagenet_chip_buttons[value] = btn
+            layout.insertWidget(layout.count() - 1, btn)
+
+    def _populate_yolo_section(self) -> None:
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.SM)
+
+        # YOLO label chips (dynamic vocabulary)
+        yolo_chips = ChipGroup()
+        yolo_chips.selection_changed.connect(
+            lambda values: self._set_state("yolo_labels", values)
+        )
+        self._chip_groups["yolo_labels"] = yolo_chips
+        layout.addWidget(self._labelled("Detected labels", yolo_chips))
+
+        # Total count operator
+        self._yolo_total_control = CountOperator()
+        self._yolo_total_control.value_changed.connect(
+            self._on_yolo_total_count_changed
+        )
+        layout.addWidget(
+            self._labelled("Total object count", self._yolo_total_control)
+        )
+
+        # Note about per-label count rules (full UI deferred)
+        note = QLabel(
+            "Per-label count rules available via apply_filters "
+            "({'yolo_per_label_rules': [('person','=',1)]})"
+        )
+        note.setWordWrap(True)
+        note.setObjectName("FilterSidebarPlaceholder")
+        layout.addWidget(note)
+
+        self.set_section_content(SECTION_YOLO, container)
+
+    def _on_yolo_total_count_changed(self, op, n):
+        if self._updating_from_state:
+            return
+        if op is None or n is None:
+            self._filter_state.yolo_total_count = None
+        else:
+            self._filter_state.yolo_total_count = (op, n)
+
+    def refresh_yolo_vocabulary(self, labels: set[str]) -> None:
+        """Update the YOLO label chip vocabulary from the union of detected labels."""
+        if labels == self._yolo_label_vocabulary:
+            return
+        self._yolo_label_vocabulary = set(labels)
+        options = [(label, label) for label in sorted(labels)]
+        self._chip_groups["yolo_labels"].set_options(options)
+        # Restore selection after options rebuild
+        self._chip_groups["yolo_labels"].set_selected(self._filter_state.yolo_labels)
+
     def _labelled(self, label_text: str, widget: QWidget) -> QWidget:
         container = QWidget()
         layout = QVBoxLayout(container)
@@ -366,6 +532,23 @@ class FilterSidebar(QWidget):
                     no_btn.setChecked(True)
                 else:
                     any_btn.setChecked(True)
+
+            # Unit 6 — ImageNet
+            if self._imagenet_mode_any is not None:
+                mode = self._filter_state.imagenet_mode
+                if mode == "all":
+                    self._imagenet_mode_all.setChecked(True)
+                else:
+                    self._imagenet_mode_any.setChecked(True)
+            self._rebuild_imagenet_chip_list()
+
+            # Unit 6 — YOLO total count
+            if self._yolo_total_control is not None:
+                yc = self._filter_state.yolo_total_count
+                if yc is None:
+                    self._yolo_total_control.clear()
+                else:
+                    self._yolo_total_control.set_value(yc[0], yc[1])
         finally:
             self._updating_from_state = False
 

--- a/ui/widgets/filter_sidebar.py
+++ b/ui/widgets/filter_sidebar.py
@@ -1,0 +1,203 @@
+"""Toggleable filter sidebar for the Cut and Analyze tabs.
+
+Houses nine collapsible sections that expose every filterable analysis
+dimension on a clip. In Unit 3 of the clip-filter sidebar plan the sections
+are scaffolded with empty bodies; Units 4–6 populate them with controls
+wired to the shared ``FilterState``.
+
+``FilterSidebar`` is a plain ``QWidget`` (not ``QDockWidget``) so it can be
+embedded inside each tab's content area via ``QSplitter``. Each tab owns its
+own sidebar instance; both point at the same ``FilterState`` so filter
+values are shared across tabs.
+"""
+
+from typing import Optional
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from core.filter_state import FilterState
+from ui.theme import Spacing, TypeScale, UISizes, theme
+from ui.widgets.collapsible_section import CollapsibleSection
+
+
+SECTION_SHOT = "shot"
+SECTION_VISUAL = "visual"
+SECTION_PEOPLE = "people"
+SECTION_IMAGENET = "imagenet"
+SECTION_YOLO = "yolo"
+SECTION_TEXT = "text"
+SECTION_AUDIO = "audio"
+SECTION_CUSTOM_QUERY = "custom_query"
+SECTION_META = "meta"
+
+
+# Ordered list of (key, display title). Drives both scaffold order and
+# persistence of expand/collapse state.
+SECTIONS: tuple[tuple[str, str], ...] = (
+    (SECTION_SHOT, "Shot"),
+    (SECTION_VISUAL, "Visual"),
+    (SECTION_PEOPLE, "People"),
+    (SECTION_IMAGENET, "ImageNet"),
+    (SECTION_YOLO, "Objects (YOLO)"),
+    (SECTION_TEXT, "Text & Transcript"),
+    (SECTION_AUDIO, "Audio"),
+    (SECTION_CUSTOM_QUERY, "Custom Queries"),
+    (SECTION_META, "Meta"),
+)
+
+
+class FilterSidebar(QWidget):
+    """Vertical stack of collapsible filter sections bound to a ``FilterState``.
+
+    Signals:
+        visibility_requested(bool): emitted when user toggles the header
+            hide button; the hosting tab is responsible for hiding/showing
+            the widget and persisting the state.
+        section_expanded_changed(str, bool): emitted when any section's
+            collapse state changes (``section_key``, ``expanded``).
+    """
+
+    visibility_requested = Signal(bool)
+    section_expanded_changed = Signal(str, bool)
+
+    def __init__(
+        self,
+        filter_state: FilterState,
+        section_expanded_state: Optional[dict[str, bool]] = None,
+        parent: Optional[QWidget] = None,
+    ):
+        super().__init__(parent)
+        self._filter_state = filter_state
+        self._sections: dict[str, CollapsibleSection] = {}
+        self._setup_ui(section_expanded_state or {})
+        self._refresh_theme()
+
+        if theme().changed:
+            theme().changed.connect(self._refresh_theme)
+
+    def _setup_ui(self, expanded_state: dict[str, bool]) -> None:
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        # Header row: title + hide button
+        header = QWidget()
+        header.setObjectName("FilterSidebarHeader")
+        header_layout = QHBoxLayout(header)
+        header_layout.setContentsMargins(Spacing.MD, Spacing.SM, Spacing.SM, Spacing.SM)
+        header_layout.setSpacing(Spacing.SM)
+
+        title = QLabel("Filters")
+        title.setObjectName("FilterSidebarTitle")
+        header_layout.addWidget(title)
+        header_layout.addStretch()
+
+        hide_btn = QPushButton("Hide")
+        hide_btn.setObjectName("FilterSidebarHideBtn")
+        hide_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT - 8)
+        hide_btn.clicked.connect(lambda: self.visibility_requested.emit(False))
+        header_layout.addWidget(hide_btn)
+
+        root.addWidget(header)
+
+        # Scrollable section stack
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+
+        container = QWidget()
+        section_layout = QVBoxLayout(container)
+        section_layout.setContentsMargins(Spacing.MD, Spacing.SM, Spacing.MD, Spacing.LG)
+        section_layout.setSpacing(Spacing.MD)
+
+        for key, title_text in SECTIONS:
+            section = CollapsibleSection(title_text)
+            placeholder = QLabel("(no filters yet)")
+            placeholder.setObjectName("FilterSidebarPlaceholder")
+            section.setContentWidget(placeholder)
+
+            expanded = expanded_state.get(key, True)
+            section.set_expanded(expanded)
+            section.expanded_changed.connect(
+                lambda exp, k=key: self.section_expanded_changed.emit(k, exp)
+            )
+            self._sections[key] = section
+            section_layout.addWidget(section)
+
+        section_layout.addStretch()
+        scroll.setWidget(container)
+        root.addWidget(scroll, 1)
+
+        self.setMinimumWidth(280)
+
+    # ── Public API ───────────────────────────────────────────────────
+
+    @property
+    def filter_state(self) -> FilterState:
+        return self._filter_state
+
+    def section(self, key: str) -> Optional[CollapsibleSection]:
+        """Return the collapsible section for a given key, or None."""
+        return self._sections.get(key)
+
+    def section_expanded_state(self) -> dict[str, bool]:
+        """Return the current expanded state for every section — for persistence."""
+        return {key: section.expanded for key, section in self._sections.items()}
+
+    def set_section_content(self, key: str, widget: QWidget) -> None:
+        """Install a content widget inside a section."""
+        section = self._sections.get(key)
+        if section is None:
+            raise KeyError(f"Unknown filter section: {key!r}")
+        section.setContentWidget(widget)
+
+    # ── Theming ──────────────────────────────────────────────────────
+
+    @Slot()
+    def _refresh_theme(self) -> None:
+        c = theme()
+        self.setStyleSheet(
+            f"""
+            FilterSidebar {{
+                background: {c.background_secondary};
+                border-left: 1px solid {c.border_secondary};
+            }}
+            #FilterSidebarHeader {{
+                background: {c.background_secondary};
+                border-bottom: 1px solid {c.border_secondary};
+            }}
+            #FilterSidebarTitle {{
+                color: {c.text_primary};
+                font-size: {TypeScale.LG}px;
+                font-weight: 600;
+            }}
+            #FilterSidebarHideBtn {{
+                background: {c.background_tertiary};
+                color: {c.text_secondary};
+                border: 1px solid {c.border_secondary};
+                border-radius: 4px;
+                padding: 2px {Spacing.SM}px;
+                font-size: {TypeScale.SM}px;
+            }}
+            #FilterSidebarHideBtn:hover {{
+                background: {c.accent_blue};
+                color: {c.text_inverted};
+                border: 1px solid {c.accent_blue};
+            }}
+            #FilterSidebarPlaceholder {{
+                color: {c.text_muted};
+                font-size: {TypeScale.SM}px;
+                font-style: italic;
+                padding: {Spacing.SM}px 0;
+            }}
+            """
+        )

--- a/ui/widgets/filter_sidebar.py
+++ b/ui/widgets/filter_sidebar.py
@@ -24,8 +24,12 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from core.analysis.color import COLOR_PALETTES, get_palette_display_name
+from core.analysis.gaze import GAZE_CATEGORY_DISPLAY
+from core.analysis.shots import SHOT_TYPES, get_display_name
 from core.filter_state import FilterState
 from ui.theme import Spacing, TypeScale, UISizes, theme
+from ui.widgets.chip_group import ChipGroup
 from ui.widgets.collapsible_section import CollapsibleSection
 
 
@@ -78,7 +82,12 @@ class FilterSidebar(QWidget):
         super().__init__(parent)
         self._filter_state = filter_state
         self._sections: dict[str, CollapsibleSection] = {}
+        self._chip_groups: dict[str, ChipGroup] = {}
+        self._updating_from_state = False
         self._setup_ui(section_expanded_state or {})
+        self._populate_existing_filters()
+        self._sync_from_state()
+        self._filter_state.changed.connect(self._sync_from_state)
         self._refresh_theme()
 
         if theme().changed:
@@ -138,6 +147,97 @@ class FilterSidebar(QWidget):
         root.addWidget(scroll, 1)
 
         self.setMinimumWidth(280)
+
+    # ── Filter population ────────────────────────────────────────────
+
+    def _populate_existing_filters(self) -> None:
+        """Install chip controls for the four multi-select enum filters.
+
+        Unit 4 coverage: shot type, color palette, aspect ratio (inside
+        Shot section), gaze direction. Duration / brightness / other
+        controls arrive in Units 5–6.
+        """
+        # Shot type chips (Visual section)
+        shot_chips = self._build_chip_group(
+            [(st, get_display_name(st)) for st in SHOT_TYPES],
+            lambda values: self._set_state("shot_type", values),
+        )
+        self._chip_groups["shot_type"] = shot_chips
+        shot_label = self._labelled("Shot type", shot_chips)
+        self.set_section_content(SECTION_VISUAL, shot_label)
+
+        # Color palette chips (Visual section is already occupied — put into
+        # the Visual section's layout via replaceWidget? Simpler: nest both
+        # chip groups inside a single container widget.)
+
+        color_chips = self._build_chip_group(
+            [(cp, get_palette_display_name(cp)) for cp in COLOR_PALETTES],
+            lambda values: self._set_state("color_palette", values),
+        )
+        self._chip_groups["color_palette"] = color_chips
+
+        # Rebuild Visual section content to hold both shot + palette chips
+        visual_container = QWidget()
+        v_layout = QVBoxLayout(visual_container)
+        v_layout.setContentsMargins(0, 0, 0, 0)
+        v_layout.setSpacing(Spacing.SM)
+        v_layout.addWidget(self._labelled("Shot type", shot_chips))
+        v_layout.addWidget(self._labelled("Color palette", color_chips))
+        self.set_section_content(SECTION_VISUAL, visual_container)
+
+        # Aspect ratio chips (Shot section)
+        aspect_chips = self._build_chip_group(
+            [("16:9", "16:9"), ("4:3", "4:3"), ("9:16", "9:16 (vertical)")],
+            lambda values: self._set_state("aspect_ratio", values),
+        )
+        self._chip_groups["aspect_ratio"] = aspect_chips
+        self.set_section_content(SECTION_SHOT, self._labelled("Aspect ratio", aspect_chips))
+
+        # Gaze direction chips (People section)
+        gaze_options = [
+            (key, display) for key, display in GAZE_CATEGORY_DISPLAY.items()
+        ]
+        gaze_chips = self._build_chip_group(
+            gaze_options,
+            lambda values: self._set_state("gaze_filter", values),
+        )
+        self._chip_groups["gaze_filter"] = gaze_chips
+        self.set_section_content(SECTION_PEOPLE, self._labelled("Gaze direction", gaze_chips))
+
+    def _build_chip_group(self, options, on_change) -> ChipGroup:
+        group = ChipGroup()
+        group.set_options(options)
+        group.selection_changed.connect(on_change)
+        return group
+
+    def _labelled(self, label_text: str, widget: QWidget) -> QWidget:
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.XXS)
+        label = QLabel(label_text)
+        label.setProperty("class", "FilterSidebarFieldLabel")
+        layout.addWidget(label)
+        layout.addWidget(widget)
+        return container
+
+    def _set_state(self, field_name: str, values: set) -> None:
+        """UI → state. Guarded against the round-trip from state → UI."""
+        if self._updating_from_state:
+            return
+        setattr(self._filter_state, field_name, values)
+
+    @Slot()
+    def _sync_from_state(self) -> None:
+        """State → UI. Push current FilterState values back onto the chip groups."""
+        self._updating_from_state = True
+        try:
+            for field_name, group in self._chip_groups.items():
+                current = getattr(self._filter_state, field_name)
+                if isinstance(current, set):
+                    group.set_selected(current)
+        finally:
+            self._updating_from_state = False
 
     # ── Public API ───────────────────────────────────────────────────
 

--- a/ui/widgets/typeahead_input.py
+++ b/ui/widgets/typeahead_input.py
@@ -1,0 +1,113 @@
+"""Typeahead input backed by QCompleter over a QStringListModel.
+
+Used for searchable vocabularies (e.g. ImageNet's 1000 classes) where a flat
+combo box would be unusable. Emits `value_selected` with the vocabulary's
+canonical form when the user commits a match via the completion popup or
+Enter. Does not emit on partial typing.
+"""
+
+from typing import Optional
+
+from PySide6.QtCore import QStringListModel, Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QCompleter,
+    QHBoxLayout,
+    QLineEdit,
+    QWidget,
+)
+
+from ui.theme import Spacing, TypeScale, UISizes, theme
+
+
+class TypeaheadInput(QWidget):
+    """QLineEdit + QCompleter over a user-provided vocabulary.
+
+    Signals:
+        value_selected(str): emitted when the user commits a vocabulary
+            entry (via popup click or Enter). Input is cleared after emit.
+    """
+
+    value_selected = Signal(str)
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self._vocab: list[str] = []
+        self._lookup: dict[str, str] = {}
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.XS)
+
+        self._line = QLineEdit()
+        self._line.setMinimumHeight(UISizes.LINE_EDIT_MIN_HEIGHT)
+
+        self._model = QStringListModel([], self)
+        self._completer = QCompleter(self._model, self)
+        self._completer.setCompletionMode(QCompleter.PopupCompletion)
+        self._completer.setCaseSensitivity(Qt.CaseInsensitive)
+        self._completer.setFilterMode(Qt.MatchContains)
+        self._line.setCompleter(self._completer)
+
+        self._completer.activated[str].connect(self._on_activated)
+        self._line.returnPressed.connect(self._on_return_pressed)
+
+        layout.addWidget(self._line)
+
+        self._refresh_theme()
+        if theme().changed:
+            theme().changed.connect(self._refresh_theme)
+
+    # ── Public API ───────────────────────────────────────────────────
+
+    def set_vocabulary(self, items: list[str]) -> None:
+        self._vocab = list(items)
+        self._lookup = {v.casefold(): v for v in self._vocab}
+        self._model.setStringList(self._vocab)
+
+    def clear_input(self) -> None:
+        self._line.clear()
+
+    def setPlaceholderText(self, text: str) -> None:  # noqa: N802 Qt style
+        self._line.setPlaceholderText(text)
+
+    # ── Slots ────────────────────────────────────────────────────────
+
+    @Slot(str)
+    def _on_activated(self, text: str) -> None:
+        canonical = self._lookup.get(text.casefold())
+        if canonical is None:
+            return
+        self._line.clear()
+        self.value_selected.emit(canonical)
+
+    @Slot()
+    def _on_return_pressed(self) -> None:
+        text = self._line.text().strip()
+        if not text:
+            return
+        canonical = self._lookup.get(text.casefold())
+        if canonical is None:
+            return
+        self._line.clear()
+        self.value_selected.emit(canonical)
+
+    # ── Theming ──────────────────────────────────────────────────────
+
+    @Slot()
+    def _refresh_theme(self) -> None:
+        c = theme()
+        self._line.setStyleSheet(
+            f"""
+            QLineEdit {{
+                background-color: {c.background_tertiary};
+                color: {c.text_primary};
+                border: 1px solid {c.border_secondary};
+                border-radius: 4px;
+                padding: 0 {Spacing.SM}px;
+                font-size: {TypeScale.SM}px;
+            }}
+            QLineEdit:focus {{
+                border: 1px solid {c.border_focus};
+            }}
+            """
+        )


### PR DESCRIPTION
## Summary

Replaces the partial filter top row + collapsing panel in the Cut and Analyze tabs with a toggleable **filter sidebar** that exposes every filterable analysis dimension the project produces. Expands 13 existing filters (most promoted from single-select to multi-select chips) and adds 15 new filter dimensions across 9 sections.

Primary use case: **shot hunting** — "close-ups OR extreme CU × exactly 1 person × at-camera gaze × no on-screen text × 2–5 seconds" is now a single fluid workflow.

## What lands

**Foundation**
- Extract `FilterState` (`core/filter_state.py`) as shared owner of filter values — Cut and Analyze both point at one instance, so filter values share across tabs by default. `apply_dict` / `to_dict` preserve the old `ClipBrowser.apply_filters` / `get_active_filters` contract.
- Four reusable UI primitives: `CollapsibleSection`, `ChipGroup`, `TypeaheadInput`, `CountOperator`.

**Filter dimensions exposed** (organized into 9 sections)
- Shot: duration range, aspect ratio (multi-select)
- Visual: shot type, color palette (both multi-select now), brightness range
- People: person count operator (`>`/`=`/`<`), gaze direction (multi-select)
- ImageNet (1000 classes): typeahead with Any/All mode + removable chip list
- Objects (YOLO): label multi-select with dynamic vocab, total count operator, per-label count rules (stackable)
- Text & transcript: has-transcript / has-on-screen-text tribools
- Audio: has-audio tribool
- Custom queries: unchanged
- Meta: has-analysis-of-type chips + enabled/disabled tribool

**Polish**
- Active filter chip bar above the grid summarizing applied filters; each chip has × to clear its specific dimension.
- "Reset filters" button in each tab toolbar.
- Per-tab sidebar visibility persists across app restarts (stored in Settings JSON).
- Old top-row filter UI is no longer visible; widget instances preserved for test backward compat.

## Commit breakdown

1. `3506bb4` FilterState extraction (pure refactor)
2. `791d282` UI primitives (4 widgets)
3. `422b29d` FilterSidebar scaffold
4. `945c769` Multi-select enum schema
5. `68ebb94` Sidebar chip controls + tab integration
6. `0a58bfe` 10 new filter dimensions + predicates
7. `c538180` Sidebar controls for Unit 5 filters
8. `4df23e7` ImageNet typeahead + YOLO filters + active chip bar + reset
9. `5e00081` Remove legacy filter UI from visible header

## Test plan

- [x] Full suite green (**1948 tests passing**)
- [x] Filter regression suite (141 existing tests) unmodified, still green after schema promotion
- [x] +57 new tests covering FilterState semantics, primitive widgets, sidebar integration, Unit 5/6 predicates, active chip bar
- [ ] Manually launch the app, open Cut tab, toggle filters sidebar, verify chips work for shot type / gaze / YOLO
- [ ] Load a project with ImageNet-classified clips, verify typeahead suggests labels; select two; toggle Any/All
- [ ] Verify "Reset filters" clears state on both tabs
- [ ] Verify chip-bar × removes a single filter

## Notes

- Per-label count rules ship as a programmatic API (`apply_filters({"yolo_per_label_rules": [("person", "=", 1)]})`); the inline stackable-row UI is deferred — the chip bar will show "Label rules: N" when any are active.
- Unit 5 UI coverage is 6 of 10 fields (person count, 4 tribools, has-analysis). Volume range slider, on-screen text search input, tag/note search input: predicates work today via `apply_filters`; sidebar controls are follow-up polish.

Ref plan: `docs/plans/2026-04-21-001-feat-comprehensive-clip-filter-system-plan.md`
Ref requirements: `docs/brainstorms/2026-04-21-comprehensive-clip-filter-system-requirements.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)