### PR TITLE
feat: Cassette Tape sequencer (transcript phrase matcher)

### DIFF
--- a/.claude/skills/feature-registry-reload-filter-scope/SKILL.md
+++ b/.claude/skills/feature-registry-reload-filter-scope/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: feature-registry-reload-filter-scope
+description: |
+  Diagnose silent "old version stuck" failures in Scene Ripper's on-demand
+  feature installer. Use when: (1) a VLM/ML feature fails with
+  "Unrecognized processing class" or "Can't instantiate a processor /
+  tokenizer / image processor" from transformers AutoProcessor after
+  feature_registry runs an install, (2) the log shows "Skipping reinstall
+  of already-loaded packages [...]" and the skipped list contains a
+  pure-Python package like transformers, mlx_vlm, ultralytics, or
+  lightning_whisper_mlx, (3) every clip in a batch fails with the same
+  model-load error in a tight loop. Root cause is scope creep in
+  core/feature_registry.py's _UNSAFE_TO_RELOAD_IF_LOADED set.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-21
+---
+
+# Feature-Registry Reload Filter Scope
+
+## Problem
+
+Scene Ripper's on-demand dependency installer skips reinstalling packages
+whose top-level module is already in `sys.modules`, to avoid corrupting
+C-extension state (e.g. torch's `"function '_has_torch_function' already has
+a docstring"` crash). The protection list `_UNSAFE_TO_RELOAD_IF_LOADED` in
+`core/feature_registry.py` must be precisely scoped to native-code packages.
+
+If the list includes a **pure-Python** package (transformers, ultralytics,
+mlx_vlm, lightning_whisper_mlx, etc.), users get silently stuck on whatever
+version they first loaded. When a new feature ships that requires a newer
+version of that pure-Python dep — for example, `mlx-vlm` pulling a
+`transformers` new enough to understand Qwen3-VL's processor class — the
+upgrade never happens and every model load fails with an obscure message.
+
+## Context / Trigger Conditions
+
+- User log shows `core.feature_registry - INFO - Skipping reinstall of
+  already-loaded packages ['torch', 'torchvision', 'transformers']` (or
+  similar, with a pure-Python package in the list)
+- Followed by repeated failures loading a VLM: `Failed to load local VLM
+  'mlx-community/Qwen3-VL-4B-Instruct-4bit': Unrecognized processing class
+  in ...`
+- The error message mentions `Can't instantiate a processor, a tokenizer,
+  an image processor or a feature extractor for this model. Make sure the
+  repository contains the files of at least one of those processing
+  classes.`
+- Affects every clip in a batch — custom_query / describe_local /
+  shot_classify all exhibit the same per-clip failure in a loop
+
+## Solution
+
+1. Open `core/feature_registry.py` and locate `_UNSAFE_TO_RELOAD_IF_LOADED`
+2. Keep **only** packages that bundle native code that breaks on reinstall
+   under a live interpreter:
+   - torch / torchvision / torchaudio (C extensions + `_has_torch_function`
+     docstring crash)
+   - onnxruntime (native inference runtime)
+   - mlx (Apple Metal native bindings)
+   - insightface (C extension for detection models)
+   - paddleocr (depends on paddlepaddle C extension)
+3. Remove any pure-Python packages (transformers, mlx_vlm, ultralytics,
+   lightning_whisper_mlx) — these MUST be reinstallable so pip can upgrade
+   them when a feature pins a newer version
+4. `install_packages` already evicts stale entries from `sys.modules` after
+   install (see `test_install_packages_refreshes_sys_path_and_clears_stale_modules`
+   in `tests/test_dependency_manager_progress.py`), so the next
+   `import transformers` picks up the new version — no app restart needed
+
+## Verification
+
+After the fix, reproduce the user's flow:
+1. Clear the HuggingFace model cache
+2. Trigger custom_query with a query against a recently-released VLM
+3. Confirm the install log does NOT skip the pure-Python dep
+4. Confirm the VLM loads and the first clip produces a result
+
+Run the dep-filter tests: `pytest tests/test_dependency_manager_progress.py -q`
+(32 tests, all must pass).
+
+## Example
+
+Before (broken):
+```python
+_UNSAFE_TO_RELOAD_IF_LOADED = {
+    "torch", "torchvision", "torchaudio", "onnxruntime",
+    "transformers",             # pure-Python — wrongly included
+    "insightface",
+    "ultralytics",              # pure-Python — wrongly included
+    "mlx",
+    "mlx_vlm",                  # pure-Python — wrongly included
+    "lightning_whisper_mlx",    # pure-Python — wrongly included
+    "paddleocr",
+}
+```
+
+After (fixed, commit `cecc299`):
+```python
+_UNSAFE_TO_RELOAD_IF_LOADED = {
+    "torch", "torchvision", "torchaudio", "onnxruntime",
+    "insightface", "mlx", "paddleocr",
+}
+```
+
+## Notes
+
+- The principle generalizes: any "reload-safety" guard over an on-demand
+  dep installer should be scoped narrowly. Pure-Python packages are
+  exactly the ones that get version-pinned by ML feature deps, so
+  protecting them creates a silent-failure mode far worse than a
+  hypothetical reload crash.
+- If a pure-Python package ever *does* need reload protection in the
+  future, prefer a targeted install-time prompt ("restart required") over
+  silently skipping the upgrade.
+- Tokenizers is Rust-backed but its reload behavior is stable in practice;
+  it stays out of the set for now. Revisit if reports surface.
+- Related commit context: `9c271b6` (original over-broad fix) → `cecc299`
+  (scope correction).

--- a/.claude/skills/rapidfuzz-alignment-unicode-length/SKILL.md
+++ b/.claude/skills/rapidfuzz-alignment-unicode-length/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: rapidfuzz-alignment-unicode-length
+description: |
+  Fix wrong-substring highlighting when using `rapidfuzz.fuzz.partial_ratio_alignment`
+  with manually case-folded text. Use when: (1) a text-search-with-highlight feature
+  shows the bold span landing on the wrong characters, (2) the bug only appears with
+  Turkish dotted-I (İ→i̇), German ß↔ss, or other Unicode chars whose `.lower()` form
+  has a different length than the original, (3) you call `text.lower()` before passing
+  to rapidfuzz and slice the original-case string with the returned indices. Root
+  cause: the alignment indices are valid against whatever string you passed in — if
+  you pre-lowercased, they index into the lowercased copy, not your original.
+author: Claude Code
+version: 1.0.0
+date: 2026-04-28
+---
+
+# RapidFuzz alignment + Unicode-length pitfall
+
+## Problem
+
+A text-search feature scores a phrase against a corpus using
+`rapidfuzz.fuzz.partial_ratio` and uses
+`rapidfuzz.fuzz.partial_ratio_alignment` to highlight the matched substring in
+the rendered text. To make matching case-insensitive, the code pre-lowercases
+both the phrase and the segment text before calling rapidfuzz:
+
+```python
+phrase_lc = phrase.lower()
+text_lc = segment_text.lower()
+score = fuzz.partial_ratio(phrase_lc, text_lc)
+alignment = fuzz.partial_ratio_alignment(phrase_lc, text_lc)
+match_start = alignment.dest_start
+match_end = alignment.dest_end
+
+# Later, the UI does:
+highlight = original_segment_text[match_start:match_end]
+```
+
+For ASCII / common Latin text this works. For text containing characters whose
+lowercase form has a **different length** than the original, the highlight
+silently lands on the wrong characters:
+
+- Turkish capital İ (U+0130) lowercases to `i̇` (2 chars). Every İ in the
+  text shifts subsequent indices by +1.
+- German ß ↔ SS / ss under Unicode casefold rules in some libraries.
+- Other Unicode chars with single-to-multi or multi-to-single case mappings.
+
+The bounds check `0 <= start < end <= len(original_text)` typically still
+passes (lengths drift by 1–2 chars, not enough to overflow), so the fallback
+to plain rendering doesn't fire and the user sees the wrong substring boldened
+without any error.
+
+## Context / Trigger Conditions
+
+- Code uses `rapidfuzz.fuzz.partial_ratio` and / or
+  `partial_ratio_alignment` for fuzzy text search.
+- Code lowercases (or otherwise normalizes) inputs before passing to rapidfuzz.
+- Code uses `alignment.dest_start` / `dest_end` to slice the **original**
+  (un-normalized) text for display.
+- Symptom: highlight visually shifts on text containing İ, ß, or similar
+  variable-length-cased characters. ASCII / pure-Latin content looks fine.
+
+## Solution
+
+Pass `processor=str.lower` (or any other normalizer) to rapidfuzz instead of
+pre-normalizing the inputs yourself. The processor is applied **internally
+for scoring only** — `partial_ratio_alignment` returns indices into your
+original strings, exactly as the UI needs them.
+
+```python
+from rapidfuzz import fuzz
+
+# WRONG: indices index into the lowercased copy
+phrase_lc = phrase.lower()
+text_lc = segment_text.lower()
+alignment = fuzz.partial_ratio_alignment(phrase_lc, text_lc)
+# original_segment_text[alignment.dest_start:alignment.dest_end] -> shifted on Turkish text
+
+# RIGHT: pass processor; alignment indexes into the original
+alignment = fuzz.partial_ratio_alignment(
+    phrase, segment_text, processor=str.lower
+)
+score = int(round(alignment.score))   # alignment carries the score too
+match_start = alignment.dest_start    # index into segment_text (original)
+match_end = alignment.dest_end        # index into segment_text (original)
+```
+
+Two further wins from this change:
+
+1. **Drop the redundant scoring call.** `partial_ratio_alignment` already
+   returns `.score`. Calling `partial_ratio` separately doubles per-pair
+   work in hot loops.
+2. **Use `processor=str.casefold` instead of `str.lower` for stricter
+   case-insensitive matching.** `casefold` handles ß→ss, dotless-I, etc.
+   correctly. Use `lower` only if you specifically want locale-naive
+   ASCII-style folding.
+
+## Verification
+
+Add a test using a Unicode-length-shifting character:
+
+```python
+def test_alignment_indices_map_into_original_case_text():
+    from rapidfuzz import fuzz
+    text = "Welcome to İstanbul tonight"
+    alignment = fuzz.partial_ratio_alignment("istanbul", text, processor=str.lower)
+    assert alignment.score >= 80
+    # Bold span maps back to the case-preserved word, not a shifted fragment.
+    assert "İstanbul" in text[alignment.dest_start:alignment.dest_end]
+```
+
+Without the fix, the assertion fails because `dest_start` / `dest_end` index
+into the lowercased copy where `İ` became 2 characters.
+
+## Example
+
+In Scene Ripper's Cassette Tape sequencer
+(`core/remix/cassette_tape.py:_score_phrase_against_segment`), this fix was
+applied as part of the code-review pass on the feature branch. The dialog
+renders the matched substring in bold via `dest_start:dest_end` slicing of
+`segment.text`, so the indices must remain valid against the original-case
+string. See PR #93 (commit `6df756e`).
+
+## Notes
+
+- This pitfall applies to **any** rapidfuzz scorer that returns alignments
+  (`partial_ratio_alignment`, `ratio_alignment`, etc.), not just
+  `partial_ratio`. The general rule: if you want indices that map into your
+  original strings, never pre-normalize the inputs — use `processor=`.
+- The processor is applied to **both** strings, so `str.lower` is symmetric
+  case-folding. If you need different normalizers for query vs. target, use
+  `processor1=` / `processor2=` (rapidfuzz ≥ 3.0).
+- The issue is invisible during development on English-only test data. Add
+  at least one Unicode test case to any text-highlight feature that uses
+  rapidfuzz alignments.
+- `rapidfuzz` ≥ 3.0 supports the `processor` kwarg on alignment functions.
+  Older versions may not — verify with `python -c "from rapidfuzz import fuzz; help(fuzz.partial_ratio_alignment)"`.
+
+## Sibling pitfall: `partial_ratio` is asymmetric on length
+
+`partial_ratio` aligns the **shorter** of the two strings against substrings
+of the **longer** and returns the best ratio. That's exactly what you want
+when you have a short query and a long body of text — but it inverts the
+relationship when the query is longer than the candidate. Concrete failure
+mode in a "find clips that say X" search:
+
+| Phrase (query) | Segment (candidate) | `partial_ratio` |
+|---|---|---|
+| `"I love you"` | `"I"` | **100** ← wrong direction |
+| `"thank you very much"` | `"a"` | **100** ← wrong direction |
+| `"thank you"` | `"well thank you for coming"` | 100 ✓ |
+
+The shorter string ("I") is found as a 1-char substring of the longer ("I
+love you") and rapidfuzz returns 100. To a user this surfaces as
+"match with no transcription text" — the segment is technically non-empty,
+but it's so short the score is meaningless.
+
+**Fix pattern:**
+
+```python
+if len(candidate) < len(query):
+    score = fuzz.ratio(query, candidate, processor=str.lower)  # length-penalised
+else:
+    alignment = fuzz.partial_ratio_alignment(query, candidate, processor=str.lower)
+    score = alignment.score
+```
+
+Plus a noise floor (e.g., reject candidates under ~3 chars) so single-char
+artifacts from upstream sources (Whisper hallucinations on silent audio,
+OCR misreads, etc.) can't surface even with `ratio`'s length penalty.
+
+See PR #93 in Scene Ripper, commit `70e9622`, for the full implementation.
+
+## References
+
+- [RapidFuzz documentation — `fuzz.partial_ratio_alignment`](https://rapidfuzz.github.io/RapidFuzz/Usage/fuzz.html#partial-ratio-alignment)
+- [Unicode TR #21 — Case Mappings](https://unicode.org/reports/tr21/) (background on
+  why some lowercase forms have different length than the original)
+- This skill's surfacing PR: `feat/cassette-tape` (Scene Ripper repo) — the
+  adversarial reviewer in `/ce-code-review` flagged the bug class with a
+  Turkish-text scenario before any user hit it in production.

--- a/core/chat_tools.py
+++ b/core/chat_tools.py
@@ -4233,6 +4233,7 @@ def list_sorting_algorithms(project) -> dict:
     # Check if clips have color analysis
     clips = project.clips
     has_colors = any(clip.dominant_colors for clip in clips) if clips else False
+    has_transcripts = any(clip.transcript for clip in clips) if clips else False
 
     has_brightness = any(clip.average_brightness is not None for clip in clips) if clips else False
     has_volume = any(clip.rms_volume is not None for clip in clips) if clips else False
@@ -4392,6 +4393,20 @@ def list_sorting_algorithms(project) -> dict:
             "available": has_gaze,
             "reason": None if has_gaze else "Run gaze analysis on clips first",
             "parameters": []
+        },
+        {
+            "key": "cassette_tape",
+            "name": "Cassette Tape",
+            "description": "Find clips that say specific phrases (transcript-driven mixtape)",
+            "available": has_transcripts,
+            "reason": None if has_transcripts else "Run transcribe analysis on clips first",
+            "parameters": [
+                {
+                    "name": "phrases",
+                    "type": "array",
+                    "description": "List of {phrase: str, count: int} dicts. count is 1-5 matches per phrase. Use generate_cassette_tape, not generate_remix."
+                }
+            ]
         },
     ]
 
@@ -4807,6 +4822,103 @@ def generate_storyteller(
             "theme": theme,
         }
     except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+@tools.register(
+    description="Generate a Cassette Tape sequence: find clips that say specific phrases. "
+                "For each phrase the agent supplies, the top-N best-matching transcript "
+                "segments are selected and assembled into a sequence of sub-clips trimmed "
+                "to just the matched lines. Requires transcribe analysis. Phrases is a list "
+                "of {phrase: str, count: int} where count is 1-5 matches per phrase.",
+    requires_project=True,
+    modifies_gui_state=True
+)
+def generate_cassette_tape(
+    project,
+    main_window,
+    phrases: list,
+) -> dict:
+    """Generate a Cassette Tape phrase-driven sequence.
+
+    Args:
+        phrases: List of {"phrase": str, "count": int} dicts. Count must be 1-5;
+            values outside that range are clamped. Empty/whitespace-only phrases
+            are skipped.
+
+    Returns:
+        Dict with success status, applied sub-clip count, and per-phrase counts.
+    """
+    if not phrases:
+        return {"success": False, "error": "No phrases provided."}
+
+    # Validate + normalize input. The agent may pass weird shapes; defend at the boundary.
+    phrases_with_counts: list[tuple[str, int]] = []
+    for entry in phrases:
+        if not isinstance(entry, dict):
+            continue
+        phrase = str(entry.get("phrase", "") or "").strip()
+        if not phrase:
+            continue
+        try:
+            count = int(entry.get("count", 3))
+        except (TypeError, ValueError):
+            count = 3
+        count = max(1, min(5, count))
+        phrases_with_counts.append((phrase, count))
+
+    if not phrases_with_counts:
+        return {"success": False, "error": "All supplied phrases were empty after trimming."}
+
+    gui_state = main_window._gui_state if main_window else None
+    selected_ids = []
+    if gui_state:
+        selected_ids = gui_state.analyze_selected_ids or gui_state.cut_selected_ids or []
+
+    # If clips are selected, use the selection; otherwise use the whole project.
+    if selected_ids:
+        candidate_clips = [project.clips_by_id[cid] for cid in selected_ids
+                           if cid in project.clips_by_id]
+    else:
+        candidate_clips = list(project.clips_by_id.values())
+
+    transcribed = [c for c in candidate_clips if c.transcript and not c.disabled]
+    if not transcribed:
+        return {
+            "success": False,
+            "error": "No transcribed clips available. Run Transcribe analysis on clips first.",
+        }
+
+    from core.remix.cassette_tape import (
+        build_sequence_data,
+        flatten_matches_in_phrase_order,
+        match_phrases,
+    )
+
+    try:
+        results = match_phrases(phrases_with_counts, transcribed)
+        if not results:
+            return {"success": False, "error": "No matches found for the supplied phrases."}
+
+        flat = flatten_matches_in_phrase_order(results)  # all matches enabled
+        sequence_data = build_sequence_data(flat, project.clips_by_id, project.sources_by_id)
+        if not sequence_data:
+            return {"success": False, "error": "Could not resolve matches to project clips."}
+
+        seq_tab = main_window.sequence_tab
+        seq_tab._apply_cassette_tape_sequence(sequence_data)
+
+        return {
+            "success": True,
+            "algorithm": "cassette_tape",
+            "clip_count": len(sequence_data),
+            "phrases": [
+                {"phrase": p, "match_count": len(results.get(p, []))}
+                for p, _ in phrases_with_counts
+            ],
+        }
+    except Exception as e:
+        logger.exception("generate_cassette_tape failed")
         return {"success": False, "error": str(e)}
 
 

--- a/core/chat_tools.py
+++ b/core/chat_tools.py
@@ -4852,6 +4852,8 @@ def generate_cassette_tape(
     if not phrases:
         return {"success": False, "error": "No phrases provided."}
 
+    from core.remix.cassette_tape import SLIDER_DEFAULT, clamp_count
+
     # Validate + normalize input. The agent may pass weird shapes; defend at the boundary.
     phrases_with_counts: list[tuple[str, int]] = []
     for entry in phrases:
@@ -4861,11 +4863,10 @@ def generate_cassette_tape(
         if not phrase:
             continue
         try:
-            count = int(entry.get("count", 3))
+            count = int(entry.get("count", SLIDER_DEFAULT))
         except (TypeError, ValueError):
-            count = 3
-        count = max(1, min(5, count))
-        phrases_with_counts.append((phrase, count))
+            count = SLIDER_DEFAULT
+        phrases_with_counts.append((phrase, clamp_count(count)))
 
     if not phrases_with_counts:
         return {"success": False, "error": "All supplied phrases were empty after trimming."}

--- a/core/remix/cassette_tape.py
+++ b/core/remix/cassette_tape.py
@@ -46,28 +46,49 @@ def _score_phrase_against_segment(phrase: str, segment_text: str) -> tuple[int, 
     """Score a phrase against a segment's text.
 
     Returns ``(score_0_100, match_start, match_end)``. ``match_start``/``end``
-    point into ``segment_text`` so the UI can highlight the matched substring.
-    Returns ``(0, -1, -1)`` for empty inputs.
+    point into the **original** ``segment_text`` so the UI can highlight the
+    matched substring without index drift on Unicode characters whose
+    lowercase form has a different length (e.g., Turkish dotted-I, German ß
+    in a casefold scenario).
+
+    We pass ``processor=str.lower`` to rapidfuzz so it lowercases internally
+    for scoring, while ``partial_ratio_alignment`` returns indices into the
+    *original* strings — which is exactly what we need for highlight
+    rendering. Returns ``(0, -1, -1)`` for empty inputs or when alignment
+    fails.
     """
     if not phrase or not segment_text:
         return 0, -1, -1
 
     from rapidfuzz import fuzz
 
-    phrase_lc = phrase.lower()
-    text_lc = segment_text.lower()
-
-    score = int(round(fuzz.partial_ratio(phrase_lc, text_lc)))
-
+    score = -1
     match_start = -1
     match_end = -1
     try:
-        alignment = fuzz.partial_ratio_alignment(phrase_lc, text_lc)
+        alignment = fuzz.partial_ratio_alignment(
+            phrase, segment_text, processor=str.lower
+        )
     except Exception:
+        logger.debug(
+            "rapidfuzz partial_ratio_alignment failed; falling back to score-only path",
+            exc_info=True,
+        )
         alignment = None
+
     if alignment is not None:
+        # alignment.score is 0-100 already; round to int so callers see a
+        # stable badge value. dest_start/dest_end index into segment_text.
+        score = int(round(alignment.score))
         match_start = int(alignment.dest_start)
         match_end = int(alignment.dest_end)
+    else:
+        # Score-only fallback when alignment is unavailable for any reason.
+        try:
+            score = int(round(fuzz.partial_ratio(phrase, segment_text, processor=str.lower)))
+        except Exception:
+            logger.debug("rapidfuzz partial_ratio also failed", exc_info=True)
+            score = 0
 
     return score, match_start, match_end
 

--- a/core/remix/cassette_tape.py
+++ b/core/remix/cassette_tape.py
@@ -42,6 +42,34 @@ class MatchResult:
     match_end: int  # substring end in segment.text (chars), or -1 if unknown
 
 
+# Slider range for matches-per-phrase. Both the dialog setup screen and
+# the agent tool's input validator clamp to this range.
+SLIDER_MIN = 1
+SLIDER_MAX = 5
+SLIDER_DEFAULT = 3
+
+
+def clamp_count(count: int) -> int:
+    """Clamp a phrase's match-count to [SLIDER_MIN, SLIDER_MAX]."""
+    return max(SLIDER_MIN, min(SLIDER_MAX, count))
+
+
+def safe_fps(source: Optional[Source]) -> float:
+    """Return the source's fps, or 30.0 if missing / non-positive.
+
+    A Source with fps<=0 (corrupted metadata, failed probe) would propagate
+    divide-by-zero into seconds-to-frames math and the timeline scene. The
+    UI apply path and build_sequence_data both need this guard, so the
+    helper lives here next to the matcher.
+    """
+    if source is None:
+        return 30.0
+    fps = getattr(source, "fps", None)
+    if fps and fps > 0:
+        return float(fps)
+    return 30.0
+
+
 _MIN_SEGMENT_CHARS = 3
 """Floor for transcript segment length. Segments shorter than this are
 treated as noise (Whisper often emits single-char artifacts on silent or
@@ -187,27 +215,36 @@ def match_phrases(
         if not phrase_clean or count <= 0:
             continue
 
-        scored: list[tuple[int, int, float, MatchResult]] = []
+        # Score each candidate and keep only the lightweight tuple needed for
+        # ranking + later MatchResult reconstruction. Deferring the dataclass
+        # construction until after the sort+slice avoids ~99% throwaway
+        # allocations at typical scale (only `count` of N candidates survive).
+        # Tuple shape: (-score, clip_index, start_time, score, m_start, m_end,
+        #               segment, clip_id, seg_index). The sort uses the first
+        # three for deterministic tie-break (best score, earliest segment,
+        # earliest clip in input order).
+        scored: list[tuple] = []
         for clip_index, clip, seg_index, segment in candidates:
             score, m_start, m_end = _score_phrase_against_segment(phrase_clean, segment.text)
-            mr = MatchResult(
-                phrase=phrase_clean,
-                clip_id=clip.id,
-                segment_index=seg_index,
-                segment=segment,
-                score=score,
-                match_start=m_start,
-                match_end=m_end,
-            )
-            # Sort key projects (-score, start_time, clip_index) — MatchResult
-            # itself is never compared because the lambda below picks indices
-            # 0/2/1 only. Deterministic tie-break: best score wins, then
-            # earliest segment in the source, then earliest clip in the
-            # candidate list.
-            scored.append((-score, clip_index, segment.start_time, mr))
+            scored.append((
+                -score, clip_index, segment.start_time,
+                score, m_start, m_end, segment, clip.id, seg_index,
+            ))
 
         scored.sort(key=lambda r: (r[0], r[2], r[1]))
-        results[phrase_clean] = [item[3] for item in scored[:count]]
+
+        results[phrase_clean] = [
+            MatchResult(
+                phrase=phrase_clean,
+                clip_id=item[7],
+                segment_index=item[8],
+                segment=item[6],
+                score=item[3],
+                match_start=item[4],
+                match_end=item[5],
+            )
+            for item in scored[:count]
+        ]
 
         logger.debug(
             "cassette_tape: phrase=%r returned %d matches (best score=%d)",
@@ -247,7 +284,7 @@ def build_sequence_data(
             logger.warning("cassette_tape: source not found for clip %s", clip.id)
             continue
 
-        fps = source.fps if source.fps and source.fps > 0 else 30.0
+        fps = safe_fps(source)
         in_frame = int(round(match.segment.start_time * fps))
         out_frame = int(round(match.segment.end_time * fps))
         if out_frame <= in_frame:

--- a/core/remix/cassette_tape.py
+++ b/core/remix/cassette_tape.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, Optional
 
 from models.clip import Clip, Source
 from core.transcription import TranscriptSegment
@@ -75,6 +75,7 @@ def _score_phrase_against_segment(phrase: str, segment_text: str) -> tuple[int, 
 def match_phrases(
     phrases_with_counts: list[tuple[str, int]],
     clips: list[Clip],
+    is_cancelled: Optional[Callable[[], bool]] = None,
 ) -> dict[str, list[MatchResult]]:
     """Score each phrase against every transcript segment and return top-N.
 
@@ -84,12 +85,17 @@ def match_phrases(
             but we defend here too).
         clips: All clips in the candidate pool. Clips without a transcript or
             with ``disabled=True`` are silently excluded.
+        is_cancelled: Optional callable returning ``True`` when the caller
+            wants to abort. Checked once per phrase; partial results are
+            discarded and an empty dict is returned. Lets a worker thread's
+            cancel() actually unblock a long-running match instead of just
+            suppressing the post-completion signal.
 
     Returns:
         Dict keyed by phrase (in input order, Python 3.7+ insertion-ordered)
         whose values are lists of ``MatchResult`` objects sorted best-first.
         Each list contains at most ``count`` results — fewer if the candidate
-        pool has fewer segments.
+        pool has fewer segments. Returns ``{}`` if cancelled mid-loop.
     """
     candidates: list[tuple[int, Clip, int, TranscriptSegment]] = []
     for clip_index, clip in enumerate(clips):
@@ -111,6 +117,10 @@ def match_phrases(
     results: dict[str, list[MatchResult]] = {}
 
     for phrase, count in phrases_with_counts:
+        if is_cancelled is not None and is_cancelled():
+            logger.info("cassette_tape: matching cancelled mid-loop")
+            return {}
+
         phrase_clean = (phrase or "").strip()
         if not phrase_clean or count <= 0:
             continue
@@ -127,8 +137,11 @@ def match_phrases(
                 match_start=m_start,
                 match_end=m_end,
             )
-            # Sort tuple: -score (best first), seg.start_time, clip_index, seg_index
-            # for deterministic tie-breaking. Tuples are sorted lexicographically.
+            # Sort key projects (-score, start_time, clip_index) — MatchResult
+            # itself is never compared because the lambda below picks indices
+            # 0/2/1 only. Deterministic tie-break: best score wins, then
+            # earliest segment in the source, then earliest clip in the
+            # candidate list.
             scored.append((-score, clip_index, segment.start_time, mr))
 
         scored.sort(key=lambda r: (r[0], r[2], r[1]))

--- a/core/remix/cassette_tape.py
+++ b/core/remix/cassette_tape.py
@@ -1,0 +1,210 @@
+"""Cassette Tape: Phrase-driven sequencing of transcribed clips.
+
+The user supplies a list of (phrase, count) pairs. For each phrase, this
+module scores every transcript segment in the project and returns the top-N
+best matches. The dialog renders matches with confidence + transcript snippet
+so the user can prune, then a sequence of sub-clips (trimmed to the matched
+segments) is built.
+
+The match unit is the TranscriptSegment, scored against each phrase via
+``rapidfuzz.fuzz.partial_ratio`` (case-insensitive). ``partial_ratio`` finds
+the best-matching substring inside the segment, which mirrors the user's
+mental model — "this clip says my phrase somewhere" — better than
+``ratio`` (which penalises length differences) or ``token_sort_ratio``
+(which is too forgiving on word order).
+
+There is no minimum-score threshold. The user controls quality on the
+review screen by toggling individual matches off.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from models.clip import Clip, Source
+from core.transcription import TranscriptSegment
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MatchResult:
+    """A single (phrase, clip, segment) match with its score."""
+
+    phrase: str
+    clip_id: str
+    segment_index: int
+    segment: TranscriptSegment
+    score: int  # 0–100, rounded
+    match_start: int  # substring start in segment.text (chars), or -1 if unknown
+    match_end: int  # substring end in segment.text (chars), or -1 if unknown
+
+
+def _score_phrase_against_segment(phrase: str, segment_text: str) -> tuple[int, int, int]:
+    """Score a phrase against a segment's text.
+
+    Returns ``(score_0_100, match_start, match_end)``. ``match_start``/``end``
+    point into ``segment_text`` so the UI can highlight the matched substring.
+    Returns ``(0, -1, -1)`` for empty inputs.
+    """
+    if not phrase or not segment_text:
+        return 0, -1, -1
+
+    from rapidfuzz import fuzz
+
+    phrase_lc = phrase.lower()
+    text_lc = segment_text.lower()
+
+    score = int(round(fuzz.partial_ratio(phrase_lc, text_lc)))
+
+    match_start = -1
+    match_end = -1
+    try:
+        alignment = fuzz.partial_ratio_alignment(phrase_lc, text_lc)
+    except Exception:
+        alignment = None
+    if alignment is not None:
+        match_start = int(alignment.dest_start)
+        match_end = int(alignment.dest_end)
+
+    return score, match_start, match_end
+
+
+def match_phrases(
+    phrases_with_counts: list[tuple[str, int]],
+    clips: list[Clip],
+) -> dict[str, list[MatchResult]]:
+    """Score each phrase against every transcript segment and return top-N.
+
+    Args:
+        phrases_with_counts: ``[(phrase, count), ...]`` in user-entered order.
+            Empty phrases are skipped (the dialog should already filter them,
+            but we defend here too).
+        clips: All clips in the candidate pool. Clips without a transcript or
+            with ``disabled=True`` are silently excluded.
+
+    Returns:
+        Dict keyed by phrase (in input order, Python 3.7+ insertion-ordered)
+        whose values are lists of ``MatchResult`` objects sorted best-first.
+        Each list contains at most ``count`` results — fewer if the candidate
+        pool has fewer segments.
+    """
+    candidates: list[tuple[int, Clip, int, TranscriptSegment]] = []
+    for clip_index, clip in enumerate(clips):
+        if clip.disabled:
+            continue
+        if not clip.transcript:
+            continue
+        for seg_index, segment in enumerate(clip.transcript):
+            if not segment.text or not segment.text.strip():
+                continue
+            candidates.append((clip_index, clip, seg_index, segment))
+
+    logger.debug(
+        "cassette_tape: %d candidate segments from %d clips",
+        len(candidates),
+        len(clips),
+    )
+
+    results: dict[str, list[MatchResult]] = {}
+
+    for phrase, count in phrases_with_counts:
+        phrase_clean = (phrase or "").strip()
+        if not phrase_clean or count <= 0:
+            continue
+
+        scored: list[tuple[int, int, float, MatchResult]] = []
+        for clip_index, clip, seg_index, segment in candidates:
+            score, m_start, m_end = _score_phrase_against_segment(phrase_clean, segment.text)
+            mr = MatchResult(
+                phrase=phrase_clean,
+                clip_id=clip.id,
+                segment_index=seg_index,
+                segment=segment,
+                score=score,
+                match_start=m_start,
+                match_end=m_end,
+            )
+            # Sort tuple: -score (best first), seg.start_time, clip_index, seg_index
+            # for deterministic tie-breaking. Tuples are sorted lexicographically.
+            scored.append((-score, clip_index, segment.start_time, mr))
+
+        scored.sort(key=lambda r: (r[0], r[2], r[1]))
+        results[phrase_clean] = [item[3] for item in scored[:count]]
+
+        logger.debug(
+            "cassette_tape: phrase=%r returned %d matches (best score=%d)",
+            phrase_clean,
+            len(results[phrase_clean]),
+            results[phrase_clean][0].score if results[phrase_clean] else 0,
+        )
+
+    return results
+
+
+def build_sequence_data(
+    matches_in_order: list[MatchResult],
+    clips_by_id: dict[str, Clip],
+    sources_by_id: dict[str, Source],
+) -> list[tuple[Clip, Source, int, int]]:
+    """Convert a flat list of matches into ``(clip, source, in_frame, out_frame)`` tuples.
+
+    The frame offsets are **relative to the clip's start_frame** — the sequence
+    tab adds ``clip.start_frame`` when calling ``add_clip_to_track``, matching
+    the pattern used by Signature Style. Frames are derived from the segment's
+    seconds-based ``start_time``/``end_time`` via ``round(t * source.fps)``.
+
+    Matches whose clip or source is missing from the lookup dicts are dropped
+    with a warning — this happens when the project changes between matching
+    and generation, which shouldn't normally occur in a single dialog run.
+    """
+    sequence: list[tuple[Clip, Source, int, int]] = []
+
+    for match in matches_in_order:
+        clip = clips_by_id.get(match.clip_id)
+        if clip is None:
+            logger.warning("cassette_tape: clip not found: %s", match.clip_id)
+            continue
+        source = sources_by_id.get(clip.source_id)
+        if source is None:
+            logger.warning("cassette_tape: source not found for clip %s", clip.id)
+            continue
+
+        fps = source.fps if source.fps and source.fps > 0 else 30.0
+        in_frame = int(round(match.segment.start_time * fps))
+        out_frame = int(round(match.segment.end_time * fps))
+        if out_frame <= in_frame:
+            out_frame = in_frame + 1  # guarantee non-empty sub-clip
+
+        sequence.append((clip, source, in_frame, out_frame))
+
+    logger.info("cassette_tape: built sequence with %d sub-clips", len(sequence))
+    return sequence
+
+
+def flatten_matches_in_phrase_order(
+    matches_by_phrase: dict[str, list[MatchResult]],
+    enabled_keys: Optional[set[tuple[str, str, int]]] = None,
+) -> list[MatchResult]:
+    """Flatten the phrase-grouped matches into the final sequence order.
+
+    Phrase order is preserved (dict insertion order); within each phrase,
+    matches are kept in their already-sorted score order.
+
+    Args:
+        matches_by_phrase: Output of :func:`match_phrases`.
+        enabled_keys: Optional set of ``(phrase, clip_id, segment_index)`` keys
+            indicating which matches should appear in the final sequence. When
+            ``None``, every match is included.
+    """
+    flat: list[MatchResult] = []
+    for phrase, matches in matches_by_phrase.items():
+        for match in matches:
+            if enabled_keys is not None:
+                key = (match.phrase, match.clip_id, match.segment_index)
+                if key not in enabled_keys:
+                    continue
+            flat.append(match)
+    return flat

--- a/core/remix/cassette_tape.py
+++ b/core/remix/cassette_tape.py
@@ -42,6 +42,14 @@ class MatchResult:
     match_end: int  # substring end in segment.text (chars), or -1 if unknown
 
 
+_MIN_SEGMENT_CHARS = 3
+"""Floor for transcript segment length. Segments shorter than this are
+treated as noise (Whisper often emits single-char artifacts on silent or
+near-silent clips: "a", ".", "uh"). They aren't excluded from the
+candidate set — empty-text exclusion still happens earlier — but their
+score is forced to 0 so they don't surface as matches."""
+
+
 def _score_phrase_against_segment(phrase: str, segment_text: str) -> tuple[int, int, int]:
     """Score a phrase against a segment's text.
 
@@ -51,20 +59,56 @@ def _score_phrase_against_segment(phrase: str, segment_text: str) -> tuple[int, 
     lowercase form has a different length (e.g., Turkish dotted-I, German ß
     in a casefold scenario).
 
-    We pass ``processor=str.lower`` to rapidfuzz so it lowercases internally
-    for scoring, while ``partial_ratio_alignment`` returns indices into the
-    *original* strings — which is exactly what we need for highlight
-    rendering. Returns ``(0, -1, -1)`` for empty inputs or when alignment
-    fails.
+    Scoring is length-aware to fix `partial_ratio`'s asymmetric bias:
+
+    - When the segment is **at least** as long as the phrase, use
+      ``partial_ratio`` so a phrase appearing inside a longer segment
+      ("thank you" inside "well thank you for coming") scores high.
+    - When the segment is **shorter** than the phrase, fall back to
+      ``ratio`` (length-penalized whole-string Levenshtein) so a single-
+      character segment like "a" or "the" cannot score 100 against a
+      multi-word phrase that happens to contain that token. Without this
+      branch, ``partial_ratio`` would invert the intent: it aligns the
+      shorter string (the segment) against substrings of the longer (the
+      phrase), so any segment that appears verbatim inside the phrase
+      scores 100 — which is the opposite of what the user wants.
+
+    Segments under :data:`_MIN_SEGMENT_CHARS` characters (after strip) are
+    treated as noise and forced to score 0; Whisper emits these on silent
+    clips as hallucination artifacts.
+
+    We pass ``processor=str.lower`` to rapidfuzz so it lowercases
+    internally for scoring, while alignment indices remain valid against
+    the *original* strings. Returns ``(0, -1, -1)`` for empty inputs or
+    when alignment fails.
     """
     if not phrase or not segment_text:
         return 0, -1, -1
 
+    # Noise floor: very short segments cannot meaningfully "say" the phrase.
+    if len(segment_text.strip()) < _MIN_SEGMENT_CHARS:
+        return 0, -1, -1
+
     from rapidfuzz import fuzz
 
-    score = -1
+    score = 0
     match_start = -1
     match_end = -1
+
+    # Length-branch: segments shorter than the phrase get whole-string ratio
+    # (penalises length difference) instead of partial_ratio (which would
+    # match the segment as a substring of the phrase — wrong direction).
+    if len(segment_text) < len(phrase):
+        try:
+            score = int(round(fuzz.ratio(phrase, segment_text, processor=str.lower)))
+        except Exception:
+            logger.debug("rapidfuzz ratio failed", exc_info=True)
+            score = 0
+        # No meaningful sub-region to highlight when scoring whole-string;
+        # let the UI render the full segment text.
+        return score, 0, len(segment_text)
+
+    # Segment is at least as long as the phrase — partial_ratio is correct.
     try:
         alignment = fuzz.partial_ratio_alignment(
             phrase, segment_text, processor=str.lower
@@ -77,13 +121,10 @@ def _score_phrase_against_segment(phrase: str, segment_text: str) -> tuple[int, 
         alignment = None
 
     if alignment is not None:
-        # alignment.score is 0-100 already; round to int so callers see a
-        # stable badge value. dest_start/dest_end index into segment_text.
         score = int(round(alignment.score))
         match_start = int(alignment.dest_start)
         match_end = int(alignment.dest_end)
     else:
-        # Score-only fallback when alignment is unavailable for any reason.
         try:
             score = int(round(fuzz.partial_ratio(phrase, segment_text, processor=str.lower)))
         except Exception:

--- a/docs/brainstorms/2026-04-21-comprehensive-clip-filter-system-requirements.md
+++ b/docs/brainstorms/2026-04-21-comprehensive-clip-filter-system-requirements.md
@@ -1,0 +1,198 @@
+---
+title: "feat: Comprehensive clip filter system for Cut and Analyze tabs"
+type: feat
+status: draft
+date: 2026-04-21
+---
+
+# Comprehensive clip filter system for Cut and Analyze tabs
+
+## Problem
+
+The current clip filter surface on the Cut and Analyze tabs doesn't cover
+the full set of analysis dimensions the project produces. The visible top
+row shows only shot type, color palette, custom query, and name search;
+many richer filters (duration, aspect ratio, gaze, object search,
+description search, brightness) live behind a "Filters" button in a
+collapsing panel and are easy to miss. Several analysis dimensions —
+notably ImageNet classification, YOLO object counts, OCR, cinematography,
+person count, audio volume, and transcript/analysis presence — have no
+filter exposure at all. Most enum filters are single-select, which blocks
+common combinations like "close-up OR extreme close-up".
+
+Primary use case driving this work: **shot hunting** — finding clips that
+match multiple precise criteria at once (e.g., *"close-ups of exactly one
+person looking at camera, no on-screen text, between 2–5 seconds"*). The
+current UI makes that workflow difficult because filters are partly
+hidden, partly missing, and partly too coarse.
+
+## Users
+
+- Video editors curating raw clip sets for a project
+- Sequencer users pre-filtering clips before running an algorithm
+- Power users with large projects (hundreds of clips) who rely on
+  analysis metadata to find needles in haystacks
+
+## Requirements
+
+### Layout
+
+- R1. Replace the current top-row filter strip + "Filters" panel with a
+  **toggleable sidebar** that can be shown/hidden as the user works.
+  Shown by default; hidden state preserved per-tab across app restarts.
+- R2. Sidebar organizes filter dimensions into **named sections** so
+  related filters group visually. Sections are collapsible so users can
+  focus on the dimensions they're actively using.
+- R3. When the sidebar is hidden, **active filter chips** appear above
+  the clip grid as read-only indicators so the user can see what's
+  applied without re-opening the sidebar. Each chip has a small `×` for
+  quick removal. This is the minimum visibility guarantee for hidden
+  state.
+- R4. Filter state is **shared by default between Cut and Analyze tabs**.
+  Each tab has its own "Reset filters" button that clears the shared
+  state without forcing the other tab to also reset. Switching tabs
+  pulls the current shared state; resetting on one tab does not
+  retroactively affect what the other tab was doing until the next tab
+  switch.
+
+### Filter dimensions
+
+Each filter must be exposed with the control type noted. Dimensions
+marked **[new]** don't exist today; others are expanding or changing
+control type.
+
+**Shot properties**
+- R5. Duration — range slider (continuous). *Existing.*
+- R6. Aspect ratio — **multi-select chips** (was single-select).
+- R7. **[new]** Has audio — boolean toggle.
+
+**Visual / cinematography**
+- R8. Shot type — **multi-select chips** (was single-select).
+- R9. Color palette — **multi-select chips** (was single-select).
+- R10. Brightness — range slider. *Existing.*
+- R11. **[new]** Cinematography (camera movement, angle, etc. as
+  produced by `cinematography` analysis) — multi-select chips.
+
+**People & gaze**
+- R12. **[new]** Person count — operator picker (`>`, `=`, `<`) with
+  numeric input. Discrete integer, so operators rather than range.
+- R13. Gaze direction — **multi-select chips** (was single-select,
+  buried). *Existing, promoted.*
+
+**ImageNet classification** (1000 classes)
+- R14. **[new]** Has ImageNet class — typeahead search that autocompletes
+  against classes **actually present in the loaded project**, sorted by
+  frequency (e.g., `dog (42 clips)`, `golden retriever (8 clips)`).
+  Selections become a multi-select chip list. A flat dropdown is not
+  viable at 1000 classes.
+- R15. **[new]** Mode toggle on the ImageNet class list: **Any** of the
+  selected classes vs **All** of the selected classes.
+
+**YOLO object detection** (~80 classes, separate data source from
+ImageNet)
+- R16. **[new]** Has object label — multi-select chips over all detected
+  labels in the project.
+- R17. **[new]** Total object count per clip — operator picker
+  (`>`, `=`, `<`).
+- R18. **[new]** Per-label count — compound rule: "at least N of
+  [label]". Multiple rules can be stacked (ANDed). Removable like a
+  chip.
+
+**Text / OCR / speech**
+- R19. **[new]** Has on-screen text — boolean.
+- R20. **[new]** On-screen text search — text input over
+  `extracted_texts`.
+- R21. **[new]** Has transcript — boolean.
+- R22. Description / transcript text search — text input. *Existing
+  partially; expand to cover transcripts explicitly.*
+
+**Audio**
+- R23. **[new]** RMS volume — range slider.
+
+**Custom queries**
+- R24. Custom query match — multi-select chips. *Existing, no change.*
+
+**Meta / housekeeping**
+- R25. **[new]** Has analysis of type X — multi-select chips over
+  analysis operation names (e.g., "describe", "objects", "colors"). Lets
+  users hide un-analyzed clips for a specific dimension.
+- R26. **[new]** Enabled / disabled — boolean toggle. Lets the user
+  hide clips they've marked disabled.
+- R27. Tag / note text search — text input.
+
+### Interaction behavior
+
+- R28. All filters combine with **AND** across dimensions. Within a
+  multi-select chip list, selected values combine with **OR** by default
+  (ImageNet has an explicit Any/All mode toggle per R15).
+- R29. **Negation is implicit only in v1** — boolean filters have Yes/No
+  options. Chip-list filters do not have per-chip or per-filter NOT.
+  (Revisit if shot-hunting workflows demand it.)
+- R30. Every filter has a visible "clear" affordance that resets only
+  that filter.
+- R31. When no clips match the active filters, the grid shows an
+  explicit empty state with a "Clear filters" CTA (not just a blank
+  area).
+
+## Scope Boundaries
+
+- **No saved filter presets in v1.** Revisit after the richer filter
+  surface ships and usage data shows whether preset reuse is a real
+  pattern.
+- **No negation beyond boolean Yes/No.** Per-chip exclude and
+  per-filter-mode switches are out of scope; their absence should be
+  acceptable for the shot-hunting use case.
+- **No changes to sequencer-tab filter behavior.** This is Cut and
+  Analyze only. Sequencer uses its own card-based UI and is out of
+  scope.
+- **No new analysis operations.** This proposal only surfaces existing
+  analysis outputs; it does not introduce new detection models or
+  inference.
+- **No filter state persisted across projects.** Sidebar visibility
+  persists, but filter values reset when switching projects.
+
+## Success Criteria
+
+- A user can construct a multi-criterion shot-hunt filter (e.g., "close-up
+  OR extreme close-up" × "1 person" × "at-camera gaze" × "no on-screen
+  text" × "≥ 2s") in a single continuous flow without opening or closing
+  multiple panels.
+- Every analysis operation the project runs (from
+  `core/analysis_operations.py`) has at least one filter exposure in the
+  sidebar.
+- Users can filter by both ImageNet classes (via typeahead across 1000
+  labels) and YOLO object detections (via chip list of ~80 labels), and
+  can express object-count constraints with `>`, `=`, `<` operators.
+- Active filters are visible whether the sidebar is shown or hidden.
+- Cut and Analyze tabs share filter state by default so switching
+  between them doesn't force reconfiguration.
+
+## Relevant Code
+
+- `ui/clip_browser.py` — current filter top row, collapsing filter
+  panel, and filter state. Most changes concentrate here.
+- `models/clip.py` — analysis fields that back each filter
+  (`object_labels` = ImageNet, `detected_objects` = YOLO,
+  `person_count`, `extracted_texts`, `rms_volume`, `transcript`,
+  `description`, `cinematography`, etc.).
+- `core/analysis/classification.py` — ImageNet source of truth for label
+  vocabulary and per-clip labels.
+- `core/analysis_operations.py` — canonical analysis operation list used
+  by R25 ("Has analysis of type X").
+- `ui/theme.py` — `UISizes` constants for sidebar width, chip height,
+  input heights (see `.claude/rules/ui-consistency.md`).
+
+## Open Questions — Deferred to Planning
+
+- **Sidebar width and location** — left rail or right rail? Fixed or
+  resizable?
+- **Filter state persistence scope** — reset on project switch, but
+  persist during a single project session including app restart?
+- **Active-filter chip overflow** — what happens when 10+ filters are
+  applied and the chip bar above the grid runs out of horizontal room?
+- **Typeahead performance** — 1000 ImageNet classes is small; no
+  anticipated concerns, but worth confirming during implementation for
+  large projects.
+- **Per-label count compound rule UI (R18)** — exact layout for stacking
+  multiple "at least N of [label]" rules deserves a design pass during
+  planning.

--- a/docs/brainstorms/2026-04-27-cassette-tape-sequencer-requirements.md
+++ b/docs/brainstorms/2026-04-27-cassette-tape-sequencer-requirements.md
@@ -1,0 +1,236 @@
+---
+title: "feat: Cassette Tape sequencer (phrase-driven transcript matcher)"
+type: feat
+status: draft
+date: 2026-04-27
+---
+
+# Cassette Tape sequencer
+
+## Problem
+
+Scene Ripper has 16 sequencer algorithms but no way to assemble a
+sequence around **what people are actually saying**. Users with
+transcribed footage who want to find clips matching a specific list of
+phrases (a quote, a lyric, a list of recurring lines) have to filter
+manually one phrase at a time and stitch results into a sequence by
+hand. There's no tool that takes a list of target phrases and surfaces
+the clips that say each one (or come close).
+
+Cassette Tape fills that gap. It's a quote-finder / clip-browser
+dressed as a sequencer: user supplies N phrases, picks how many matches
+to pull per phrase, reviews match confidence, and gets a sequence built
+from the matched transcript segments.
+
+## Users
+
+- Editors working with transcribed interview, documentary, or
+  found-footage material who want to cite specific lines.
+- Researchers building reference reels around recurring phrases or
+  motifs in a corpus.
+- Creative remixers building dialogue-driven supercuts where the
+  source of each cut is "a clip that says X".
+
+## Use case framing
+
+This is **not** narrative composition (Storyteller already handles
+that). The mental model is **search results playlist**: user enters a
+list of queries, gets back a sequence of clips that match. Scoring
+controls quality; phrase grouping preserves the user's intent. Confidence
+is shown so users can prune obviously-bad matches before committing.
+
+## Requirements
+
+### R1. Phrase entry
+
+- R1.1. The setup screen presents a list of **phrase rows**. Each row
+  has a text input for the phrase and a **count slider (1–5)** that
+  controls how many matches that phrase contributes to the final
+  sequence.
+- R1.2. Users can **add and remove rows**. Empty rows are ignored at
+  generation time. Default starting state: 3 empty rows.
+- R1.3. The slider's tick marks are integer values 1, 2, 3, 4, 5. Default
+  midpoint: 3.
+- R1.4. Every phrase row's slider is independent — different phrases can
+  pull different counts in the same run.
+
+### R2. Source clips
+
+- R2.1. Cassette Tape only considers clips with a non-empty
+  `transcript`. Clips without transcription are silently excluded from
+  the candidate pool. (Algorithm reference table calls out
+  `transcribe` as required analysis — same convention as other
+  transcript-aware features.)
+- R2.2. Disabled clips are excluded from matching (consistent with
+  every other sequencer).
+- R2.3. The candidate pool is the project's full set of enabled,
+  transcribed clips — not a tab-local selection. (Aligns with how
+  existing sequencers operate on the project pool.)
+
+### R3. Matching
+
+- R3.1. The matching unit is the **TranscriptSegment**. Each (clip,
+  segment) pair is scored against each phrase independently. A clip
+  with multiple segments contributes multiple match candidates.
+- R3.2. Similarity scoring uses `rapidfuzz.fuzz.partial_ratio`
+  (case-insensitive) by default. Rationale: transcript segments are
+  often longer than the user's phrase, and `partial_ratio` finds the
+  best-matching substring within the segment — which mirrors what
+  "this clip says my phrase somewhere" feels like to a user.
+  Alternative algorithms (`token_sort_ratio`, embedding-based) are
+  worth evaluating during planning if `partial_ratio` produces
+  unexpected results, but `partial_ratio` is the v1 default.
+- R3.3. For each phrase, the top **N best-scoring (clip, segment)
+  pairs** are retained, where N is that phrase's slider value. There
+  is no minimum-score threshold — the user controls quality on the
+  review screen by toggling off bad matches (see R4).
+- R3.4. Tie-breaking when scores are equal: prefer earlier
+  `segment.start` within the source clip, then earlier source clip
+  creation order. (Deterministic and avoids randomness across runs.)
+- R3.5. The same (clip, segment) can match multiple phrases. The user
+  may want this (different phrases happen to match the same line) or
+  not (duplicate playback). v1 behavior: **allow duplicates** across
+  phrase groups. The review screen makes them visible so the user can
+  toggle one off if undesired.
+
+### R4. Review / confidence screen
+
+- R4.1. After matching runs, the user sees a **review screen** showing
+  every match the algorithm produced, grouped by phrase, in score order
+  (best first within each phrase).
+- R4.2. Each match displays:
+  - the phrase it matched;
+  - the **source clip** thumbnail and name;
+  - the **matched transcript segment text** (the actual words the
+    clip says);
+  - the **confidence score** (0–100, rendered as a numeric badge plus
+    a colored bar — green ≥ 80, yellow 50–79, red < 50);
+  - a **toggle (checkbox)** that includes/excludes the match from the
+    final sequence. Defaults to enabled.
+- R4.3. Users can scroll through all matches, untoggle low-confidence
+  picks, then click **Generate sequence**. Only enabled matches end up
+  in the sequence.
+- R4.4. The review screen has **Cancel** (return to setup) and **Back**
+  (re-enter phrase setup with prior values preserved) buttons. Users
+  who want different counts re-tune sliders on the setup screen, not
+  the review screen.
+
+### R5. Sequence output
+
+- R5.1. The final sequence contains one `SequenceClip` per
+  enabled-after-review match.
+- R5.2. Each `SequenceClip` is a **sub-clip** of the source: its
+  `in_point` and `out_point` correspond to the matched
+  `TranscriptSegment`'s `start`/`end` (converted from seconds to
+  source frames using the source's fps).
+- R5.3. Sequence order: **phrase order, grouped**. Phrase 1's enabled
+  matches first (best to worst within the phrase), then phrase 2's
+  matches, etc. Empty phrase groups (all matches disabled) are
+  skipped.
+- R5.4. The sequence replaces the project's current sequence
+  (consistent with how other dialog-based sequencers behave —
+  Storyteller, Exquisite Corpus, Free Association).
+
+### R6. Edge cases
+
+- R6.1. **No transcribed clips in project**: setup screen shows an
+  inline message ("This project has no transcribed clips. Run Analyze
+  → Transcribe first.") and the Generate button is disabled.
+- R6.2. **No phrases entered**: Generate button is disabled until at
+  least one non-empty phrase row exists.
+- R6.3. **Phrase has no acceptable matches at all**: the review screen
+  still shows the top N picks, however bad. The user can toggle them
+  all off to skip that phrase.
+- R6.4. **Phrase count exceeds available segments**: if N=5 but only 3
+  segments exist in the corpus, return all 3. Don't pad.
+- R6.5. **Cancellation mid-match**: the worker should be a
+  `CancellableWorker` so users can abort matching on large corpora.
+
+## UX flow
+
+1. **Sequence tab → algorithm dropdown → "Cassette Tape"**: opens the
+   setup dialog (modal `QDialog`, like other dialog-based
+   sequencers).
+2. **Setup screen**: user enters phrases, tunes count sliders, clicks
+   **Find matches**.
+3. **Progress**: a brief progress indicator while matching runs (fast
+   for typical projects but worth surfacing, especially on cancel).
+4. **Review screen**: matches grouped by phrase, with toggle and
+   confidence display. User prunes, clicks **Generate sequence**.
+5. The dialog closes; the project sequence is replaced; the timeline
+   shows the new sub-clip sequence.
+
+## Out of scope (v1)
+
+- **Saving / loading phrase lists** as presets. Useful future feature
+  but not required for v1.
+- **Word-level timing** for tighter sub-clip boundaries (extracting
+  only the exact words rather than the whole segment). v1 uses
+  segment boundaries as recorded by faster-whisper / lightning-whisper.
+  Word-level slicing is a v2 polish.
+- **Embedding-based semantic matching** (sentence-transformers).
+  Defer until users hit the limits of `partial_ratio`. The
+  string-distance approach is faster, deterministic, and has no extra
+  model dependency.
+- **Per-phrase minimum-score threshold** (we discussed and explicitly
+  rejected this — count semantics + manual review screen pruning is
+  the agreed approach).
+- **Auto-trim of leading/trailing silence** within the matched
+  segment.
+- **Matching across phrase boundaries** (e.g., phrase that spans two
+  consecutive segments). v1 scores per segment; v2 could explore
+  segment concatenation if needed.
+
+## Dependencies / assumptions
+
+- `rapidfuzz` is already a project dependency (used in
+  `core/scene_detect.py:232`).
+- `Clip.transcript` is `list[TranscriptSegment]` with each segment
+  carrying `start`, `end`, and `text` fields. Confirmed in
+  `models/clip.py:227` and `core/transcription.py`.
+- `TranscriptSegment.start` / `end` are seconds, not frames —
+  conversion to frames will use the source clip's fps.
+- The `Clip` data model already has `disabled`, so source filtering
+  in R2.2 is straightforward.
+- The Sequence tab's algorithm dropdown and dialog routing
+  infrastructure already exists (Storyteller, Exquisite Corpus, etc.
+  follow this pattern).
+
+## Success criteria
+
+A user with a transcribed project can:
+
+1. Open Cassette Tape from the Sequence tab.
+2. Enter 3–5 phrases and pick a count for each.
+3. See a review screen where every match is annotated with the
+   transcript snippet and a 0–100 confidence score.
+4. Untoggle 1–2 obviously-bad matches.
+5. Click Generate and immediately see a sequence on the timeline that
+   plays back: phrase 1's clips in score order, then phrase 2's, etc.,
+   each clip trimmed to just the line that matched.
+
+The whole flow should take under 60 seconds for a 50-clip project
+with 5 phrases. Matching itself should be sub-second per phrase on
+typical project sizes — the slow path (if any) is faster-whisper at
+analysis time, not matching here.
+
+## Open questions
+
+- **OQ1.** Should confidence scores below ~30 be auto-untoggled on the
+  review screen? Reduces "click 5 boxes" tedium when the slider is
+  set high but the corpus is small. Defer; v1 ships with all matches
+  toggled on.
+- **OQ2.** How should the review screen handle very long transcript
+  segments (e.g., a 30-word segment matched on 2 words)? Truncate
+  display with an expand button? Highlight the matched substring in
+  the rendered text? v1 default: render full segment, highlight
+  matched substring (`rapidfuzz` exposes the matching position).
+- **OQ3.** Algorithm key in `ui/algorithm_config.py`: propose
+  `"cassette_tape"`. Required analysis: `["transcribe"]`. Dialog:
+  `True`. Confirm during planning.
+
+## Next step
+
+Hand off to `/ce-plan` to design the implementation: dialog UI, worker
+threading, `core/remix/cassette_tape.py` module, and registration in
+`ui/algorithm_config.py` + `ui/main_window.py` dialog routing.

--- a/docs/plans/2026-04-21-001-feat-comprehensive-clip-filter-system-plan.md
+++ b/docs/plans/2026-04-21-001-feat-comprehensive-clip-filter-system-plan.md
@@ -1,0 +1,947 @@
+---
+title: "feat: Comprehensive clip filter system for Cut and Analyze tabs"
+type: feat
+status: active
+date: 2026-04-21
+origin: docs/brainstorms/2026-04-21-comprehensive-clip-filter-system-requirements.md
+---
+
+# feat: Comprehensive clip filter system for Cut and Analyze tabs
+
+## Overview
+
+Replace the split filter surface in `ui/clip_browser.py` (a partial
+always-visible row plus a collapsing panel) with a toggleable **filter
+sidebar** that exposes every relevant analysis dimension in one place.
+Expand 13 existing filters and add 15 new ones across 9 categories.
+Lift filter state out of per-tab `ClipBrowser` instances into a shared
+`FilterState` object so the Cut and Analyze tabs operate on the same
+filter values, with per-tab reset (see origin: `docs/brainstorms/2026-04-21-comprehensive-clip-filter-system-requirements.md`).
+
+## Problem Frame
+
+Shot hunting is the driving use case: finding clips matching multiple
+precise criteria (e.g., "close-ups of exactly one person looking at
+camera, no on-screen text, 2–5 seconds"). The current filter surface
+fails this workflow in three ways:
+
+1. **Partial coverage.** Several analysis dimensions have no filter
+   (ImageNet labels, YOLO object count, cinematography, OCR, audio
+   volume, transcript presence, per-type analysis completion).
+2. **Split visibility.** Richer filters live behind a "Filters" button
+   and are easy to miss; discoverability for gaze/object/brightness is
+   poor.
+3. **Single-select everywhere.** Shot type, aspect ratio, color
+   palette, gaze are single-select, so "close-up OR extreme close-up"
+   is impossible.
+
+## Requirements Trace
+
+Full requirements in the origin document. The plan carries all 31
+requirements forward. Short reference by Unit:
+
+- **Layout (R1–R4)** — Units 3, 4, 7
+- **Shot properties (R5–R7)** — Units 4, 5
+- **Visual/cinematography (R8–R11)** — Units 4, 5
+- **People & gaze (R12–R13)** — Units 4, 5
+- **ImageNet (R14–R15)** — Unit 6
+- **YOLO objects (R16–R18)** — Unit 6
+- **Text/OCR/speech (R19–R22)** — Unit 5
+- **Audio (R23)** — Unit 5
+- **Custom queries (R24)** — Unit 4 (no behavior change)
+- **Meta/housekeeping (R25–R27)** — Unit 5
+- **Interaction behavior (R28–R31)** — Units 1, 7
+
+## Scope Boundaries
+
+- **No saved filter presets** (explicit non-goal in origin).
+- **No per-chip or per-filter NOT** (implicit Yes/No on booleans only).
+- **No Sequencer-tab filter changes** (explicit non-goal).
+- **No new analysis operations** — only new exposure of existing
+  analysis output.
+- **No cross-project filter persistence** — sidebar visibility
+  persists, filter values reset on project switch.
+- **No ImageNet confidence thresholding** — `Clip.object_labels` stores
+  a flat `list[str]` (confidences dropped at `ui/main_window.py:7333`).
+  Label-only filtering is sufficient for R14/R15.
+
+### Deferred to Separate Tasks
+
+- **Confidence-aware ImageNet filtering**: would require storing
+  confidences on `Clip.object_labels` and migrating CLI/UI emission
+  sites. Not in current requirements; revisit if shot-hunting demands
+  it.
+- **Dock state full persistence** (`QMainWindow.saveState/restoreState`
+  for width + dock-area): only sidebar *visibility* is persisted in v1.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**Files this plan touches or mirrors:**
+
+- `ui/clip_browser.py` — Current filter state (lines 711–751), filter
+  composition `_matches_filter` (1632–1720), public
+  `apply_filters` (2034–2167) / `get_active_filters` (2177–2201) /
+  `has_active_filters` (2203) / `clear_all_filters` (1975–2032)
+  contracts. Header filter row (762–856). Collapsible filter panel
+  `_create_filter_panel` (1722–1823).
+- `ui/tabs/cut_tab.py:114` and `ui/tabs/analyze_tab.py:162` — two
+  separate `ClipBrowser` instances today; sibling pattern for R4.
+- `ui/main_window.py:1607–1619` — tab-level `filters_changed` wiring.
+- `ui/clip_details_sidebar.py:56–100` — `QDockWidget` pattern to
+  mirror for `FilterSidebar` (object name, allowed areas, min/max
+  width, `toggleViewAction()`).
+- `ui/widgets/range_slider.py:10` — existing `RangeSlider` for all
+  continuous numeric filters (duration, brightness, volume).
+- `ui/widgets/category_pill_bar.py:10` — pill/chip styling template.
+  Currently exclusive; new `ChipGroup` will be non-exclusive variant.
+- `ui/theme.py:185–208` — `UISizes` constants (see
+  `.claude/rules/ui-consistency.md`). Use `background_tertiary`,
+  `accent_blue`, `badge_analyzed` (see
+  `.claude/skills/scene-ripper-theme-colors/SKILL.md`).
+- `models/clip.py:215–518` — all requirement fields confirmed present
+  (`object_labels`, `detected_objects`, `person_count`,
+  `extracted_texts`, `rms_volume`, `cinematography`, `description`,
+  `transcript`, `average_brightness`, `gaze_category`, `shot_type`,
+  `dominant_colors`, `custom_queries`, `tags`, `notes`).
+- `models/cinematography.py:181–487` — 23 enum-valued fields; value
+  constants at module level (`SHOT_SIZES`, `CAMERA_MOVEMENTS`, etc.)
+  feed R11 multi-select chips.
+- `core/analysis/classification.py:107–132` — cached
+  `imagenet_classes.txt` (1000 labels) for R14 typeahead vocabulary;
+  readable at app startup regardless of analysis completion.
+- `core/analysis/detection.py:17–32, 295–349, 378, 408` — YOLO
+  `detected_objects` schema; `get_object_counts()` helper for R18
+  per-label rule.
+- `core/analysis_availability.py:8–36` —
+  `operation_is_complete_for_clip(op_key, clip)` is the exact filter
+  primitive for R25. Reuse, don't re-derive.
+- `core/analysis_operations.py:23–87` — canonical analysis operation
+  list (`OPERATIONS_BY_KEY`) for R25.
+- `core/settings.py:374–521` — `Settings` JSON store for sidebar
+  visibility persistence (not QSettings).
+- `tests/test_clip_browser_filters.py` (502 lines), `tests/test_custom_query_ui.py`,
+  `tests/test_clip_browser_similarity.py`,
+  `tests/test_clip_browser_selection.py`, `tests/test_shot_type_filter.py`,
+  `tests/test_filter_clips_expanded.py` — current coverage; every
+  test using the `apply_filters` / `get_active_filters` dict contract
+  must keep passing.
+
+### Institutional Learnings
+
+High-relevance skills (apply during implementation):
+
+- `.claude/skills/pyside6-signal-handler-stale-state/SKILL.md` —
+  `filters_changed` rebuild handlers must look up clips by ID every
+  time, never cache `self.current_X`. Filter state is shared across
+  tabs in this plan; cross-tab contamination risk is real.
+- `.claude/skills/pyside6-duplicate-signal-guard/SKILL.md` and
+  `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`
+  — high-traffic `filters_changed` signal needs `Qt.UniqueConnection`
+  + guard flags + `@Slot()`.
+- `.claude/skills/pyside6-unique-connection-lambda-failure/SKILL.md` —
+  `UniqueConnection` + lambda silently fails. All chip click handlers
+  use named `@Slot` methods or `functools.partial` (no `UniqueConnection`).
+- `.claude/skills/pyside6-checkbox-state-enum/SKILL.md` — use
+  `checkbox.isChecked()`, never `state == Qt.Checked`.
+- `.claude/skills/pyside6-sidebar-stale-data-refresh/SKILL.md` —
+  when analysis workers mutate clip metadata (new YOLO labels, new
+  cinematography fields), filter vocabulary lists must refresh via
+  explicit `refresh_if_showing` hooks, with signals blocked during
+  refresh.
+- `.claude/skills/pyside6-tab-refactor-state-isolation/SKILL.md` —
+  direct precedent for R4. Tabs should expose public methods
+  (`get_filter_state()`, `set_filter_state()`), not poke widgets.
+- `.claude/skills/scene-ripper-theme-colors/SKILL.md` — use
+  `background_tertiary`, `accent_blue`, `badge_analyzed`. Do not
+  reach for `input_background` (doesn't exist).
+- `.claude/skills/pyside6-app-wide-theming/SKILL.md` — custom-styled
+  chips must connect to `theme().changed`.
+
+Known gaps (no prior learnings; call out in Risks):
+
+- No precedent for `QCompleter` typeahead over 1000+ items in this
+  codebase.
+- No precedent for multi-section collapsible sidebar or `QSplitter`
+  state persistence.
+
+## Key Technical Decisions
+
+- **Shared `FilterState` at MainWindow level with two `FilterSidebar`
+  widgets (one per tab)** — honors R4 "shared by default" while
+  respecting R1 "hidden state preserved per-tab." Both sidebars bind
+  to the same `FilterState` instance; visibility is toggled
+  independently per tab. Rejected alternatives: (a) single MainWindow
+  sidebar (can't satisfy per-tab visibility cleanly), (b) sync on
+  tab-switch (fragile and hard to reason about).
+- **`ClipBrowser` remains the grid renderer, not the filter owner.**
+  It no longer owns filter state attributes; it subscribes to
+  `FilterState.changed` and re-runs `_matches_filter()` using injected
+  state. This is a refactor with no behavior change for Unit 1.
+- **Public `apply_filters` / `get_active_filters` dict contract stays
+  stable.** Existing tests and any agent tools depending on it keep
+  working. `ClipBrowser.apply_filters(d)` delegates to
+  `self._filter_state.apply_dict(d)`.
+- **Multi-select becomes the default for enum filters.** Shot type,
+  aspect ratio, color palette, gaze, cinematography — all go from
+  single-value to `set[str]`. The existing dict contract's string
+  values (e.g., `shot_type: "Close-up"`) expand to accept `list[str]`
+  and `set[str]`; a single string remains valid (single-item set).
+- **Typeahead is a new reusable widget** (`ui/widgets/typeahead_input.py`)
+  built on `QCompleter` + `QStringListModel`. Source vocabulary:
+  - ImageNet: read once from `<model_cache_dir>/imagenet_classes.txt`
+    (1000 labels, stable vocabulary).
+  - YOLO: dynamic — union of labels present across loaded clips;
+    refresh on clip-add/clip-update.
+- **Reuse `operation_is_complete_for_clip()` for R25.** Don't
+  re-derive the completion check; wire the existing primitive.
+- **Sidebar sections are collapsible; collapse state persists via
+  `Settings` JSON**, not QSettings (Settings JSON is the migration
+  target per the existing `_migrate_qsettings_to_json` helper).
+- **Active filter chips render above the grid** (not inside the
+  sidebar), so hidden-sidebar mode still shows what's applied (R3).
+  Each tab renders its own chip bar since each tab has its own
+  `ClipBrowser`, but both consult the same `FilterState`.
+- **Per-tab reset button lives in the tab (not in the sidebar)** and
+  clears the shared `FilterState`. Resetting on one tab visibly
+  affects both — this is expected given shared state.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **How does R4's "shared by default" coexist with R1's "hidden state
+  preserved per-tab"?** Resolution: shared `FilterState` (values
+  shared), independent `FilterSidebar` visibility per tab. Reset
+  button per tab clears shared state for both.
+- **ImageNet typeahead vocabulary source?** Cached
+  `imagenet_classes.txt` (1000 labels) — loaded at sidebar init, not
+  deferred behind first analysis.
+- **YOLO label vocabulary source?** Union of labels actually present
+  in `detected_objects` across loaded clips, not the static COCO 80.
+  Covers `detection_mode: open_vocab` with user-defined classes.
+- **Per-label count rule UI (R18)?** Stackable rule rows: `[label
+  dropdown] [> / = / <] [int input] [× remove]`. Multiple rules ANDed.
+- **Sidebar persistence storage?** `core/settings.py:Settings` JSON
+  (`cut_filter_sidebar_visible: bool`, `analyze_filter_sidebar_visible: bool`,
+  `filter_sidebar_section_expanded: dict[str, bool]`).
+
+### Deferred to Implementation
+
+- **Sidebar location (left vs right rail) and resizability** — decide
+  during Unit 3 based on how it composes with the existing
+  `ClipDetailsSidebar` (which is left-allowed + right-allowed). Likely
+  right rail when left is taken by details. Width: match
+  `ClipDetailsSidebar`'s 400–550 min/max.
+- **Active-filter chip bar overflow behavior** — wrap to second line
+  vs horizontal scroll. Decide during Unit 7 after seeing realistic
+  state densities.
+- **Typeahead performance at 1000 items** — `QCompleter` with
+  `QStringListModel` handles this size comfortably per Qt docs; verify
+  empirically during Unit 6 and add prefix-only filtering if popup
+  feels slow.
+- **Exact label strings for chip display** vs internal keys
+  (e.g., `at_camera` → "At Camera") — use `models/cinematography.py`
+  helpers (`get_display_badges_formatted`) and existing key→display
+  mappings in `ui/clip_browser.py` where present.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+Component relationships after the refactor:
+
+```mermaid
+flowchart LR
+    MW[MainWindow] -->|owns| FS[FilterState]
+    MW -->|creates| CT[Cut tab]
+    MW -->|creates| AT[Analyze tab]
+    CT -->|contains| CSB[FilterSidebar<br/>Cut instance]
+    CT -->|contains| CCB[ClipBrowser<br/>Cut instance]
+    CT -->|contains| CCH[Active filter chips<br/>above grid]
+    AT -->|contains| ASB[FilterSidebar<br/>Analyze instance]
+    AT -->|contains| ACB[ClipBrowser<br/>Analyze instance]
+    AT -->|contains| ACH[Active filter chips<br/>above grid]
+
+    CSB -->|reads/writes| FS
+    ASB -->|reads/writes| FS
+    CCB -->|subscribes<br/>changed signal| FS
+    ACB -->|subscribes<br/>changed signal| FS
+    CCH -->|subscribes| FS
+    ACH -->|subscribes| FS
+```
+
+The `FilterState.changed` signal fires once per mutation. `ClipBrowser`
+re-runs `_matches_filter` for its visible thumbnails (same loop shape
+as today; only the data source changes). Both tabs' sidebars show the
+same values because they read from the same `FilterState`. Per-tab
+visibility is independent because each tab owns its own sidebar
+widget.
+
+## Implementation Units
+
+- [ ] **Unit 1: Extract `FilterState` data object and refactor `ClipBrowser` to use it**
+
+  **Goal:** Introduce a `FilterState` dataclass as the single owner of
+  filter values. `ClipBrowser` loses its filter state attributes; it
+  holds a reference and subscribes to change signals. Public
+  `apply_filters` / `get_active_filters` dict contract is preserved
+  byte-for-byte so existing tests pass without modification.
+
+  **Requirements:** R28 (AND/OR combination semantics carried forward)
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `core/filter_state.py`
+  - Modify: `ui/clip_browser.py` (remove `_current_filter` etc.
+    attributes; route handlers to `self._filter_state`)
+  - Modify: `ui/tabs/cut_tab.py`, `ui/tabs/analyze_tab.py`,
+    `ui/main_window.py` (construct a single `FilterState`, inject into
+    both `ClipBrowser` instances)
+  - Test: `tests/test_filter_state.py` (new)
+  - Touch: `tests/test_clip_browser_filters.py`,
+    `tests/test_custom_query_ui.py`,
+    `tests/test_clip_browser_similarity.py`,
+    `tests/test_clip_browser_selection.py`,
+    `tests/test_shot_type_filter.py`,
+    `tests/test_filter_clips_expanded.py` — should require no change
+    if contract is preserved
+
+  **Approach:**
+  - `FilterState` is a `QObject` with a single `changed` signal
+    (payload: changed field names, or void if all-changes).
+  - Fields mirror the existing 13 filter attributes exactly
+    (`min_duration`, `aspect_ratio`, `shot_type`, `color_palette`,
+    `search_query`, `selected_custom_queries`, `gaze_filter`,
+    `object_search`, `description_search`, `min_brightness`,
+    `max_brightness`, `similarity_anchor_id`, `similarity_scores`).
+  - Enum fields that will become multi-select in Unit 4 (shot_type,
+    aspect_ratio, color_palette, gaze) stay single-value here to keep
+    this unit a pure refactor.
+  - `FilterState.apply_dict(d: dict)` mirrors today's
+    `ClipBrowser.apply_filters` signature.
+  - `FilterState.to_dict()` mirrors today's `get_active_filters`.
+  - `ClipBrowser._matches_filter` reads from `self._filter_state`
+    instead of `self._...` attributes.
+  - `ClipBrowser.apply_filters` / `get_active_filters` /
+    `clear_all_filters` / `has_active_filters` delegate to
+    `FilterState`.
+  - `ClipBrowser.filters_changed` signal remains — forwarded from
+    `FilterState.changed`.
+
+  **Execution note:** Characterization-first. Run full filter test
+  suite before and after; any behavior change is a regression.
+
+  **Patterns to follow:**
+  - `QObject` subclass pattern from `ui/clip_browser.py:686`
+    (`ClipBrowser` itself).
+  - Signal forwarding: see how `ClipBrowser.filters_changed` is
+    consumed at `ui/main_window.py:1607–1619`.
+
+  **Test scenarios:**
+  - **Happy path:** `FilterState.apply_dict({"shot_type": "Close-up"})`
+    sets `state.shot_type == "Close-up"` and emits `changed` once.
+  - **Happy path:** `FilterState.to_dict()` round-trips to an input
+    matching `ClipBrowser.get_active_filters()` pre-refactor (parity
+    snapshot).
+  - **Edge case:** `apply_dict({})` is a no-op; `changed` does not
+    emit.
+  - **Edge case:** Setting the same value twice only emits `changed`
+    once (implicit dirty-check).
+  - **Integration:** `ClipBrowser` with an injected `FilterState`
+    produces identical `_matches_filter` outputs for a fixture set of
+    clips vs. the pre-refactor implementation (parity harness).
+
+  **Verification:**
+  - Every existing test in `test_clip_browser_filters.py`,
+    `test_custom_query_ui.py`, `test_clip_browser_similarity.py`,
+    `test_clip_browser_selection.py`, `test_shot_type_filter.py`,
+    `test_filter_clips_expanded.py` passes unchanged.
+  - `ClipBrowser` no longer holds filter state attributes (grep
+    `self._current_filter`, `self._gaze_filter`, etc. returns empty
+    in ui/clip_browser.py).
+
+- [ ] **Unit 2: Reusable sidebar UI primitives**
+
+  **Goal:** Build the small widgets the sidebar and its sections need.
+  Each is isolated and testable without a live `FilterSidebar`.
+
+  **Requirements:** R1 (sidebar), R2 (collapsible sections),
+  R6/R8/R9/R11/R13 (multi-select chips), R12/R17 (count operators),
+  R14 (typeahead)
+
+  **Dependencies:** None
+
+  **Files:**
+  - Create: `ui/widgets/collapsible_section.py`
+  - Create: `ui/widgets/chip_group.py`
+  - Create: `ui/widgets/typeahead_input.py`
+  - Create: `ui/widgets/count_operator.py`
+  - Test: `tests/test_collapsible_section.py`,
+    `tests/test_chip_group.py`,
+    `tests/test_typeahead_input.py`,
+    `tests/test_count_operator.py`
+
+  **Approach:**
+  - `CollapsibleSection`: `QWidget` with a header `QToolButton`
+    (`Qt.ToolButtonTextBesideIcon`, chevron rotates on toggle) and a
+    content `QFrame`. Exposes `setContentWidget(w)`,
+    `set_expanded(bool)`, `expanded` property. Emits
+    `expanded_changed(bool)`.
+  - `ChipGroup`: non-exclusive `QButtonGroup` wrapping checkable pill
+    buttons. Accepts `(value, label)` tuples. Exposes
+    `selected_values() -> set[str]`, `set_selected(set[str])`,
+    `clear_selection()`. Emits `selection_changed(set[str])`. Styling
+    mirrors `ui/widgets/category_pill_bar.py` (use `Radii.FULL`,
+    `theme().badge_analyzed` for selected, `background_tertiary` for
+    unselected).
+  - `TypeaheadInput`: `QLineEdit` + `QCompleter(popupCompletion,
+    caseInsensitive)` backed by `QStringListModel`. Exposes
+    `set_vocabulary(list[str])`, `selected_value` (emitted on
+    completion selection). Intended for single-term entry; caller
+    (sidebar) handles chip accumulation.
+  - `CountOperator`: `QComboBox` (`>`, `=`, `<`) + `QSpinBox`.
+    Exposes `value() -> tuple[str, int] | None`, `set_value(op, n)`,
+    `clear()`. Emits `value_changed(op, n)`.
+  - All four widgets must connect to `theme().changed` and re-apply
+    styling on theme switch (per app-wide theming skill).
+
+  **Patterns to follow:**
+  - Chip styling: `ui/widgets/category_pill_bar.py:95–114` pills with
+    `Radii.FULL`.
+  - Theme signal wiring:
+    `ui/clip_browser.py:265–266, 595–608` (ClipThumbnail) and
+    `ui/widgets/category_pill_bar.py:34–35`.
+  - Range sliders are NOT built here — reuse `ui/widgets/range_slider.py`.
+
+  **Test scenarios:**
+  - **Happy path** (all four): construct with fixture inputs, verify
+    initial state, simulate interaction, assert signal emission and
+    accessor output.
+  - **Edge case (ChipGroup):** `set_selected({})` clears all chips;
+    `set_selected({"nonexistent"})` does nothing (silent skip).
+  - **Edge case (TypeaheadInput):** Empty vocabulary — popup does not
+    show; committing empty text emits no signal.
+  - **Edge case (CollapsibleSection):** Toggle expands/collapses in
+    place without emitting stray signals on initial `set_expanded`
+    that matches current state.
+  - **Edge case (CountOperator):** Clearing resets both operator and
+    int input; `value()` returns `None`.
+  - **Integration:** All four widgets render correctly under both
+    dark and light themes (theme-switch test).
+
+  **Verification:**
+  - Each widget can be instantiated, used, and torn down in isolation
+    under `QT_QPA_PLATFORM=offscreen`.
+  - No widget references `theme().input_background` or similar
+    non-existent attributes (project-standards-reviewer will catch;
+    test runs a smoke `apply_to_app` before widget creation).
+
+- [ ] **Unit 3: `FilterSidebar` widget scaffold**
+
+  **Goal:** Build the sidebar as a `QDockWidget` wrapping a scrollable
+  column of 9 `CollapsibleSection` instances with empty bodies. Two
+  instances (one per tab) bind to the shared `FilterState`.
+  Visibility toggles per-tab; collapse state persists via Settings.
+
+  **Requirements:** R1, R2, R4 (shared state wiring), R30 (per-filter
+  clear)
+
+  **Dependencies:** Unit 1 (FilterState), Unit 2 (primitives)
+
+  **Files:**
+  - Create: `ui/widgets/filter_sidebar.py`
+  - Modify: `ui/tabs/cut_tab.py`, `ui/tabs/analyze_tab.py` (add
+    sidebar instance, toggle action)
+  - Modify: `ui/main_window.py` (instantiate shared `FilterState`;
+    pass to both tabs)
+  - Modify: `core/settings.py` — add `cut_filter_sidebar_visible: bool
+    = True`, `analyze_filter_sidebar_visible: bool = True`,
+    `filter_sidebar_section_expanded: dict[str, bool]` fields
+  - Test: `tests/test_filter_sidebar.py`
+
+  **Approach:**
+  - `FilterSidebar(QDockWidget)` — set `objectName`
+    ("CutFilterSidebar" / "AnalyzeFilterSidebar" — unique per tab for
+    any future `saveState` support); `setAllowedAreas(LeftDockWidgetArea
+    | RightDockWidgetArea)`; default min/max width 360/480.
+  - Constructor takes `filter_state: FilterState` and binds to
+    `filter_state.changed`.
+  - Scroll area wraps a `QVBoxLayout` of 9 `CollapsibleSection`
+    instances keyed by section name (Shot / Visual / People / ImageNet
+    / YOLO / Text / Audio / Custom Queries / Meta). Bodies are empty
+    in this unit; Units 4–6 populate them.
+  - Each section has a small "clear section" button in its header
+    (activates when anything in that section has a non-default
+    value). Implements R30.
+  - Tab owns its own sidebar; tab exposes
+    `toggleViewAction()`-backed Show/Hide in a tab menu or toolbar.
+  - Visibility change persists to
+    `settings.cut_filter_sidebar_visible` / `analyze_filter_sidebar_visible`.
+  - Section collapse change persists to
+    `settings.filter_sidebar_section_expanded`.
+
+  **Patterns to follow:**
+  - `ui/clip_details_sidebar.py:56–100` as QDockWidget template.
+  - MainWindow dock registration at
+    `ui/main_window.py:1680–1723` (chat_dock, clip_details_sidebar).
+  - Settings migration at `ui/main_window.py:732–734`.
+
+  **Test scenarios:**
+  - **Happy path:** Construct sidebar with empty `FilterState`;
+    assert 9 sections present in a defined order.
+  - **Happy path:** Toggle visibility; setting persists to
+    `settings.cut_filter_sidebar_visible`.
+  - **Happy path:** Toggle a section's collapse; setting persists to
+    `settings.filter_sidebar_section_expanded[<section>]`.
+  - **Integration:** Two sidebars bound to same `FilterState`: mutating
+    state from one sidebar emits `changed` that the other receives
+    (cross-instance sync via shared state).
+  - **Edge case:** Construct sidebar with no Settings entry for
+    collapse state; falls back to sensible default (all expanded).
+
+  **Verification:**
+  - `QT_QPA_PLATFORM=offscreen` construction succeeds.
+  - Cut tab and Analyze tab each render a sidebar that can be shown
+    / hidden independently.
+  - `MainWindow` holds one `FilterState` shared between both tabs.
+
+- [ ] **Unit 4: Migrate existing filters into the sidebar**
+
+  **Goal:** Move the 13 existing filters from `ClipBrowser`'s header
+  row and collapsing panel into the appropriate `FilterSidebar`
+  sections. Promote shot type, aspect ratio, color palette, and gaze
+  from single-select to multi-select. Remove the now-obsolete header
+  row and collapsing panel from `ClipBrowser`. Public
+  `apply_filters` / `get_active_filters` contract extends to accept
+  `list`/`set` for promoted fields while still accepting a string for
+  backward compat.
+
+  **Requirements:** R5, R6, R8, R9, R10, R13, R24 (layout preserved),
+  R28 (within-chip OR, across-filter AND), R30
+
+  **Dependencies:** Unit 3
+
+  **Files:**
+  - Modify: `ui/clip_browser.py` (remove header filter row and
+    `_create_filter_panel`; simplify `_setup_ui`)
+  - Modify: `ui/widgets/filter_sidebar.py` (populate Shot / Visual /
+    People / Custom Queries sections)
+  - Modify: `core/filter_state.py` (expand enum fields to `set[str]`;
+    extend `apply_dict` coercion for backward-compat string input)
+  - Modify: `tests/test_clip_browser_filters.py`,
+    `tests/test_shot_type_filter.py`,
+    `tests/test_filter_clips_expanded.py`,
+    `tests/test_custom_query_ui.py` (update assertions for
+    multi-select semantics)
+
+  **Approach:**
+  - **Shot (section):** duration `RangeSlider` (R5), aspect ratio
+    `ChipGroup` (R6).
+  - **Visual (section):** shot type `ChipGroup` (R8), color palette
+    `ChipGroup` (R9), brightness `RangeSlider` (R10).
+  - **People (section):** gaze direction `ChipGroup` (R13). Person
+    count (R12) deferred to Unit 5.
+  - **Custom Queries (section):** existing custom-query menu
+    (R24) — rendered as `ChipGroup` consistent with other multi-select
+    visuals. No behavior change; same AND-across-selected semantics.
+  - **Promotion to multi-select:** `FilterState.shot_type` becomes
+    `set[str]`. `_matches_filter` now: `if state.shot_type and thumb.shot_type not in state.shot_type: False`.
+    `apply_dict` accepts either string or `list`/`set`/`tuple`.
+    `to_dict()` returns the set for programmatic callers but includes
+    a single-string representation when exactly one value is set (for
+    MCP backward compat if any).
+  - **Remove old UI:** `filters_btn`, `filter_combo`,
+    `color_filter_combo`, `search_input`, `custom_query_filter_btn`,
+    and the entire `_create_filter_panel` output are deleted from
+    `ClipBrowser._setup_ui`. `filter_panel` teardown logic gone.
+    `ClipBrowser` header shrinks to only the sort order combo and
+    selection count label.
+
+  **Execution note:** Characterization-first on multi-select
+  promotion. Before changing `_matches_filter`, add failing tests
+  for multi-select semantics (e.g., "shot_type=['close-up', 'extreme_cu']
+  matches both"); then change the code; the pre-existing single-value
+  tests stay green via backward compat.
+
+  **Patterns to follow:**
+  - Custom query multi-select chip pattern: current
+    `_sync_custom_query_filter_options` at
+    `ui/clip_browser.py:1346–1377` and chip UI at `:835–842`.
+  - `_matches_filter` structure at
+    `ui/clip_browser.py:1632–1720` — mirror the same short-circuit
+    AND chain, just reading from `FilterState` and handling `set`
+    inputs.
+
+  **Test scenarios:**
+  - **Happy path:** `set_selected` on shot-type chips to `{"close-up"}`
+    matches only close-up clips.
+  - **Happy path:** `set_selected` to `{"close-up", "extreme_cu"}`
+    matches clips with either shot type (OR-within-field).
+  - **Integration:** Filter values simultaneously set on shot type,
+    color palette, and gaze apply as AND — only clips matching all
+    three appear.
+  - **Edge case (backward compat):** `apply_filters({"shot_type":
+    "Close-up"})` (string) produces the same result as
+    `apply_filters({"shot_type": ["Close-up"]})`.
+  - **Edge case:** `apply_filters({"shot_type": None})` clears the
+    filter; `apply_filters({"shot_type": []})` does the same; both
+    are equivalent to "no shot_type constraint."
+  - **Edge case:** Clearing a section's values via the per-section
+    clear button emits `changed` once and leaves other sections
+    untouched.
+
+  **Verification:**
+  - Header row in `ClipBrowser` is gone (only sort order and
+    selection count remain).
+  - All existing filter tests pass (may have minor assertion updates
+    for multi-select where explicit single-value was asserted).
+  - Visual parity: every filter that existed pre-refactor is reachable
+    from the sidebar.
+
+- [ ] **Unit 5: Add new non-object filter dimensions**
+
+  **Goal:** Wire up the 9 new filters that don't touch
+  `object_labels` / `detected_objects`: person count (R12), has audio
+  (R7), cinematography (R11), on-screen text (R19–R20), transcript
+  (R21–R22), RMS volume (R23), has-analysis-of-type (R25), enabled /
+  disabled (R26), tag/note search (R27).
+
+  **Requirements:** R7, R11, R12, R19, R20, R21, R22, R23, R25, R26,
+  R27
+
+  **Dependencies:** Unit 4
+
+  **Files:**
+  - Modify: `ui/widgets/filter_sidebar.py` (populate People / Visual /
+    Text / Audio / Meta sections with new controls)
+  - Modify: `core/filter_state.py` (add fields:
+    `person_count: tuple[str, int] | None`,
+    `has_audio: bool | None`, `cinematography_filters: dict[str, set[str]]`,
+    `has_on_screen_text: bool | None`, `on_screen_text_search: str`,
+    `has_transcript: bool | None`, `min_volume`/`max_volume`,
+    `has_analysis_ops: set[str]`, `enabled_filter: bool | None`,
+    `tag_note_search: str`)
+  - Modify: `ui/clip_browser.py` (extend `_matches_filter` with new
+    predicates)
+  - Test: `tests/test_filter_state.py` (extend), `tests/test_clip_browser_filters.py`
+    (add per-filter predicate tests)
+
+  **Approach:**
+  - Each new filter: add state field, add UI control in sidebar,
+    extend `_matches_filter`, extend `apply_dict` / `to_dict`.
+  - **Person count:** `CountOperator` (from Unit 2); predicate:
+    `op(clip.person_count, n)` with `None` treated as 0.
+  - **Has audio:** boolean chip pair (Yes / No / Any). Derived from
+    existing `Source.has_audio` attribute or `Clip` metadata; if
+    neither exists, gate by whether clip has transcript OR rms_volume
+    set.
+  - **Cinematography:** one `ChipGroup` per meaningful enum field
+    (`camera_angle`, `camera_movement`, `dutch_tilt`,
+    `focus_type`, etc.), or a single "Cinematography" section that
+    groups them as nested collapsibles. Implementer's call based on
+    visual density. Vocabularies come from `models/cinematography.py`
+    module-level constants (`CAMERA_ANGLES`, `CAMERA_MOVEMENTS`,
+    etc.). Predicate: AND across selected fields, OR within each.
+  - **On-screen text:** boolean for presence
+    (`bool(clip.extracted_texts)`); `QLineEdit` text search over
+    `ExtractedText.text` concatenation (case-insensitive substring).
+  - **Transcript:** boolean for presence
+    (`bool(clip.transcript)`); text search folded into existing
+    description search at R22 (rename control to "Description /
+    transcript").
+  - **RMS volume:** `RangeSlider` over `clip.rms_volume`, dB units.
+  - **Has analysis of type X:** `ChipGroup` with
+    `OPERATIONS_BY_KEY.keys()` as values. Predicate uses
+    `operation_is_complete_for_clip(op_key, clip)`. Semantics: AND
+    across selected ops ("must have all these analyses done").
+  - **Enabled / disabled:** boolean. Predicate on `clip.disabled`.
+  - **Tag/note search:** text search over
+    `" ".join(clip.tags) + " " + clip.notes`.
+
+  **Patterns to follow:**
+  - Predicate layout: mirror `_matches_filter` short-circuit AND
+    chain at `ui/clip_browser.py:1632–1720`.
+  - Analysis completion check: reuse
+    `core/analysis_availability.py:operation_is_complete_for_clip`.
+
+  **Test scenarios:**
+  - **Happy path (person count):** `state.person_count = (">", 1)`
+    filters to clips with `person_count > 1`.
+  - **Happy path (cinematography):** set camera_angle to
+    `{"low_angle", "high_angle"}`, matches clips with either.
+  - **Happy path (has-analysis):** select `{"describe", "colors"}` —
+    only clips where both are complete appear.
+  - **Edge case:** `clip.person_count is None` treated as 0 across
+    all operators.
+  - **Edge case:** `clip.rms_volume is None` excluded from matches
+    when the volume range is active.
+  - **Edge case:** `has_audio` boolean does not over-filter clips
+    from sources with no audio analysis run yet (tolerate None).
+  - **Edge case:** `operation_is_complete_for_clip` returns False
+    for `custom_query` by design — ensure R25 filter doesn't
+    erroneously reject all clips when custom_query is selected.
+  - **Integration:** Combining person-count, cinematography, and
+    has-analysis filters produces the AND intersection; visible
+    count in grid equals the expected fixture count.
+
+  **Verification:**
+  - `get_active_filters()` dict gains new keys mirroring the new
+    fields; `apply_filters` round-trips them.
+  - All new filters reachable from the sidebar.
+  - `_matches_filter` stays O(N_clips) per rebuild — no new O(N²)
+    work.
+
+- [ ] **Unit 6: ImageNet and YOLO object filters**
+
+  **Goal:** The two object filter categories with novel UI
+  requirements: ImageNet typeahead over 1000 classes, YOLO
+  label chips, total object count, and per-label count rules.
+
+  **Requirements:** R14, R15, R16, R17, R18
+
+  **Dependencies:** Unit 4 (sidebar populated), Unit 5 (pattern for
+  state/predicate extension)
+
+  **Files:**
+  - Modify: `ui/widgets/filter_sidebar.py` (populate ImageNet and
+    YOLO sections)
+  - Create: `ui/widgets/per_label_count_rule.py` — compound row
+    widget: `[label dropdown] [> / = / <] [int] [× remove]`
+  - Modify: `core/filter_state.py` — add fields:
+    `imagenet_labels: set[str]`, `imagenet_mode: str` ("any"/"all"),
+    `yolo_labels: set[str]`, `yolo_total_count: tuple[str, int] | None`,
+    `yolo_per_label_rules: list[tuple[str, str, int]]`
+  - Modify: `ui/clip_browser.py` (predicates for the 5 new fields)
+  - Modify: `core/analysis/classification.py` — expose a helper
+    `load_imagenet_class_list() -> list[str]` reading the cached
+    `imagenet_classes.txt` (if not already publicly accessible)
+  - Test: `tests/test_clip_browser_filters.py` (add object-filter
+    scenarios), `tests/test_per_label_count_rule.py` (new widget
+    test)
+
+  **Approach:**
+  - **ImageNet typeahead (R14):** `TypeaheadInput` populated from
+    `load_imagenet_class_list()` (1000 labels). User selects →
+    chip added to `imagenet_labels` set. Removed via chip × button.
+    Sort-by-frequency display *nice-to-have*: show counts like
+    `"dog (42)"` only when the sidebar has access to clip data; if
+    too expensive, defer. (Implementer's call — deferred.)
+  - **ImageNet Any/All toggle (R15):** two radio buttons above the
+    chip list. Predicate:
+    `any()` for "Any", `all()` for "All" across selected labels vs
+    `clip.object_labels`.
+  - **YOLO label chips (R16):** `ChipGroup` populated from the union
+    of `{d["label"] for clip in clips for d in (clip.detected_objects or [])}`.
+    Refresh the vocabulary when clips are added/updated (hook via
+    `FilterSidebar.refresh_yolo_vocab()` called from
+    `ClipBrowser.add_clip` / `update_clip`). Semantics: OR within
+    selected.
+  - **Total object count (R17):** `CountOperator`. Predicate:
+    `op(len(clip.detected_objects or []), n)`.
+  - **Per-label count rules (R18):** stacked `PerLabelCountRule`
+    widgets. Each produces a `(label, op, int)` tuple. Predicate per
+    rule: `op(Counter(d["label"] for d in clip.detected_objects)[label], n)`.
+    Rules combine as AND. "Add rule" button appends a new empty
+    row; "×" removes.
+
+  **Patterns to follow:**
+  - Helper: `core/analysis/detection.py:get_object_counts()` (378)
+    for per-image label counting — inline equivalent is fine too.
+  - Vocabulary refresh pattern:
+    `_update_filter_availability` at
+    `ui/clip_browser.py:2248–2291` for disabling controls when no
+    data present; mirror for YOLO vocabulary refresh.
+
+  **Test scenarios:**
+  - **Happy path (ImageNet Any):** select `{"dog"}` → matches clips
+    whose `object_labels` contains "dog".
+  - **Happy path (ImageNet All):** select `{"dog", "golden retriever"}`
+    with mode="all" → matches only clips containing both labels.
+  - **Happy path (YOLO labels):** `yolo_labels = {"person", "car"}` →
+    matches clips with either "person" or "car" in `detected_objects`.
+  - **Happy path (YOLO total count):** `yolo_total_count = (">", 3)`
+    → matches clips where `len(detected_objects) > 3`.
+  - **Happy path (per-label rule):** rule `("person", "=", 1)` →
+    matches clips with exactly one person detection.
+  - **Happy path (stacked rules):**
+    `[("person", "=", 1), ("car", ">", 0)]` → matches clips with 1
+    person AND at least 1 car.
+  - **Edge case (empty detections):** `clip.detected_objects is None`
+    is treated as empty list across all predicates.
+  - **Edge case (open-vocab label):** YOLO vocabulary includes user
+    custom class ("frisbee"), filter still works when selected.
+  - **Edge case (ImageNet vocabulary):** typeahead never crashes
+    when imagenet_classes.txt is missing (fall back to empty list,
+    disable the section with a nudge tooltip).
+  - **Integration:** Combined "ImageNet has dog" AND "YOLO has-label
+    person" AND "total count ≥ 2" returns the AND intersection.
+
+  **Verification:**
+  - ImageNet typeahead responds to input within a reasonable
+    interactive budget (subjective: feels immediate on `main_window`
+    startup with 1000 labels loaded).
+  - YOLO vocabulary updates when new YOLO analysis completes and
+    adds novel labels to a clip.
+  - Per-label count rules can be added, configured, and removed
+    multiple times without leaking widgets.
+
+- [ ] **Unit 7: Active filter chips, per-tab reset, empty state, polish**
+
+  **Goal:** Surface applied filter state as chips above the grid,
+  add per-tab reset buttons, provide an explicit empty-results state,
+  persist sidebar visibility across app restarts, and wire shared
+  filter state between Cut and Analyze tabs.
+
+  **Requirements:** R3, R4, R29 (boolean Yes/No), R31
+
+  **Dependencies:** Units 1, 3, 4, 5, 6
+
+  **Files:**
+  - Create: `ui/widgets/active_filter_chips.py` — compact read-only
+    chip bar that mirrors the current `FilterState` values, each
+    with a small × that clears just that filter.
+  - Modify: `ui/tabs/cut_tab.py`, `ui/tabs/analyze_tab.py` (add
+    `ActiveFilterChips` above grid, add "Reset filters" button)
+  - Modify: `ui/clip_browser.py` (empty-state message when no clips
+    match active filters)
+  - Modify: `core/settings.py` (already added fields in Unit 3 —
+    ensure load/save/migration are wired)
+  - Test: `tests/test_active_filter_chips.py`,
+    `tests/test_clip_browser_empty_state.py`
+
+  **Approach:**
+  - `ActiveFilterChips` subscribes to `FilterState.changed` and
+    renders one chip per non-default field. Chip label format:
+    `<section>: <value summary>` (e.g., `"Shot: Close-up, Extreme CU"`,
+    `"People: >1"`, `"Objects: person, car"`).
+  - Each chip has a × that clears that specific field on
+    `FilterState`.
+  - Reset button calls `filter_state.clear_all()` — visible effect
+    on both tabs because of shared state.
+  - Empty state: `ClipBrowser` detects
+    `has_active_filters() and visible_count == 0` and shows a
+    centered message with a "Clear filters" action. Existing empty
+    state for "no clips at all" stays as the fallback.
+  - Persistence: on close/save, write sidebar visibility and
+    section-expand state to `settings`. On app startup, read these
+    into the two `FilterSidebar` instances.
+  - Wire the two tabs' sidebars and `ClipBrowser` instances through
+    `MainWindow` so both tabs see changes immediately (already done
+    in Unit 3; verify here).
+
+  **Patterns to follow:**
+  - Active-filter chip pattern: reuse `ChipGroup` visuals, but
+    read-only.
+  - Empty state: see existing empty-state handling in
+    `ClipBrowser` (grep for current "no clips" display); stack or
+    adjacent to grid as appropriate.
+  - Settings load/save sequencing:
+    `core/settings.py:load_settings` / `save_settings`; new fields
+    follow the dataclass-field pattern.
+
+  **Test scenarios:**
+  - **Happy path:** Apply several filters; chip bar shows one chip
+    per active filter.
+  - **Happy path:** Click × on a chip; that field clears; chip
+    disappears; grid refreshes.
+  - **Happy path:** Reset button clears all filters; both tabs
+    reflect empty state instantly.
+  - **Edge case:** No active filters — chip bar collapses/hides
+    (no empty row).
+  - **Edge case (chip label):** A multi-value filter with 5+ values
+    renders as `"Cinematography: 5 selected"` rather than listing
+    all.
+  - **Integration (persistence):** Toggle sidebar visibility, quit
+    app, relaunch — visibility matches.
+  - **Integration (shared state):** Set a filter on Cut tab, switch
+    to Analyze tab — same filter value is active and reflected in
+    Analyze's sidebar.
+  - **Integration (per-tab reset):** Click reset on Cut tab while
+    filters are active — Analyze tab also shows cleared state
+    (shared).
+  - **Edge case (empty results):** Apply a filter combination with no
+    matches; grid shows the empty state with Clear Filters CTA.
+
+  **Verification:**
+  - Chip bar visible at the top of both Cut and Analyze tab grids.
+  - Closing with sidebar hidden on Cut tab and visible on Analyze tab
+    then reopening — same state.
+  - Cross-tab filter sync works end-to-end through the shared
+    `FilterState`.
+
+## System-Wide Impact
+
+- **Interaction graph:** `FilterState.changed` will fire very
+  frequently. Both tabs' `ClipBrowser._rebuild_grid`, both tabs'
+  `ActiveFilterChips`, and both `FilterSidebar` instances subscribe.
+  Use `Qt.UniqueConnection` + `@Slot()` + guard flags per
+  `pyside6-duplicate-signal-guard` skill. Do not use lambdas with
+  `UniqueConnection` (silent failure per
+  `pyside6-unique-connection-lambda-failure`).
+- **Error propagation:** Filter predicates that touch potentially
+  `None` fields (e.g., `clip.person_count is None`) must gracefully
+  treat None as the non-match side rather than raising. Add a
+  defensive path in each new predicate.
+- **State lifecycle risks:** When background analysis workers mutate
+  clip metadata (e.g., YOLO labels added), the filter sidebar's
+  vocabulary lists (YOLO label chips) must refresh. Use explicit
+  `refresh_*` methods called from clip-update handlers, per
+  `pyside6-sidebar-stale-data-refresh`. Block state signals during
+  refresh to prevent edit loops.
+- **API surface parity:** The `apply_filters` / `get_active_filters`
+  dict contract is part of the external surface — MCP tools and any
+  persisted state may depend on it. Preserve all existing keys;
+  accept both string and list/set for promoted multi-select fields;
+  add new keys without breaking old ones.
+- **Integration coverage:** Unit tests with mocks won't prove the
+  shared-state wiring is correct; at least one integration test per
+  R4 scenario must exercise real `MainWindow` + both tabs with a real
+  `FilterState`.
+- **Unchanged invariants:** `Clip` schema and analysis data shapes
+  (`object_labels`, `detected_objects`, etc.) are not modified.
+  `ClipBrowser._matches_filter` retains its short-circuit AND chain
+  structure; only its data source changes. Sequencer tab filtering
+  is untouched.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Typeahead over 1000 ImageNet classes feels laggy | `QCompleter` + `QStringListModel` handles this size per Qt docs. Verify empirically in Unit 6; add prefix-only filtering or max-suggestion limit if popup feels slow. |
+| Cross-tab state sync causes infinite signal loops | Use `Qt.UniqueConnection` + guard flags (`self._updating_from_state`) on all `FilterState.changed` handlers. Named `@Slot` methods, no lambdas with UniqueConnection. |
+| Multi-select promotion breaks API consumers expecting strings | `apply_dict` coerces string → single-item set; `to_dict` emits string when exactly one value. Existing tests stay green. Document the extension in code. |
+| Collapsible sections + sidebar splitter persistence is a new pattern | Keep v1 persistence minimal: visibility + section-collapse only. Full dock geometry (width, position) deferred. |
+| Filter vocabulary drift (YOLO labels change as analysis runs) | Explicit `refresh_yolo_vocab()` hook called from clip add/update. Snapshot tested. |
+| Large number of units may ship incrementally with broken intermediate states | Unit 1 is a pure refactor (tests stay green). Units 2–3 add infrastructure without removing old UI. Unit 4 removes the old UI in the same unit that lands the new sidebar-backed migration — ship as one change. |
+| User has open session with current filter UI on upgrade | The public `apply_filters` dict contract keeps working; worst case is a brief visual disruption on first launch with v0.3.x persisted state. Settings migration is defensive (unknown keys tolerated). |
+
+## Documentation / Operational Notes
+
+- Update `docs/user-guide/analysis.md` and
+  `docs/user-guide/cut.md` (if present) to describe the sidebar and
+  the new filter dimensions after Units 6 and 7 land.
+- Consider a demo GIF for the PR description
+  (`/compound-engineering:ce-demo-reel`) showing the shot-hunt
+  workflow: open sidebar → add multiple filters → reset → switch tab.
+- No migration logic required for persisted project state — filter
+  values are runtime-only, not serialized to project file in v1.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-21-comprehensive-clip-filter-system-requirements.md](../brainstorms/2026-04-21-comprehensive-clip-filter-system-requirements.md)
+- Related code: `ui/clip_browser.py`, `ui/clip_details_sidebar.py`,
+  `ui/widgets/range_slider.py`, `ui/widgets/category_pill_bar.py`,
+  `models/clip.py`, `models/cinematography.py`,
+  `core/analysis/classification.py`, `core/analysis/detection.py`,
+  `core/analysis_availability.py`, `core/analysis_operations.py`,
+  `core/settings.py`
+- Institutional skills that apply: `pyside6-signal-handler-stale-state`,
+  `pyside6-duplicate-signal-guard`,
+  `pyside6-unique-connection-lambda-failure`,
+  `pyside6-checkbox-state-enum`,
+  `pyside6-sidebar-stale-data-refresh`,
+  `pyside6-tab-refactor-state-isolation`,
+  `scene-ripper-theme-colors`, `pyside6-app-wide-theming`

--- a/docs/plans/2026-04-27-001-feat-cassette-tape-sequencer-plan.md
+++ b/docs/plans/2026-04-27-001-feat-cassette-tape-sequencer-plan.md
@@ -1,0 +1,588 @@
+---
+title: "feat: Cassette Tape sequencer"
+type: feat
+status: active
+date: 2026-04-27
+origin: docs/brainstorms/2026-04-27-cassette-tape-sequencer-requirements.md
+---
+
+# Cassette Tape sequencer
+
+## Overview
+
+Add a new dialog-based sequencer that lets the user enter a list of phrases
+and pulls the closest matches from transcribed clips, returning a sequence of
+sub-clips trimmed to the matched transcript segments. Two-step UX:
+phrase entry + per-phrase count slider, then a review screen showing each
+match with confidence so the user can prune before generating.
+
+---
+
+## Problem Frame
+
+Scene Ripper has 16 sequencers but none operate on **what's being said**.
+Users with transcribed footage who want to assemble a sequence around
+specific quotes have to filter manually one phrase at a time. Cassette Tape
+fills that gap as a quote-finder / clip-browser dressed as a sequencer
+(see origin: `docs/brainstorms/2026-04-27-cassette-tape-sequencer-requirements.md`).
+
+---
+
+## Requirements Trace
+
+- R1. Phrase entry rows with per-phrase count slider (1–5), add/remove rows,
+  default 3 empty rows.
+- R2. Source pool = enabled clips with non-empty `transcript`; project-wide.
+- R3. Match unit = `TranscriptSegment`; score with
+  `rapidfuzz.fuzz.partial_ratio` (case-insensitive). Top-N best per phrase,
+  no threshold.
+- R4. Review screen: every match grouped by phrase, with phrase, source clip,
+  transcript snippet, 0–100 confidence (numeric badge + colored bar:
+  green ≥ 80 / yellow 50–79 / red < 50), and an include/exclude toggle.
+- R5. Output sequence = enabled-after-review matches as `SequenceClip`
+  sub-clips with `in_point`/`out_point` derived from segment start/end
+  (seconds → frames via source fps); ordered phrase-then-score; replaces
+  current sequence.
+- R6. Edge cases: no transcribed clips → setup-screen message; no phrases →
+  Generate disabled; cancellable worker.
+
+---
+
+## Scope Boundaries
+
+- **Non-goals (v1):** preset save/load of phrase lists; word-level sub-clip
+  boundaries; embedding-based semantic matching; per-phrase score threshold;
+  auto-trim of leading/trailing silence; matching across segment boundaries.
+- **Auto-untoggle below confidence ~30:** deferred (origin OQ1) — v1 leaves
+  every match enabled by default; user prunes manually.
+
+### Deferred to Follow-Up Work
+
+- None. The feature ships as a single PR.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- **Sequencer module pattern:** `core/remix/storyteller.py`,
+  `core/remix/exquisite_corpus.py` — module exposes a generation function
+  plus a `sequence_by_*` helper that returns clip tuples.
+- **Sub-clip in/out emission pattern:** `core/remix/signature_style.py` +
+  `ui/tabs/sequence_tab.py:1301-1313` — the dialog emits 4-tuples
+  `(clip, source, in_point, out_point)` and the apply method calls
+  `timeline.scene.add_clip_to_track(...)` with
+  `in_point=clip.start_frame + in_point`. Cassette Tape will follow this
+  pattern exactly.
+- **Multi-step dialog pattern:** `ui/dialogs/storyteller_dialog.py` —
+  `QDialog` + `QStackedWidget`, page constants (`PAGE_CONFIG`,
+  `PAGE_PROGRESS`, `PAGE_PREVIEW`), `QThread` worker with
+  `progress / finished_* / error` signals, dialog emits a `sequence_ready`
+  signal that the sequence tab connects to.
+- **Algorithm registration:** `ui/algorithm_config.py` — add a
+  `cassette_tape` entry with `is_dialog: True`,
+  `required_analysis: ["transcribe"]`, `categories: ["arrange", "audio"]`.
+- **Dialog dispatch:** `ui/tabs/sequence_tab.py:776-786` — `_on_card_clicked`
+  routes dialog algorithms by name; add a `cassette_tape` branch calling a
+  new `_show_cassette_tape_dialog(clips)` helper. Mirror the `apply_*`
+  receiver pattern at `:1290-1325`.
+- **Intention-workflow re-entry:** `ui/main_window.py:8166-8186` already
+  handles `is_dialog` routing back through `sequence_tab._on_card_clicked`
+  — no changes needed there for Cassette Tape (transcribe is a known
+  analysis op).
+- **Transcript model:** `core/transcription.py:239` —
+  `TranscriptSegment(start_time, end_time, text, confidence)`, all in
+  seconds. Helper `Clip.get_transcript_text()` at `models/clip.py:295`.
+- **Fuzzy scoring:** `core/scene_detect.py:232` already uses
+  `rapidfuzz.fuzz.ratio`. Cassette Tape uses `partial_ratio` for
+  substring-aware matching. `rapidfuzz` exposes the matched substring
+  position via `fuzz.partial_ratio_alignment` for highlight rendering.
+
+### Institutional Learnings
+
+- **`docs/solutions/` skills relevant here:**
+  - `wire-sequencer-algorithm` — registration dance for new sequencers
+    (algorithm_config + sequence_tab dispatch + apply method).
+  - `pyside6-qthread-finished-signal-shadowing` — don't name a signal
+    `finished` (clashes with `QThread.finished`); use `finished_matches`
+    or similar.
+  - `litellm-empty-response-validation` — N/A here (no LLM).
+  - `pyside6-duplicate-signal-guard` — relevant if the dialog is
+    re-opened; ensure worker signals connect once per worker instance.
+- **Signal naming:** Use `matches_ready = Signal(list)` and
+  `sequence_ready = Signal(list)` to avoid `QThread.finished` shadowing.
+
+### External References
+
+- `rapidfuzz` docs: `fuzz.partial_ratio` and `fuzz.partial_ratio_alignment`
+  are stable, already-installed APIs. No external research needed —
+  pattern is local and well-understood.
+
+---
+
+## Key Technical Decisions
+
+- **Match unit = `TranscriptSegment` (one row per segment), not whole-clip
+  transcript.** Rationale: gives the user tight quote boundaries for free
+  (R3, R5) without needing word-level timing. Whole-clip matching would
+  blur which segment matched, making the review screen misleading.
+- **`partial_ratio` over `ratio` or `token_sort_ratio`.** Rationale: the
+  user types short phrases ("I love you") to find them inside longer
+  segments ("well I love you very much"). `partial_ratio` finds the best
+  substring; `ratio` would penalize length differences; `token_sort_ratio`
+  is too forgiving on word order, which inverts user intent.
+- **No threshold; user prunes manually on review screen.** Carried from
+  origin (R3, R4). Removes the "0 matches returned" UX pain.
+- **Dialog emits 4-tuples, not `SequenceClip` objects.** Match the
+  `signature_style` precedent so the sequence tab's
+  `add_clip_to_track` integration works without a new code path.
+- **Deterministic tie-breaking:** equal scores break by earlier
+  `segment.start_time` then earlier source-clip creation order. Avoids
+  test flakiness and surprising result reordering between runs.
+- **Dialog dimensions and page constants** mirror `StorytellerDialog`
+  (3 pages: setup / progress / review) for consistency.
+- **Algorithm key = `cassette_tape`.** Required analysis =
+  `["transcribe"]`. Categories = `["arrange", "audio"]`.
+- **Highlight matched substring on review screen** (origin OQ2). Use
+  `rapidfuzz.fuzz.partial_ratio_alignment` to get the matched range and
+  render with bold/colored span in the segment text.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **OQ3 — algorithm key + required analysis:** `cassette_tape`,
+  `required_analysis: ["transcribe"]`, `is_dialog: True`,
+  `categories: ["arrange", "audio"]`.
+- **OQ2 — long-segment display:** render full segment text with the
+  matched substring highlighted (bold + theme accent color). Use
+  `partial_ratio_alignment.dest_start/dest_end` for the highlight range.
+  No truncation in v1.
+- **Worker signal naming:** `matches_ready = Signal(list)` (not
+  `finished`) to avoid `QThread.finished` shadowing.
+
+### Deferred to Implementation
+
+- **Exact widget choice for the per-row controls:** likely
+  `QLineEdit` + `QSlider(Horizontal)` + `QLabel` for current count + an
+  `×` remove button per row. Final layout decided when wiring.
+- **Review screen widget:** likely a scrolling `QVBoxLayout` of phrase
+  group headers + per-match rows with embedded `QCheckBox`. Could
+  alternatively use `QTableView`; defer until first pass shows the rough
+  density.
+- **Threading model for matching:** plan calls for a `CancellableWorker`
+  (R6.5). Since `partial_ratio` over a few hundred segments is
+  millisecond-fast, the worker may not be strictly necessary for
+  performance — but it future-proofs for large corpora and matches the
+  pattern other dialog sequencers use. Implement as a worker.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+USER FLOW
+─────────
+Sequence tab
+   └─ click "Cassette Tape" card
+       └─ sequence_tab._on_card_clicked("cassette_tape")
+           └─ _show_cassette_tape_dialog(clips)
+               └─ CassetteTapeDialog
+                   ├─ PAGE_SETUP  →  user enters phrases + counts, clicks Find Matches
+                   ├─ PAGE_PROGRESS  →  CassetteTapeWorker runs match_phrases()
+                   └─ PAGE_REVIEW  →  user toggles, clicks Generate
+                       └─ emit sequence_ready([(clip, source, in_frame, out_frame), ...])
+                           └─ sequence_tab._apply_cassette_tape_sequence()
+                               └─ timeline.scene.add_clip_to_track(...) per match
+
+
+DATA FLOW
+─────────
+phrases = ["I love you", "thank you", ...]      # from setup page
+counts  = [3, 5, ...]                           # per-phrase slider values
+clips_with_transcripts = [clip for clip in available_clips
+                          if clip.transcript and not clip.disabled]
+
+# Build (clip, segment) candidate set once
+candidates = [(clip, seg) for clip in clips_with_transcripts
+                          for seg in clip.transcript]
+
+# Score per phrase, keep top-N
+matches_per_phrase = {}
+for phrase, n in zip(phrases, counts):
+    scored = [
+        (score(phrase, seg.text), clip, seg)
+        for clip, seg in candidates
+    ]
+    scored.sort(key=lambda r: (-r[0], seg.start_time, clip_index(clip)))
+    matches_per_phrase[phrase] = scored[:n]
+
+# Review screen renders matches_per_phrase with toggles
+# On Generate: build SequenceClip tuples for enabled matches in phrase order
+```
+
+---
+
+## Implementation Units
+
+- U1. **Core matching module: `core/remix/cassette_tape.py`**
+
+**Goal:** Pure-logic module that scores phrases against
+`(clip, TranscriptSegment)` pairs and returns top-N matches per phrase.
+No Qt, no threading.
+
+**Requirements:** R2, R3, R5
+
+**Dependencies:** none
+
+**Files:**
+- Create: `core/remix/cassette_tape.py`
+- Test: `tests/test_cassette_tape.py`
+
+**Approach:**
+- Define a `MatchResult` dataclass: `phrase`, `clip_id`, `segment_index`,
+  `segment` (TranscriptSegment), `score` (0–100 int), `match_start`,
+  `match_end` (substring positions for highlight).
+- `match_phrases(phrases: list[tuple[str, int]], clips: list[Clip])
+  -> dict[str, list[MatchResult]]` — input is `(phrase, count)` pairs;
+  output preserves phrase order in the dict (Python 3.7+).
+- Internal: build candidate `(clip, segment)` list from clips with
+  non-empty `transcript`; for each phrase score every candidate via
+  `rapidfuzz.fuzz.partial_ratio` (lowercased on both sides); sort with
+  the documented tie-break; slice to N.
+- Use `rapidfuzz.fuzz.partial_ratio_alignment` to get
+  `match_start/match_end` on the segment text for highlight rendering.
+- `build_sequence_data(matches_in_order: list[MatchResult],
+  clips_by_id: dict, sources_by_id: dict, ...) ->
+  list[tuple[Clip, Source, int, int]]` — converts segment seconds to
+  frames using `source.fps`; in_frame = `round(seg.start_time * fps)`,
+  out_frame = `round(seg.end_time * fps)` (relative to clip start, to
+  match the `signature_style` convention where the sequence tab adds
+  `clip.start_frame`).
+
+**Patterns to follow:**
+- `core/remix/signature_style.py` for the build-sequence-data shape.
+- `core/scene_detect.py:232` for `rapidfuzz` usage.
+
+**Test scenarios:**
+- *Happy path:* phrase "thank you", segment "well thank you for coming",
+  expect score ≥ 90 and `match_start`/`match_end` cover "thank you".
+- *Happy path:* phrase "I love you" with 3 matches available, count=2,
+  returns the 2 highest-scoring `(clip, segment)` pairs.
+- *Edge case:* clip with `transcript=None` is silently excluded.
+- *Edge case:* clip with `disabled=True` is silently excluded.
+- *Edge case:* phrase matches no segment well (top score < 30); top-N
+  is still returned (no threshold).
+- *Edge case:* count > available segments → returns all available
+  without padding.
+- *Edge case:* same phrase appears in two clips with identical scores —
+  tie-broken by earlier `segment.start_time` then earlier clip index;
+  deterministic across runs.
+- *Happy path:* `build_sequence_data` converts seconds to frames using
+  source fps; for fps=24 and seg.start_time=2.5, in_frame=60.
+- *Edge case:* segment with start_time=0.0 yields in_frame=0.
+
+**Verification:**
+- `pytest tests/test_cassette_tape.py` passes.
+- `match_phrases` returns a dict keyed by phrase order, each value a
+  list of `MatchResult` with length ≤ requested count.
+- No PySide6, Qt, or threading imports in the module.
+
+---
+
+- U2. **Algorithm registration: `ui/algorithm_config.py`**
+
+**Goal:** Register `cassette_tape` so it appears in the Sequence tab card
+grid with the correct required-analysis gating.
+
+**Requirements:** R1, R2
+
+**Dependencies:** U1 (logic exists, even if dialog isn't wired yet —
+keeps the registration valid).
+
+**Files:**
+- Modify: `ui/algorithm_config.py`
+
+**Approach:**
+- Add a `cassette_tape` entry to `ALGORITHM_CONFIG`:
+  - `label`: "Cassette Tape"
+  - `description`: e.g., "Find clips that say specific phrases — the
+    transcript-driven mixtape"
+  - `required_analysis`: `["transcribe"]`
+  - `is_dialog`: `True`
+  - `allow_duplicates`: `False`
+  - `categories`: `["arrange", "audio"]`
+- No icon required (existing entries leave the field as empty string).
+
+**Patterns to follow:**
+- Other dialog entries: `exquisite_corpus`, `storyteller`,
+  `signature_style`.
+
+**Test scenarios:**
+- Test expectation: none — pure config addition. Covered indirectly by
+  U3's dialog dispatch tests, which look up the algorithm by key.
+
+**Verification:**
+- `cassette_tape` appears in the Sequence tab algorithm card grid when
+  the project has at least one clip with a transcript.
+- Card is gated correctly when no clips have transcripts (existing
+  `required_analysis` machinery handles this).
+
+---
+
+- U3. **Dialog: `ui/dialogs/cassette_tape_dialog.py`**
+
+**Goal:** Three-page modal dialog (setup / progress / review) that
+collects phrases and counts, runs matching in a worker, lets the user
+toggle individual matches, and emits `sequence_ready` with the chosen
+sub-clip tuples.
+
+**Requirements:** R1, R4, R5, R6
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `ui/dialogs/cassette_tape_dialog.py`
+- Test: `tests/test_cassette_tape_dialog.py`
+
+**Approach:**
+- Mirror `StorytellerDialog` structure: `QDialog` + `QStackedWidget`,
+  three page constants (`PAGE_SETUP=0`, `PAGE_PROGRESS=1`,
+  `PAGE_REVIEW=2`).
+- **Setup page:** scrollable list of phrase rows; `+` adds a row, `×`
+  removes a row, default 3 empty rows; each row has a `QLineEdit` and a
+  `QSlider(1,5)` plus a count label; "Find Matches" button at the
+  bottom — disabled until at least one phrase has non-empty text.
+  Header above the list shows a one-line message if no transcribed
+  clips exist (R6.1) and disables Find Matches.
+- **Progress page:** simple status label + a `QProgressBar` (or
+  indeterminate spinner) and a Cancel button.
+- **Review page:** scrolling layout grouped by phrase. Each group shows
+  the phrase header (and "no acceptable matches" if all matches scored
+  near zero — visual hint, not a hard filter); per-match rows show
+  thumbnail, clip name, segment snippet (with the matched substring
+  highlighted), confidence badge + colored bar, and an enabled-by-default
+  `QCheckBox`. "Generate Sequence" button (disabled if zero rows
+  enabled), "Back" returns to setup with prior values preserved,
+  "Cancel" closes the dialog.
+- **Worker:** `CassetteTapeWorker(QThread, CancellableWorker mixin)` with
+  signals `progress = Signal(int, int)` (n, total),
+  `matches_ready = Signal(dict)` (phrase → [MatchResult]),
+  `error = Signal(str)`. Worker calls `match_phrases` from U1.
+  Avoid the `finished` name to prevent QThread.finished shadowing.
+- **Public signal:** `sequence_ready = Signal(list)` emitting
+  `list[tuple[Clip, Source, int, int]]` once the user clicks Generate.
+- Confidence color thresholds: green ≥ 80, yellow 50–79, red < 50;
+  read from `ui/theme.py` if existing accent colors fit, otherwise
+  introduce three constants in the dialog module.
+- Worker connection happens at instantiation; if dialog is reopened,
+  create a new worker each run (avoids the duplicate-signal-guard
+  pattern).
+
+**Patterns to follow:**
+- `ui/dialogs/storyteller_dialog.py` for page management and worker
+  signal layout.
+- `ui/workers/base.py:CancellableWorker` for cancellation.
+- `ui/theme.py:UISizes` for slider/button heights and label widths
+  (per `.claude/rules/ui-consistency.md`).
+- For review-screen styling, mirror the per-match cards used in
+  `ui/dialogs/free_association_dialog.py` if a similar list-of-cards
+  surface exists; otherwise build a minimal layout.
+
+**Test scenarios:**
+- *Happy path:* dialog initializes with 3 empty rows; Find Matches is
+  disabled until a phrase is entered.
+- *Happy path:* entering 2 phrases and clicking Find Matches advances
+  to the progress page.
+- *Happy path:* worker emits `matches_ready`; dialog advances to review
+  with all match toggles checked by default.
+- *Happy path:* user unchecks one match; clicking Generate emits
+  `sequence_ready` with the remaining matches.
+- *Edge case:* no transcribed clips supplied → setup page shows the
+  no-transcripts message and Find Matches is disabled.
+- *Edge case:* user clicks Cancel during progress → worker is
+  requested-cancel, dialog closes without emitting `sequence_ready`.
+- *Edge case:* worker emits `error("...")` → dialog returns to setup
+  with the error displayed in a banner.
+- *Edge case:* user toggles every match off → Generate is disabled.
+- *Edge case:* dialog closed and reopened in same session → new worker
+  is created; signals do not double-fire.
+- *Integration:* `partial_ratio_alignment` highlight range is non-empty
+  on a real `(phrase, segment)` pair (verifies U1↔U3 contract).
+
+**Verification:**
+- `pytest tests/test_cassette_tape_dialog.py` passes.
+- Manually opening the dialog from the Sequence tab card produces a
+  usable flow end-to-end on a small project with transcribed clips.
+
+---
+
+- U4. **Dialog dispatch + sequence application: `ui/tabs/sequence_tab.py`**
+
+**Goal:** Wire the algorithm card click to open the dialog, and add the
+`_apply_cassette_tape_sequence` handler that turns the dialog's
+4-tuples into timeline clips.
+
+**Requirements:** R5
+
+**Dependencies:** U2, U3
+
+**Files:**
+- Modify: `ui/tabs/sequence_tab.py`
+- Test: covered by U3's dialog tests (which assert `sequence_ready`
+  shape) plus an existing-style smoke test in
+  `tests/test_sequence_tab_dialog_routing.py` if that file already
+  exists; otherwise add a minimal targeted test in
+  `tests/test_cassette_tape_dialog.py` covering the wiring contract.
+
+**Approach:**
+- Add `from ui.dialogs import CassetteTapeDialog` (and update
+  `ui/dialogs/__init__.py` to export it).
+- In `_on_card_clicked`, after the existing `is_dialog` checks
+  (storyteller, exquisite_corpus, etc.), add an `elif algorithm ==
+  "cassette_tape": self._show_cassette_tape_dialog(clips); return`.
+- New helper `_show_cassette_tape_dialog(clips)` — mirror
+  `_show_storyteller_dialog` shape: instantiate dialog with
+  `clips_with_sources`, connect `sequence_ready` to
+  `self._apply_cassette_tape_sequence`, call `dialog.exec()`.
+- New handler `_apply_cassette_tape_sequence(sequence_data)` — mirror
+  `_apply_signature_style_sequence` at `:1290-1325`:
+  - clear timeline, set fps from first clip's source
+  - for each `(clip, source, in_point, out_point)` tuple, call
+    `timeline.scene.add_clip_to_track(track_index=0,
+    source_clip_id=clip.id, source_id=source.id,
+    start_frame=current_frame, in_point=clip.start_frame + in_point,
+    out_point=clip.start_frame + out_point, thumbnail_path=...)`
+  - advance `current_frame` by `out_point - in_point`
+  - emit `clip_added` per tuple
+  - update timeline preview, algorithm dropdown label ("Cassette Tape"),
+    fit zoom
+- Update `ui/dialogs/__init__.py` to export `CassetteTapeDialog`.
+
+**Patterns to follow:**
+- `_show_storyteller_dialog` and `_apply_signature_style_sequence` in
+  the same file.
+- Existing `from ui.dialogs import …` block at line 26 of
+  `ui/tabs/sequence_tab.py`.
+
+**Test scenarios:**
+- *Happy path:* feeding a 3-tuple sequence into
+  `_apply_cassette_tape_sequence` puts 3 clips on the timeline at
+  correct `start_frame` offsets and matching `in_point`/`out_point`.
+- *Edge case:* empty `sequence_data` does not crash and shows a
+  user-visible "no clips" status (mirror existing apply methods).
+- *Integration:* end-to-end through dialog → apply: covered by U3's
+  manual verification step plus dialog test asserting the emitted
+  shape.
+
+**Verification:**
+- `pytest tests/` is green for new and existing tests.
+- Manually clicking the Cassette Tape card on a transcribed project
+  routes to the dialog and a generated sequence appears on the
+  timeline.
+
+---
+
+- U5. **User-facing docs: `docs/user-guide/sequencers.md`**
+
+**Goal:** Document the new sequencer in the user guide so it's
+discoverable.
+
+**Requirements:** documentation hygiene per `CLAUDE.md`'s
+`sync-sequencer-docs` skill convention.
+
+**Dependencies:** U2 (registration must be in place so the doc
+reference is correct).
+
+**Files:**
+- Modify: `docs/user-guide/sequencers.md`
+
+**Approach:**
+- Add a "Cassette Tape" section following the existing per-sequencer
+  format (label, when to use, required analysis, dialog flow,
+  examples).
+- Include the use case framing from the brainstorm: quote-finder, not
+  narrative composition.
+
+**Patterns to follow:**
+- Existing per-sequencer sections in `docs/user-guide/sequencers.md`.
+- Optionally invoke the `sync-sequencer-docs` skill to ensure
+  alignment with `ui/algorithm_config.py`.
+
+**Test scenarios:**
+- Test expectation: none — documentation only.
+
+**Verification:**
+- The new section renders correctly in markdown preview.
+- The label, required analysis, and behavior description match U2's
+  registration entry verbatim.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** new dialog plugs into the existing Sequence
+  tab card-click → dialog → sequence_ready chain. No new entry points.
+- **Error propagation:** worker errors surface on the dialog's error
+  banner; no upstream handler changes.
+- **State lifecycle risks:** dialog closing mid-match must cancel the
+  worker (R6.5). Reopening the dialog must not reuse a stale worker —
+  instantiate fresh per run.
+- **API surface parity:** the existing intention-workflow re-entry at
+  `ui/main_window.py:8166-8186` already routes any `is_dialog`
+  algorithm via `sequence_tab._on_card_clicked`, so the new dialog is
+  reachable from both the Sequence-tab card and the
+  intention-workflow path without extra plumbing.
+- **Integration coverage:** U3's `partial_ratio_alignment` integration
+  test guards the U1↔U3 contract; U4's apply method test guards
+  U3↔U4 contract.
+- **Unchanged invariants:** existing sequencers, `SequenceClip` schema,
+  timeline `add_clip_to_track` contract, transcribe analysis pipeline,
+  and `ALGORITHM_CONFIG`'s shape are all preserved.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| `partial_ratio` produces unintuitive scores on very short phrases (e.g., "hi" matches almost everything). | Document in the user guide that 2–3-word phrases work best; consider an opt-in min-phrase-length warning in v2. |
+| Long transcript segments inflate score variance and make highlights span most of the visible text. | Highlight-only rendering (no truncation) + per-match toggle let users prune; v2 can revisit truncation-with-expand. |
+| `QThread` worker reuse triggers duplicate signal connections (see `pyside6-duplicate-signal-guard` learning). | Instantiate a fresh worker per Find-Matches click; do not store the worker on the dialog beyond one run. |
+| Signal name `finished` would shadow `QThread.finished`. | Use `matches_ready` for the worker, `sequence_ready` for the dialog (see `pyside6-qthread-finished-signal-shadowing` learning). |
+| Float→frame conversion can produce a 1-frame gap or overlap if `start_time`/`end_time` aren't aligned with frame boundaries. | Use `round()` consistently for both bounds; tests cover the 0.0 and mid-frame edge cases. |
+| User pastes hundreds of phrases. | The matching loop is O(phrases × candidates × short-string-cost) — fast, but the review screen could become unwieldy. v1 documents the practical limit (~10 phrases) in the user guide; no hard cap. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `docs/user-guide/sequencers.md` (U5).
+- Optional: add a `docs/solutions/` learning if the
+  `partial_ratio_alignment` highlight integration uncovers anything
+  surprising during U3 implementation.
+- No migration, monitoring, or rollout concerns — feature is purely
+  additive and project-local.
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-27-cassette-tape-sequencer-requirements.md`
+- Related code:
+  - `core/remix/signature_style.py` (sub-clip in/out emission)
+  - `ui/dialogs/storyteller_dialog.py` (multi-step dialog pattern)
+  - `core/transcription.py:239` (TranscriptSegment shape)
+  - `models/clip.py:227` (Clip.transcript)
+  - `ui/tabs/sequence_tab.py:1290-1325` (apply pattern)
+  - `ui/algorithm_config.py` (registration shape)
+- Related skills:
+  - `wire-sequencer-algorithm`
+  - `pyside6-qthread-finished-signal-shadowing`
+  - `pyside6-duplicate-signal-guard`
+  - `sync-sequencer-docs`

--- a/docs/user-guide/sequencers.md
+++ b/docs/user-guide/sequencers.md
@@ -322,3 +322,24 @@ Build a sequence one clip at a time with an LLM collaborator. The algorithm open
 Embeddings power a local candidate shortlist so the LLM only sees the most similar clips at each step — this keeps prompts small and responses fast. Without embeddings the algorithm falls back to random sampling, which degrades proposal quality. Each accepted transition is saved as a rationale on the resulting SequenceClip, visible in exported SRTs.
 
 Requires a cloud LLM API key.
+
+### Cassette Tape
+
+Find clips that say specific phrases — the transcript-driven mixtape. This is a quote-finder: you supply a list of phrases and Cassette Tape pulls the closest matches from your transcribed clips, returning a sequence of sub-clips trimmed to just the lines that matched.
+
+**Required analysis:** Transcribe (speech transcription with per-segment timing)
+
+**Dialog workflow:**
+
+1. **Setup.** Enter one phrase per row. The slider next to each phrase sets how many matches to pull (1–5). Add or remove rows as needed. Click **Find Matches**.
+2. **Review.** Cassette Tape scores every transcript segment in the project against each phrase and groups the top matches under their phrase. Each match shows the source clip, the matched transcript snippet (with the matching words highlighted), and a 0–100 confidence score (green ≥ 80, yellow 50–79, red < 50). Toggle any match off to exclude it.
+3. **Generate.** The remaining matches are assembled into a sequence in phrase order, with each clip trimmed to just the matched transcript segment.
+
+**Tips:**
+
+- Short, distinct phrases (3–6 words) work best. Two-word phrases like "thank you" tend to match too broadly.
+- The slider controls *how many* matches per phrase, not how strict the matching is. Quality control happens on the review screen.
+- Clips without transcripts are silently excluded. If the project has no transcribed clips, the dialog will tell you to run **Analyze → Transcribe** first.
+- Disabled clips are excluded automatically.
+
+Cassette Tape uses local string-similarity matching (RapidFuzz `partial_ratio`). It does not require a cloud API key.

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -10,6 +10,7 @@ opencv-python>=4.8
 numpy>=1.24
 scikit-learn>=1.3
 Pillow>=10.0
+rapidfuzz>=3.0.0
 google-api-python-client>=2.100.0
 keyring>=24.0
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -25,7 +25,6 @@ ultralytics>=8.4.0,<9
 
 # OCR / Text Extraction
 paddleocr>=3.0.0,<4
-rapidfuzz>=3.0.0
 
 # Audio Analysis
 librosa>=0.10.0,<1.0

--- a/tests/test_algorithm_config.py
+++ b/tests/test_algorithm_config.py
@@ -35,4 +35,4 @@ def test_multi_tagged_algorithms():
 
 
 def test_algorithm_count():
-    assert len(ALGORITHM_CONFIG) == 20
+    assert len(ALGORITHM_CONFIG) == 21

--- a/tests/test_build_support.py
+++ b/tests/test_build_support.py
@@ -152,9 +152,10 @@ def test_core_requirement_distributions_follow_requirements_file(tmp_path):
     assert "opencv-python" in distributions
     assert "google-api-python-client" in distributions
     assert "pyside6" in distributions
-    # paddleocr and rapidfuzz are optional (on-demand), not core
+    # rapidfuzz is required by the Cassette Tape sequencer (core)
+    assert "rapidfuzz" in distributions
+    # paddleocr is optional (on-demand)
     assert "paddleocr" not in distributions
-    assert "rapidfuzz" not in distributions
 
 
 def test_core_requirement_distributions_support_direct_reference_requirements(tmp_path):
@@ -211,9 +212,10 @@ def test_core_pyinstaller_collect_targets_cover_packaged_runtime_dependencies(tm
     assert "cv2" in targets
     assert "numpy" in targets
     assert "mpv" in targets
-    # paddleocr/rapidfuzz are in requirements-core-macos.txt, not core
+    # rapidfuzz is required by the Cassette Tape sequencer (core)
+    assert "rapidfuzz" in targets
+    # paddleocr is optional (on-demand)
     assert "paddleocr" not in targets
-    assert "rapidfuzz" not in targets
 
 
 def test_core_pyinstaller_metadata_covers_core_requirements(tmp_path):

--- a/tests/test_cassette_tape.py
+++ b/tests/test_cassette_tape.py
@@ -67,6 +67,17 @@ class TestScorePhraseAgainstSegment:
         )
         assert score < 60
 
+    def test_alignment_indices_map_into_original_case_text(self):
+        """rapidfuzz alignment must return indices into the ORIGINAL text,
+        not the lowercased copy — otherwise Unicode chars whose lowercase
+        form has a different length (Turkish dotted-I, German ß casefold,
+        etc.) shift the highlight."""
+        text = "Welcome to İstanbul tonight"
+        score, start, end = _score_phrase_against_segment("istanbul", text)
+        assert score >= 80
+        # The highlighted span must contain the (case-preserved) word.
+        assert "İstanbul" in text[start:end]
+
 
 class TestMatchPhrasesHappyPaths:
     def test_phrase_thank_you_finds_match(self):

--- a/tests/test_cassette_tape.py
+++ b/tests/test_cassette_tape.py
@@ -1,0 +1,231 @@
+"""Unit tests for the Cassette Tape matching module."""
+
+from pathlib import Path
+
+import pytest
+
+from core.remix.cassette_tape import (
+    MatchResult,
+    _score_phrase_against_segment,
+    build_sequence_data,
+    flatten_matches_in_phrase_order,
+    match_phrases,
+)
+from core.transcription import TranscriptSegment
+from models.clip import Clip, Source
+
+
+def _seg(start: float, end: float, text: str) -> TranscriptSegment:
+    return TranscriptSegment(start_time=start, end_time=end, text=text)
+
+
+def _clip(clip_id: str, source_id: str, transcript: list[TranscriptSegment] | None,
+          *, disabled: bool = False) -> Clip:
+    return Clip(
+        id=clip_id,
+        source_id=source_id,
+        start_frame=0,
+        end_frame=900,  # 30s @ 30fps
+        transcript=transcript,
+        disabled=disabled,
+    )
+
+
+def _source(source_id: str = "src1", fps: float = 30.0) -> Source:
+    return Source(
+        id=source_id,
+        file_path=Path(f"/test/{source_id}.mp4"),
+        duration_seconds=60.0,
+        fps=fps,
+        width=1920,
+        height=1080,
+    )
+
+
+class TestScorePhraseAgainstSegment:
+    def test_phrase_inside_longer_segment_scores_high(self):
+        score, start, end = _score_phrase_against_segment(
+            "thank you", "well thank you for coming today"
+        )
+        assert score >= 90
+        assert start != -1 and end != -1
+        assert "thank you" in "well thank you for coming today"[start:end].lower()
+
+    def test_case_insensitive(self):
+        score_a, _, _ = _score_phrase_against_segment("HELLO", "hello world")
+        score_b, _, _ = _score_phrase_against_segment("hello", "HELLO WORLD")
+        assert score_a >= 90
+        assert score_b >= 90
+
+    def test_empty_inputs_score_zero(self):
+        assert _score_phrase_against_segment("", "anything") == (0, -1, -1)
+        assert _score_phrase_against_segment("anything", "") == (0, -1, -1)
+
+    def test_unrelated_phrase_scores_low(self):
+        score, _, _ = _score_phrase_against_segment(
+            "purple zebra spaceship", "and then we went to the store"
+        )
+        assert score < 60
+
+
+class TestMatchPhrasesHappyPaths:
+    def test_phrase_thank_you_finds_match(self):
+        clip = _clip("c1", "src1", [_seg(0.0, 2.0, "well thank you for coming")])
+        results = match_phrases([("thank you", 1)], [clip])
+        assert "thank you" in results
+        assert len(results["thank you"]) == 1
+        match = results["thank you"][0]
+        assert match.clip_id == "c1"
+        assert match.score >= 90
+        assert match.match_start >= 0 and match.match_end > match.match_start
+
+    def test_top_n_picks_best_scoring_pairs(self):
+        c1 = _clip("c1", "s", [_seg(0.0, 2.0, "I love you so much")])
+        c2 = _clip("c2", "s", [_seg(0.0, 2.0, "I love you")])
+        c3 = _clip("c3", "s", [_seg(0.0, 2.0, "she loves him")])
+        results = match_phrases([("I love you", 2)], [c1, c2, c3])
+        matches = results["I love you"]
+        assert len(matches) == 2
+        # Best two should be c1 and c2 (both contain "I love you" exactly)
+        clip_ids = {m.clip_id for m in matches}
+        assert "c3" not in clip_ids
+        # First match's score >= second match's score
+        assert matches[0].score >= matches[1].score
+
+
+class TestMatchPhrasesEdgeCases:
+    def test_clip_without_transcript_is_excluded(self):
+        c1 = _clip("c1", "s", None)
+        c2 = _clip("c2", "s", [_seg(0.0, 2.0, "thank you very much")])
+        results = match_phrases([("thank you", 5)], [c1, c2])
+        assert len(results["thank you"]) == 1
+        assert results["thank you"][0].clip_id == "c2"
+
+    def test_disabled_clip_is_excluded(self):
+        c1 = _clip("c1", "s", [_seg(0.0, 2.0, "thank you")], disabled=True)
+        c2 = _clip("c2", "s", [_seg(0.0, 2.0, "thank you")])
+        results = match_phrases([("thank you", 5)], [c1, c2])
+        assert {m.clip_id for m in results["thank you"]} == {"c2"}
+
+    def test_no_threshold_returns_top_n_even_with_bad_matches(self):
+        # Phrase has no good match — should still return up to N picks
+        c1 = _clip("c1", "s", [_seg(0.0, 1.0, "hello")])
+        results = match_phrases([("intergalactic warfare", 3)], [c1])
+        # 1 candidate exists, count=3 → returns 1 (no padding)
+        assert len(results["intergalactic warfare"]) == 1
+
+    def test_count_exceeds_available_returns_all_without_padding(self):
+        c1 = _clip("c1", "s", [_seg(0.0, 1.0, "alpha bravo")])
+        c2 = _clip("c2", "s", [_seg(0.0, 1.0, "alpha charlie")])
+        results = match_phrases([("alpha", 5)], [c1, c2])
+        assert len(results["alpha"]) == 2
+
+    def test_empty_phrase_is_skipped(self):
+        c1 = _clip("c1", "s", [_seg(0.0, 1.0, "hello world")])
+        results = match_phrases([("", 3), ("hello", 3)], [c1])
+        assert "" not in results
+        assert "hello" in results
+
+    def test_zero_count_phrase_is_skipped(self):
+        c1 = _clip("c1", "s", [_seg(0.0, 1.0, "hello world")])
+        results = match_phrases([("hello", 0)], [c1])
+        assert results == {}
+
+    def test_empty_segment_text_is_excluded(self):
+        c1 = _clip("c1", "s", [_seg(0.0, 1.0, ""), _seg(1.0, 2.0, "   ")])
+        c2 = _clip("c2", "s", [_seg(0.0, 1.0, "thank you")])
+        results = match_phrases([("thank you", 5)], [c1, c2])
+        assert len(results["thank you"]) == 1
+        assert results["thank you"][0].clip_id == "c2"
+
+    def test_tie_break_is_deterministic_across_runs(self):
+        # Two identical-scoring segments, one earlier in clip order, one earlier in time
+        c1 = _clip("c1", "s", [_seg(2.0, 3.0, "thank you")])
+        c2 = _clip("c2", "s", [_seg(0.5, 1.5, "thank you")])
+        # Run twice; same order both times
+        r1 = match_phrases([("thank you", 2)], [c1, c2])["thank you"]
+        r2 = match_phrases([("thank you", 2)], [c1, c2])["thank you"]
+        assert [m.clip_id for m in r1] == [m.clip_id for m in r2]
+        # Tie-break: earlier segment.start_time wins → c2 first
+        assert r1[0].clip_id == "c2"
+        assert r1[1].clip_id == "c1"
+
+    def test_phrase_order_preserved_in_results(self):
+        c1 = _clip("c1", "s", [_seg(0.0, 1.0, "alpha bravo charlie")])
+        results = match_phrases([("charlie", 1), ("alpha", 1), ("bravo", 1)], [c1])
+        assert list(results.keys()) == ["charlie", "alpha", "bravo"]
+
+
+class TestBuildSequenceData:
+    def test_seconds_to_frames_conversion(self):
+        clip = _clip("c1", "src1", [_seg(2.5, 3.5, "thank you")])
+        source = _source("src1", fps=24.0)
+        match = MatchResult(
+            phrase="thank you",
+            clip_id="c1",
+            segment_index=0,
+            segment=clip.transcript[0],
+            score=95,
+            match_start=0,
+            match_end=9,
+        )
+        result = build_sequence_data([match], {"c1": clip}, {"src1": source})
+        assert len(result) == 1
+        ret_clip, ret_source, in_frame, out_frame = result[0]
+        assert ret_clip is clip
+        assert ret_source is source
+        assert in_frame == 60   # 2.5 * 24
+        assert out_frame == 84  # 3.5 * 24
+
+    def test_segment_starting_at_zero(self):
+        clip = _clip("c1", "src1", [_seg(0.0, 1.0, "hi")])
+        source = _source("src1", fps=30.0)
+        match = MatchResult(
+            phrase="hi", clip_id="c1", segment_index=0,
+            segment=clip.transcript[0], score=100, match_start=0, match_end=2,
+        )
+        result = build_sequence_data([match], {"c1": clip}, {"src1": source})
+        assert result[0][2] == 0
+        assert result[0][3] == 30
+
+    def test_zero_duration_segment_pads_to_one_frame(self):
+        clip = _clip("c1", "src1", [_seg(1.0, 1.0, "hi")])
+        source = _source("src1", fps=30.0)
+        match = MatchResult(
+            phrase="hi", clip_id="c1", segment_index=0,
+            segment=clip.transcript[0], score=100, match_start=0, match_end=2,
+        )
+        result = build_sequence_data([match], {"c1": clip}, {"src1": source})
+        in_frame, out_frame = result[0][2], result[0][3]
+        assert out_frame == in_frame + 1
+
+    def test_missing_clip_or_source_drops_match_with_warning(self, caplog):
+        # match references c2, but c2 not in lookup
+        match = MatchResult(
+            phrase="x", clip_id="c2", segment_index=0,
+            segment=_seg(0.0, 1.0, "x"), score=50, match_start=-1, match_end=-1,
+        )
+        result = build_sequence_data([match], {}, {})
+        assert result == []
+
+
+class TestFlattenMatchesInPhraseOrder:
+    def test_preserves_phrase_order_and_score_order(self):
+        m1 = MatchResult("a", "c1", 0, _seg(0, 1, "a1"), 90, 0, 1)
+        m2 = MatchResult("a", "c1", 1, _seg(1, 2, "a2"), 80, 0, 2)
+        m3 = MatchResult("b", "c2", 0, _seg(0, 1, "b1"), 95, 0, 2)
+        flat = flatten_matches_in_phrase_order({"a": [m1, m2], "b": [m3]})
+        assert flat == [m1, m2, m3]
+
+    def test_enabled_keys_filters_out_disabled(self):
+        m1 = MatchResult("a", "c1", 0, _seg(0, 1, "a1"), 90, 0, 1)
+        m2 = MatchResult("a", "c1", 1, _seg(1, 2, "a2"), 80, 0, 2)
+        # Only m1 is enabled
+        enabled = {("a", "c1", 0)}
+        flat = flatten_matches_in_phrase_order({"a": [m1, m2]}, enabled_keys=enabled)
+        assert flat == [m1]
+
+    def test_empty_enabled_set_yields_empty_list(self):
+        m1 = MatchResult("a", "c1", 0, _seg(0, 1, "a1"), 90, 0, 1)
+        flat = flatten_matches_in_phrase_order({"a": [m1]}, enabled_keys=set())
+        assert flat == []

--- a/tests/test_cassette_tape.py
+++ b/tests/test_cassette_tape.py
@@ -78,6 +78,47 @@ class TestScorePhraseAgainstSegment:
         # The highlighted span must contain the (case-preserved) word.
         assert "İstanbul" in text[start:end]
 
+    def test_short_segment_does_not_score_100_against_long_phrase(self):
+        """Regression for the asymmetric-partial_ratio bug. partial_ratio
+        aligns the shorter string against substrings of the longer; a
+        1-char segment like 'I' would score 100 against any phrase
+        containing 'I'. After the length-branch fix, short segments get
+        whole-string ratio scoring (length-penalized) so they can't fake
+        a perfect match."""
+        score, _, _ = _score_phrase_against_segment("I love you", "I")
+        assert score < 50, f"single-char segment should not score 100 (got {score})"
+
+    def test_single_char_a_does_not_match_long_phrase(self):
+        score, _, _ = _score_phrase_against_segment("thank you very much", "a")
+        # 'a' is below the noise floor, hard-zeroed.
+        assert score == 0
+
+    def test_noise_floor_drops_two_char_segments(self):
+        """Segments under 3 chars are forced to score 0 — Whisper
+        artifacts like single letters or punctuation should not surface
+        as matches."""
+        for noisy in ["a", ".", "uh", "I"]:
+            score, _, _ = _score_phrase_against_segment("hello world", noisy)
+            assert score == 0, f"noise '{noisy}' scored {score}, expected 0"
+
+    def test_segment_just_under_phrase_length_uses_ratio(self):
+        """When segment is shorter than phrase but still substantive,
+        ratio is used (not partial_ratio). Score should be high but not
+        the inflated 100 partial_ratio would have given."""
+        # phrase 13 chars, segment 9 chars, both meaningful
+        score, _, _ = _score_phrase_against_segment("hello there mate", "hello there")
+        # ratio gives length-penalized score, partial_ratio would give 100
+        assert 50 <= score < 100
+
+    def test_segment_longer_than_phrase_still_uses_partial_ratio(self):
+        """Don't regress the original behavior: phrase-inside-longer-segment
+        still scores 100."""
+        score, start, end = _score_phrase_against_segment(
+            "thank you", "well thank you for coming today"
+        )
+        assert score >= 95
+        assert start >= 0 and end > start
+
 
 class TestMatchPhrasesHappyPaths:
     def test_phrase_thank_you_finds_match(self):

--- a/tests/test_cassette_tape_dialog.py
+++ b/tests/test_cassette_tape_dialog.py
@@ -179,6 +179,62 @@ class TestProgressPageAndWorkerFlow:
         assert "rapidfuzz blew up" in args[2]
 
 
+class TestPhraseOrderPreservation:
+    """Regression for the dict→QVariantMap reordering bug.
+
+    PySide6 marshals dicts across thread-boundary signals as QVariantMap
+    (a QMap, sorted alphabetically by key). The worker must emit a list
+    of tuples to preserve user-entered phrase order on the review screen.
+    """
+
+    def test_worker_emits_list_not_dict(self, qapp):
+        # The matches_ready signal must be Signal(list), not Signal(dict),
+        # so cross-thread queued connections don't silently sort by key.
+        from ui.dialogs.cassette_tape_dialog import CassetteTapeWorker
+        worker = CassetteTapeWorker(phrases_with_counts=[], clips=[])
+        # Trigger run() and capture the emit. We patch match_phrases to
+        # return phrases in non-alphabetical order ("sorry", "rescue", "search")
+        # and assert the emitted list preserves that order.
+        from unittest.mock import patch
+        captured = []
+        worker.matches_ready.connect(lambda r: captured.append(r))
+        ordered_dict = {"sorry": [], "rescue": [], "search": []}
+        with patch("ui.dialogs.cassette_tape_dialog.match_phrases", return_value=ordered_dict):
+            worker.run()
+        assert len(captured) == 1
+        result = captured[0]
+        # Must be a list of (phrase, matches) tuples, not a dict.
+        assert isinstance(result, list), f"expected list payload, got {type(result).__name__}"
+        keys_in_order = [phrase for phrase, _ in result]
+        assert keys_in_order == ["sorry", "rescue", "search"], (
+            f"phrase order not preserved across signal: {keys_in_order}"
+        )
+
+    def test_dialog_preserves_user_order_in_review(self, qapp, transcribed_project):
+        """End-to-end: typing 'sorry', 'rescue', 'search' in three rows and
+        running matches places them in that order on the review page."""
+        clips, _, _ = transcribed_project
+        dialog = _make_dialog(qapp, transcribed_project)
+        dialog.phrase_rows[0].line_edit.setText("sorry")
+        dialog.phrase_rows[1].line_edit.setText("rescue")
+        dialog.phrase_rows[2].line_edit.setText("search")
+
+        # Build a results payload in user order
+        match_for = lambda phrase: MatchResult(
+            phrase=phrase, clip_id="c1", segment_index=0,
+            segment=clips[0].transcript[0], score=80, match_start=0, match_end=5,
+        )
+        ordered_results = [
+            ("sorry", [match_for("sorry")]),
+            ("rescue", [match_for("rescue")]),
+            ("search", [match_for("search")]),
+        ]
+        dialog._on_matches_ready(ordered_results)
+
+        # matches_by_phrase preserves order via dict insertion semantics
+        assert list(dialog.matches_by_phrase.keys()) == ["sorry", "rescue", "search"]
+
+
 class TestCancellation:
     def test_match_phrases_aborts_when_is_cancelled_returns_true(self, qapp, transcribed_project):
         # match_phrases checks the cancel flag between phrases and returns {}.

--- a/tests/test_cassette_tape_dialog.py
+++ b/tests/test_cassette_tape_dialog.py
@@ -149,9 +149,53 @@ class TestProgressPageAndWorkerFlow:
 
     def test_match_error_returns_to_setup(self, qapp, transcribed_project):
         dialog = _make_dialog(qapp, transcribed_project)
-        dialog._on_match_error("rapidfuzz blew up")
+        with patch("ui.dialogs.cassette_tape_dialog.QMessageBox.warning") as warn:
+            dialog._on_match_error("rapidfuzz blew up")
         assert dialog.stack.currentIndex() == dialog.PAGE_SETUP
-        assert "rapidfuzz" in dialog.progress_status.text()
+        # Error surfaces via QMessageBox, not the hidden progress page label.
+        assert warn.called
+        args = warn.call_args.args
+        assert "rapidfuzz blew up" in args[2]
+
+
+class TestCancellation:
+    def test_match_phrases_aborts_when_is_cancelled_returns_true(self, qapp, transcribed_project):
+        # match_phrases checks the cancel flag between phrases and returns {}.
+        from core.remix.cassette_tape import match_phrases
+        clips, _, _ = transcribed_project
+        cancelled = {"flag": True}
+        result = match_phrases(
+            [("thank you", 1), ("hello", 1)],
+            clips,
+            is_cancelled=lambda: cancelled["flag"],
+        )
+        assert result == {}
+
+    def test_cancel_during_progress_disconnects_signals_and_clears_worker(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        dialog.phrase_rows[0].line_edit.setText("thank you")
+        with patch("ui.dialogs.cassette_tape_dialog.CassetteTapeWorker.start"):
+            dialog._on_next()
+        # Worker is alive but not running (start patched). Force isRunning to True.
+        with patch.object(dialog.worker, "isRunning", return_value=True), \
+             patch.object(dialog.worker, "wait") as wait_call, \
+             patch.object(dialog.worker, "quit") as quit_call:
+            dialog._stop_worker_if_running()
+        wait_call.assert_called_once_with()  # unbounded
+        quit_call.assert_called_once()
+        assert dialog.worker is None
+
+    def test_close_event_stops_worker(self, qapp, transcribed_project):
+        from PySide6.QtGui import QCloseEvent
+        dialog = _make_dialog(qapp, transcribed_project)
+        dialog.phrase_rows[0].line_edit.setText("thank you")
+        with patch("ui.dialogs.cassette_tape_dialog.CassetteTapeWorker.start"):
+            dialog._on_next()
+        called = {"stop": 0}
+        with patch.object(dialog, "_stop_worker_if_running",
+                          side_effect=lambda: called.update(stop=called["stop"] + 1)):
+            dialog.closeEvent(QCloseEvent())
+        assert called["stop"] == 1
 
 
 class TestReviewPage:

--- a/tests/test_cassette_tape_dialog.py
+++ b/tests/test_cassette_tape_dialog.py
@@ -128,18 +128,18 @@ class TestSetupPage:
         dialog.phrase_rows[1].slider.setValue(5)
         dialog.phrase_rows[2].line_edit.setText("hello")
         dialog.phrase_rows[2].slider.setValue(1)
-        result = dialog._phrases_with_counts()
+        entries, had_dups = dialog._collect_phrase_entries()
         # First-occurrence original-case spelling preserved; counts merged via max.
-        assert result == [("thank you", 5), ("hello", 1)]
-        assert dialog._has_duplicate_phrase_rows() is True
+        assert entries == [("thank you", 5), ("hello", 1)]
+        assert had_dups is True
 
     def test_no_duplicates_returns_each_row(self, qapp, transcribed_project):
         dialog = _make_dialog(qapp, transcribed_project)
         dialog.phrase_rows[0].line_edit.setText("alpha")
         dialog.phrase_rows[1].line_edit.setText("bravo")
-        assert dialog._has_duplicate_phrase_rows() is False
-        result = dialog._phrases_with_counts()
-        assert {p for p, _ in result} == {"alpha", "bravo"}
+        entries, had_dups = dialog._collect_phrase_entries()
+        assert had_dups is False
+        assert {p for p, _ in entries} == {"alpha", "bravo"}
 
 
 class TestProgressPageAndWorkerFlow:

--- a/tests/test_cassette_tape_dialog.py
+++ b/tests/test_cassette_tape_dialog.py
@@ -1,0 +1,260 @@
+"""Tests for the CassetteTapeDialog state transitions and emitted signals.
+
+These tests focus on the dialog's UX contract — page navigation, button
+enablement, signal emission shapes — rather than the matching algorithm
+itself (covered in tests/test_cassette_tape.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from core.remix.cassette_tape import MatchResult
+from core.transcription import TranscriptSegment
+from models.clip import Clip, Source
+
+
+@pytest.fixture
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _seg(start: float, end: float, text: str) -> TranscriptSegment:
+    return TranscriptSegment(start_time=start, end_time=end, text=text)
+
+
+def _make_clip(clip_id: str, source_id: str, segments) -> Clip:
+    return Clip(
+        id=clip_id,
+        source_id=source_id,
+        start_frame=0,
+        end_frame=900,
+        transcript=segments,
+    )
+
+
+def _make_source(source_id: str = "s1", fps: float = 30.0) -> Source:
+    return Source(
+        id=source_id,
+        file_path=Path(f"/test/{source_id}.mp4"),
+        duration_seconds=60.0,
+        fps=fps,
+        width=1920,
+        height=1080,
+    )
+
+
+@pytest.fixture
+def transcribed_project(qapp):
+    """A small project with two transcribed clips."""
+    src = _make_source("s1")
+    c1 = _make_clip("c1", "s1", [
+        _seg(0.0, 1.5, "well thank you for coming today"),
+        _seg(1.5, 3.0, "I really appreciate it"),
+    ])
+    c2 = _make_clip("c2", "s1", [_seg(0.0, 2.0, "thank you very much")])
+    return [c1, c2], {"s1": src}, None  # (clips, sources_by_id, project)
+
+
+@pytest.fixture
+def empty_project(qapp):
+    """A project with no transcribed clips."""
+    src = _make_source("s1")
+    c1 = Clip(id="c1", source_id="s1", start_frame=0, end_frame=900, transcript=None)
+    return [c1], {"s1": src}, None
+
+
+def _make_dialog(qapp, project_data):
+    from ui.dialogs.cassette_tape_dialog import CassetteTapeDialog
+    clips, sources, project = project_data
+    return CassetteTapeDialog(clips=clips, sources_by_id=sources, project=project)
+
+
+class TestSetupPage:
+    def test_initializes_with_three_empty_phrase_rows(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        assert len(dialog.phrase_rows) == 3
+        assert all(r.phrase() == "" for r in dialog.phrase_rows)
+
+    def test_find_matches_disabled_until_phrase_entered(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        assert dialog.next_btn.isEnabled() is False
+        # Type in the first row
+        dialog.phrase_rows[0].line_edit.setText("thank you")
+        assert dialog.next_btn.isEnabled() is True
+
+    def test_no_transcripts_disables_find_matches_with_warning(self, qapp, empty_project):
+        dialog = _make_dialog(qapp, empty_project)
+        assert dialog._setup_no_transcripts is True
+        # Even with phrase typed, button stays disabled
+        dialog.phrase_rows[0].line_edit.setText("thank you")
+        assert dialog.next_btn.isEnabled() is False
+
+    def test_add_phrase_row_increases_count(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        before = len(dialog.phrase_rows)
+        dialog._add_phrase_row()
+        assert len(dialog.phrase_rows) == before + 1
+
+    def test_remove_phrase_row_decreases_count(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        row = dialog.phrase_rows[0]
+        before = len(dialog.phrase_rows)
+        dialog._remove_phrase_row(row)
+        assert len(dialog.phrase_rows) == before - 1
+
+    def test_phrases_with_counts_skips_empty_rows(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        dialog.phrase_rows[0].line_edit.setText("thank you")
+        dialog.phrase_rows[1].slider.setValue(2)  # but no phrase text
+        dialog.phrase_rows[2].line_edit.setText("hello")
+        dialog.phrase_rows[2].slider.setValue(4)
+        result = dialog._phrases_with_counts()
+        assert result == [("thank you", 3), ("hello", 4)]
+
+
+class TestProgressPageAndWorkerFlow:
+    def test_clicking_find_matches_advances_to_progress(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        dialog.phrase_rows[0].line_edit.setText("thank you")
+
+        # Patch worker.start so it doesn't actually run a thread
+        with patch("ui.dialogs.cassette_tape_dialog.CassetteTapeWorker.start"):
+            dialog._on_next()
+
+        assert dialog.stack.currentIndex() == dialog.PAGE_PROGRESS
+        assert dialog.next_btn.text() == "Please wait…"
+        assert dialog.next_btn.isEnabled() is False
+
+    def test_matches_ready_advances_to_review(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        clips, _, _ = transcribed_project
+        match = MatchResult(
+            phrase="thank you", clip_id="c1", segment_index=0,
+            segment=clips[0].transcript[0], score=92, match_start=5, match_end=14,
+        )
+        dialog._on_matches_ready({"thank you": [match]})
+        assert dialog.stack.currentIndex() == dialog.PAGE_REVIEW
+        assert dialog.next_btn.text() == "Generate Sequence"
+        assert dialog.next_btn.isEnabled() is True
+        assert len(dialog._match_rows) == 1
+
+    def test_match_error_returns_to_setup(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        dialog._on_match_error("rapidfuzz blew up")
+        assert dialog.stack.currentIndex() == dialog.PAGE_SETUP
+        assert "rapidfuzz" in dialog.progress_status.text()
+
+
+class TestReviewPage:
+    def _populate(self, dialog, clips, n=2):
+        match1 = MatchResult(
+            phrase="thank you", clip_id="c1", segment_index=0,
+            segment=clips[0].transcript[0], score=92, match_start=5, match_end=14,
+        )
+        match2 = MatchResult(
+            phrase="thank you", clip_id="c2", segment_index=0,
+            segment=clips[1].transcript[0], score=88, match_start=0, match_end=9,
+        )
+        dialog._on_matches_ready({"thank you": [match1, match2][:n]})
+
+    def test_all_matches_default_enabled(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        clips, _, _ = transcribed_project
+        self._populate(dialog, clips, n=2)
+        assert all(r.is_enabled() for r in dialog._match_rows)
+
+    def test_toggling_all_off_disables_generate(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        clips, _, _ = transcribed_project
+        self._populate(dialog, clips, n=2)
+        for row in dialog._match_rows:
+            row.checkbox.setChecked(False)
+        assert dialog.next_btn.isEnabled() is False
+
+    def test_back_returns_to_setup(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        clips, _, _ = transcribed_project
+        self._populate(dialog, clips, n=1)
+        dialog._on_back()
+        assert dialog.stack.currentIndex() == dialog.PAGE_SETUP
+
+
+class TestSequenceReadyEmission:
+    def test_generate_emits_sequence_ready_with_4_tuples(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        clips, sources, _ = transcribed_project
+        match = MatchResult(
+            phrase="thank you", clip_id="c1", segment_index=0,
+            segment=clips[0].transcript[0], score=92, match_start=5, match_end=14,
+        )
+        dialog._on_matches_ready({"thank you": [match]})
+
+        captured = []
+        dialog.sequence_ready.connect(lambda data: captured.append(data))
+        dialog._finish_with_sequence()
+
+        assert len(captured) == 1
+        seq = captured[0]
+        assert len(seq) == 1
+        ret_clip, ret_source, in_frame, out_frame = seq[0]
+        assert ret_clip.id == "c1"
+        assert ret_source.id == "s1"
+        # 0.0–1.5s @ 30fps → 0–45
+        assert in_frame == 0
+        assert out_frame == 45
+
+    def test_generate_filters_disabled_matches(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        clips, sources, _ = transcribed_project
+        match1 = MatchResult(
+            phrase="thank you", clip_id="c1", segment_index=0,
+            segment=clips[0].transcript[0], score=92, match_start=5, match_end=14,
+        )
+        match2 = MatchResult(
+            phrase="thank you", clip_id="c2", segment_index=0,
+            segment=clips[1].transcript[0], score=88, match_start=0, match_end=9,
+        )
+        dialog._on_matches_ready({"thank you": [match1, match2]})
+
+        # Disable the first match
+        dialog._match_rows[0].checkbox.setChecked(False)
+
+        captured = []
+        dialog.sequence_ready.connect(lambda data: captured.append(data))
+        dialog._finish_with_sequence()
+
+        assert len(captured) == 1
+        seq = captured[0]
+        assert len(seq) == 1
+        assert seq[0][0].id == "c2"
+
+
+class TestHighlightRendering:
+    def test_match_row_highlights_substring(self, qapp, transcribed_project):
+        from ui.dialogs.cassette_tape_dialog import _MatchRow
+
+        clips, _, _ = transcribed_project
+        match = MatchResult(
+            phrase="thank you", clip_id="c1", segment_index=0,
+            segment=clips[0].transcript[0], score=92, match_start=5, match_end=14,
+        )
+        row = _MatchRow(match, "Test Clip")
+        # Find the snippet QLabel by walking children
+        from PySide6.QtCore import Qt
+        from PySide6.QtWidgets import QLabel
+        snippet_labels = [w for w in row.findChildren(QLabel)
+                          if w.textFormat() == Qt.RichText]
+        assert snippet_labels, "expected at least one rich-text snippet label"
+        html = snippet_labels[0].text()
+        assert "<b" in html  # the matched substring is wrapped in <b>
+        # The exact matched text "thank you" should appear inside the bold
+        assert "thank you" in html

--- a/tests/test_cassette_tape_dialog.py
+++ b/tests/test_cassette_tape_dialog.py
@@ -120,6 +120,27 @@ class TestSetupPage:
         result = dialog._phrases_with_counts()
         assert result == [("thank you", 3), ("hello", 4)]
 
+    def test_duplicate_phrases_merge_with_max_count(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        dialog.phrase_rows[0].line_edit.setText("thank you")
+        dialog.phrase_rows[0].slider.setValue(2)
+        dialog.phrase_rows[1].line_edit.setText("Thank You")  # different case
+        dialog.phrase_rows[1].slider.setValue(5)
+        dialog.phrase_rows[2].line_edit.setText("hello")
+        dialog.phrase_rows[2].slider.setValue(1)
+        result = dialog._phrases_with_counts()
+        # First-occurrence original-case spelling preserved; counts merged via max.
+        assert result == [("thank you", 5), ("hello", 1)]
+        assert dialog._has_duplicate_phrase_rows() is True
+
+    def test_no_duplicates_returns_each_row(self, qapp, transcribed_project):
+        dialog = _make_dialog(qapp, transcribed_project)
+        dialog.phrase_rows[0].line_edit.setText("alpha")
+        dialog.phrase_rows[1].line_edit.setText("bravo")
+        assert dialog._has_duplicate_phrase_rows() is False
+        result = dialog._phrases_with_counts()
+        assert {p for p, _ in result} == {"alpha", "bravo"}
+
 
 class TestProgressPageAndWorkerFlow:
     def test_clicking_find_matches_advances_to_progress(self, qapp, transcribed_project):

--- a/tests/test_cassette_tape_integration.py
+++ b/tests/test_cassette_tape_integration.py
@@ -1,0 +1,122 @@
+"""Integration tests for Cassette Tape's apply path on SequenceTab.
+
+Covers the U3↔U4 contract: the dialog emits 4-tuples
+``(Clip, Source, in_frame, out_frame)`` and ``_apply_cassette_tape_sequence``
+must place the right number of sub-clips on the timeline at the correct
+frame offsets, with the algorithm key recorded on the sequence.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# SequenceTab contains video widgets — use offscreen for headless runs
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _make_source(source_id: str = "src-1", fps: float = 30.0):
+    from models.clip import Source
+
+    return Source(
+        id=source_id,
+        file_path=Path("/test/video.mp4"),
+        duration_seconds=60.0,
+        fps=fps,
+        width=1920,
+        height=1080,
+    )
+
+
+def _make_clip(clip_id: str, source_id: str = "src-1", *, start_frame: int = 0,
+               end_frame: int = 900):
+    from models.clip import Clip
+
+    return Clip(
+        id=clip_id,
+        source_id=source_id,
+        start_frame=start_frame,
+        end_frame=end_frame,
+    )
+
+
+class TestApplyCassetteTapeSequence:
+    def _make_tab(self, qapp):
+        from ui.tabs.sequence_tab import SequenceTab
+        tab = SequenceTab()
+        source = _make_source(fps=30.0)
+        tab._sources = {source.id: source}
+        tab.video_player = MagicMock()
+        tab.timeline_preview = MagicMock()
+        return tab, source
+
+    def test_three_subclips_create_three_timeline_clips_at_correct_offsets(self, qapp):
+        tab, source = self._make_tab(qapp)
+        clip = _make_clip("c1")
+
+        # Three sub-clips: 0-30, 60-90, 120-150 (all relative to clip.start_frame)
+        payload = [
+            (clip, source, 0, 30),
+            (clip, source, 60, 90),
+            (clip, source, 120, 150),
+        ]
+
+        tab._apply_cassette_tape_sequence(payload)
+
+        sequence = tab.timeline.get_sequence()
+        seq_clips = sequence.get_all_clips()
+        assert len(seq_clips) == 3
+
+        # in/out are clip.start_frame + offset (0 + offset here)
+        assert seq_clips[0].in_point == 0
+        assert seq_clips[0].out_point == 30
+        assert seq_clips[1].in_point == 60
+        assert seq_clips[1].out_point == 90
+        assert seq_clips[2].in_point == 120
+        assert seq_clips[2].out_point == 150
+
+        # Cumulative timeline placement: each clip starts where the previous ended.
+        # First sub-clip duration = 30, second starts at 30, etc.
+        assert seq_clips[0].start_frame == 0
+        assert seq_clips[1].start_frame == 30
+        assert seq_clips[2].start_frame == 60  # 30 + 30
+
+        assert sequence.algorithm == "cassette_tape"
+        assert sequence.allow_repeats is False
+
+    def test_apply_with_empty_payload_is_no_op(self, qapp):
+        tab, _ = self._make_tab(qapp)
+        # Should not raise
+        tab._apply_cassette_tape_sequence([])
+
+    def test_apply_sets_algorithm_dropdown_label(self, qapp):
+        tab, source = self._make_tab(qapp)
+        clip = _make_clip("c1")
+        tab._apply_cassette_tape_sequence([(clip, source, 0, 15)])
+        assert tab.algorithm_dropdown.currentText() == "Cassette Tape"
+        assert tab._current_algorithm == "cassette_tape"
+
+    def test_apply_with_zero_fps_falls_back_to_30(self, qapp):
+        from ui.tabs.sequence_tab import SequenceTab
+        tab = SequenceTab()
+        # Source with fps=0 (corrupted metadata)
+        bad_source = _make_source(fps=0.0)
+        tab._sources = {bad_source.id: bad_source}
+        tab.video_player = MagicMock()
+        tab.timeline_preview = MagicMock()
+        clip = _make_clip("c1")
+        # Should not raise (would divide-by-zero without the guard)
+        tab._apply_cassette_tape_sequence([(clip, bad_source, 0, 15)])
+        # Timeline fps was set to the fallback, not 0
+        assert tab.timeline.sequence.fps == 30.0

--- a/tests/test_export_logging.py
+++ b/tests/test_export_logging.py
@@ -46,6 +46,8 @@ def test_sequence_export_logs_concat_failure(monkeypatch, tmp_path, caplog):
         id="seq-1",
         is_frame_entry=False,
         source_clip_id="clip-1",
+        start_frame=0,
+        end_frame=lambda: 30,
         in_point=0,
         out_point=30,
         reverse=False,

--- a/tests/test_sorting_card_grid.py
+++ b/tests/test_sorting_card_grid.py
@@ -14,17 +14,18 @@ app = QApplication.instance() or QApplication(sys.argv)
 
 
 EXPECTED_COUNTS = {
-    "All": 20,
-    "Arrange": 9,
+    "All": 21,
+    "Arrange": 10,  # +1 for cassette_tape
     "Find": 4,
     "Connect": 6,  # +1 for free_association
-    "Audio": 3,
+    "Audio": 4,  # +1 for cassette_tape
     "Text": 3,  # +1 for free_association
 }
 
 ARRANGE_KEYS = {
     "shuffle", "sequential", "duration", "color",
     "brightness", "volume", "shot_type", "proximity", "gaze_sort",
+    "cassette_tape",
 }
 
 TEXT_KEYS = {"exquisite_corpus", "storyteller", "free_association"}
@@ -49,11 +50,11 @@ class TestCategoryFiltering:
         self.grid.set_category("All")
         assert _visible_keys(self.grid) == set(ALGORITHM_CONFIG.keys())
 
-    def test_arrange_shows_9_cards(self):
+    def test_arrange_shows_expected_cards(self):
         self.grid.set_category("Arrange")
         visible = _visible_keys(self.grid)
         assert visible == ARRANGE_KEYS
-        assert len(visible) == 9
+        assert len(visible) == 10
 
     def test_text_shows_2_cards(self):
         self.grid.set_category("Text")
@@ -88,7 +89,7 @@ class TestCategoryFiltering:
         self.grid.set_category("Text")
         assert len(_visible_keys(self.grid)) == 3
         self.grid.set_category("All")
-        assert len(_visible_keys(self.grid)) == 20
+        assert len(_visible_keys(self.grid)) == 21
 
     def test_selection_cleared_on_hidden_card(self):
         # Select a card in Arrange

--- a/ui/algorithm_config.py
+++ b/ui/algorithm_config.py
@@ -122,6 +122,15 @@ ALGORITHM_CONFIG = {
         "is_dialog": True,
         "categories": ["connect", "text"],
     },
+    "cassette_tape": {
+        "icon": "",
+        "label": "Cassette Tape",
+        "description": "Find clips that say specific phrases — the transcript-driven mixtape",
+        "allow_duplicates": False,
+        "required_analysis": ["transcribe"],
+        "is_dialog": True,
+        "categories": ["arrange", "audio"],
+    },
     "reference_guided": {
         "icon": "",
         "label": "Reference Guide",

--- a/ui/chat_worker.py
+++ b/ui/chat_worker.py
@@ -761,6 +761,7 @@ Available tools:
                 "gaze_sort": analysis_counts.get("gaze_category", 0) > 0,
                 "gaze_consistency": analysis_counts.get("gaze_category", 0) > 0,
                 "eyes_without_a_face": analysis_counts.get("gaze_category", 0) > 0,
+                "cassette_tape": any(c.transcript for c in self.project.clips),
             }
             # These always work (no analysis required)
             for a in ("duration", "shuffle", "sequential", "exquisite_corpus",

--- a/ui/dialogs/__init__.py
+++ b/ui/dialogs/__init__.py
@@ -12,6 +12,7 @@ from .dice_roll_dialog import DiceRollDialog
 from .staccato_dialog import StaccatoDialog
 from .eyes_without_a_face_dialog import EyesWithoutAFaceDialog
 from .free_association_dialog import FreeAssociationDialog
+from .cassette_tape_dialog import CassetteTapeDialog
 from .url_import_dialog import URLImportDialog
 
 __all__ = [
@@ -28,5 +29,6 @@ __all__ = [
     "StaccatoDialog",
     "EyesWithoutAFaceDialog",
     "FreeAssociationDialog",
+    "CassetteTapeDialog",
     "URLImportDialog",
 ]

--- a/ui/dialogs/cassette_tape_dialog.py
+++ b/ui/dialogs/cassette_tape_dialog.py
@@ -143,8 +143,8 @@ class _PhraseRow(QWidget):
         self.count_label.setAlignment(Qt.AlignCenter)
         layout.addWidget(self.count_label)
 
-        self.remove_btn = QPushButton("×")
-        self.remove_btn.setFixedSize(28, 28)
+        self.remove_btn = QPushButton("Remove")
+        self.remove_btn.setFixedHeight(UISizes.BUTTON_MIN_HEIGHT)
         self.remove_btn.setToolTip("Remove this phrase")
         self.remove_btn.clicked.connect(lambda: self.remove_requested.emit(self))
         layout.addWidget(self.remove_btn)
@@ -361,7 +361,9 @@ class CassetteTapeDialog(QDialog):
         ct_label = QLabel("Matches per phrase")
         ct_label.setFixedWidth(160)
         head_row.addWidget(ct_label)
-        head_row.addSpacing(34)  # Align with × buttons below
+        # The Remove button column has a flexible width; reserve enough
+        # right-padding so the column header doesn't crowd the count badge.
+        head_row.addSpacing(86)
         layout.addLayout(head_row)
 
         # Scrollable phrase list

--- a/ui/dialogs/cassette_tape_dialog.py
+++ b/ui/dialogs/cassette_tape_dialog.py
@@ -1,0 +1,597 @@
+"""Multi-step dialog for the Cassette Tape sequencer.
+
+Guides the user through:
+1. Phrase entry (text + per-phrase count slider 1-5)
+2. Background matching across transcribed clips
+3. Reviewing matches with confidence scores and a per-match toggle
+4. Generating the final sub-clip sequence
+
+Emits ``sequence_ready`` with a list of ``(Clip, Source, in_frame, out_frame)``
+tuples; ``in_frame`` / ``out_frame`` are relative to ``clip.start_frame``,
+matching the convention used by Signature Style.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from PySide6.QtCore import Qt, Signal, QThread
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QProgressBar,
+    QPushButton,
+    QScrollArea,
+    QSlider,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from core.remix.cassette_tape import MatchResult, match_phrases
+from ui.theme import UISizes, theme
+
+logger = logging.getLogger(__name__)
+
+
+# Confidence color thresholds
+CONFIDENCE_HIGH = 80
+CONFIDENCE_MID = 50
+
+# Slider range
+SLIDER_MIN = 1
+SLIDER_MAX = 5
+SLIDER_DEFAULT = 3
+DEFAULT_PHRASE_ROWS = 3
+
+
+class CassetteTapeWorker(QThread):
+    """Background worker that runs phrase matching off the UI thread."""
+
+    progress = Signal(int, int)  # (current, total)
+    matches_ready = Signal(dict)  # phrase -> [MatchResult]
+    error = Signal(str)
+
+    def __init__(self, phrases_with_counts: list[tuple[str, int]],
+                 clips: list, parent=None):
+        super().__init__(parent)
+        self.phrases_with_counts = phrases_with_counts
+        self.clips = clips
+        self._cancelled = False
+
+    def run(self):
+        try:
+            self.progress.emit(0, len(self.phrases_with_counts))
+            results = match_phrases(self.phrases_with_counts, self.clips)
+            if not self._cancelled:
+                self.matches_ready.emit(results)
+        except Exception as exc:
+            if not self._cancelled:
+                logger.exception("Cassette Tape matching failed")
+                self.error.emit(str(exc))
+
+    def cancel(self):
+        self._cancelled = True
+
+
+class _PhraseRow(QWidget):
+    """One phrase entry row: text input + count slider + remove button."""
+
+    text_changed = Signal()
+    remove_requested = Signal(QWidget)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        self.line_edit = QLineEdit()
+        self.line_edit.setMinimumHeight(UISizes.LINE_EDIT_MIN_HEIGHT)
+        self.line_edit.setPlaceholderText("Enter a phrase to find…")
+        self.line_edit.textChanged.connect(lambda _: self.text_changed.emit())
+        layout.addWidget(self.line_edit, 1)
+
+        self.slider = QSlider(Qt.Horizontal)
+        self.slider.setRange(SLIDER_MIN, SLIDER_MAX)
+        self.slider.setValue(SLIDER_DEFAULT)
+        self.slider.setTickInterval(1)
+        self.slider.setTickPosition(QSlider.TicksBelow)
+        self.slider.setFixedWidth(140)
+        self.slider.valueChanged.connect(self._on_slider_changed)
+        layout.addWidget(self.slider)
+
+        self.count_label = QLabel(str(SLIDER_DEFAULT))
+        self.count_label.setFixedWidth(20)
+        self.count_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.count_label)
+
+        self.remove_btn = QPushButton("×")
+        self.remove_btn.setFixedSize(28, 28)
+        self.remove_btn.setToolTip("Remove this phrase")
+        self.remove_btn.clicked.connect(lambda: self.remove_requested.emit(self))
+        layout.addWidget(self.remove_btn)
+
+    def _on_slider_changed(self, value: int):
+        self.count_label.setText(str(value))
+
+    def phrase(self) -> str:
+        return self.line_edit.text().strip()
+
+    def count(self) -> int:
+        return self.slider.value()
+
+
+class _MatchRow(QWidget):
+    """One match in the review screen: checkbox + snippet + score."""
+
+    def __init__(self, match: MatchResult, clip_name: str, parent=None):
+        super().__init__(parent)
+        self.match = match
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(8, 4, 8, 4)
+        layout.setSpacing(10)
+
+        self.checkbox = QCheckBox()
+        self.checkbox.setChecked(True)
+        self.checkbox.setToolTip("Include this match in the final sequence")
+        layout.addWidget(self.checkbox)
+
+        # Text body: clip name + segment snippet (matched substring highlighted)
+        body = QVBoxLayout()
+        body.setSpacing(2)
+
+        name_label = QLabel(clip_name)
+        name_font = QFont()
+        name_font.setBold(True)
+        name_label.setFont(name_font)
+        body.addWidget(name_label)
+
+        snippet_label = QLabel(self._build_snippet_html(match))
+        snippet_label.setTextFormat(Qt.RichText)
+        snippet_label.setWordWrap(True)
+        body.addWidget(snippet_label)
+
+        layout.addLayout(body, 1)
+
+        # Confidence score badge + bar
+        score_block = QVBoxLayout()
+        score_block.setSpacing(2)
+        score_label = QLabel(f"{match.score}")
+        score_label.setAlignment(Qt.AlignCenter)
+        score_label.setStyleSheet(
+            f"color: {self._score_color(match.score)}; font-weight: bold;"
+        )
+        score_label.setFixedWidth(40)
+        score_block.addWidget(score_label)
+
+        score_bar = QFrame()
+        score_bar.setFixedSize(40, 4)
+        score_bar.setStyleSheet(
+            f"background-color: {self._score_color(match.score)}; border-radius: 2px;"
+        )
+        score_block.addWidget(score_bar)
+        layout.addLayout(score_block)
+
+    @staticmethod
+    def _score_color(score: int) -> str:
+        t = theme()
+        if score >= CONFIDENCE_HIGH:
+            return getattr(t, "accent_green", "#5cb85c")
+        if score >= CONFIDENCE_MID:
+            return getattr(t, "accent_yellow", "#f0ad4e")
+        return getattr(t, "accent_red", "#d9534f")
+
+    @staticmethod
+    def _build_snippet_html(match: MatchResult) -> str:
+        """Render the segment text with the matched substring highlighted."""
+        text = match.segment.text or ""
+        start = match.match_start
+        end = match.match_end
+        if 0 <= start < end <= len(text):
+            before = _escape_html(text[:start])
+            hit = _escape_html(text[start:end])
+            after = _escape_html(text[end:])
+            return f'{before}<b style="color: {theme().accent_blue};">{hit}</b>{after}'
+        return _escape_html(text)
+
+    def is_enabled(self) -> bool:
+        return self.checkbox.isChecked()
+
+
+def _escape_html(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+    )
+
+
+class CassetteTapeDialog(QDialog):
+    """Three-page modal dialog for the Cassette Tape sequencer.
+
+    Pages:
+        PAGE_SETUP    — phrase entry + count sliders
+        PAGE_PROGRESS — matching in progress
+        PAGE_REVIEW   — per-match toggle + confidence
+
+    Signals:
+        sequence_ready: emitted on Generate with
+            ``list[tuple[Clip, Source, in_frame, out_frame]]``.
+    """
+
+    sequence_ready = Signal(list)
+
+    PAGE_SETUP = 0
+    PAGE_PROGRESS = 1
+    PAGE_REVIEW = 2
+
+    def __init__(self, clips, sources_by_id, project, parent=None):
+        super().__init__(parent)
+        self.all_clips = clips
+        self.sources_by_id = sources_by_id
+        self.project = project
+        self.worker: Optional[CassetteTapeWorker] = None
+        self.matches_by_phrase: dict[str, list[MatchResult]] = {}
+        self._match_rows: list[_MatchRow] = []
+
+        # Filter to clips that have a transcript and aren't disabled.
+        # The matching logic also filters, but we need this for the setup-page banner.
+        self.transcribed_clips = [
+            c for c in clips
+            if c.transcript and not c.disabled
+        ]
+
+        self.setWindowTitle("Cassette Tape")
+        self.setMinimumSize(700, 600)
+        self.setModal(True)
+
+        self._setup_ui()
+
+    # ---------- UI construction ----------
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setSpacing(12)
+
+        self.stack = QStackedWidget()
+        layout.addWidget(self.stack)
+
+        self.stack.addWidget(self._create_setup_page())
+        self.stack.addWidget(self._create_progress_page())
+        self.stack.addWidget(self._create_review_page())
+
+        # Navigation
+        nav = QHBoxLayout()
+        self.back_btn = QPushButton("Back")
+        self.back_btn.clicked.connect(self._on_back)
+        self.back_btn.setVisible(False)
+        nav.addWidget(self.back_btn)
+
+        nav.addStretch()
+
+        self.cancel_btn = QPushButton("Cancel")
+        self.cancel_btn.clicked.connect(self._on_cancel)
+        nav.addWidget(self.cancel_btn)
+
+        self.next_btn = QPushButton("Find Matches")
+        self.next_btn.clicked.connect(self._on_next)
+        nav.addWidget(self.next_btn)
+        layout.addLayout(nav)
+
+        self._update_nav_buttons()
+        self._update_next_btn_enabled()
+
+    def _create_setup_page(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        header = QLabel("Cassette Tape")
+        header_font = QFont()
+        header_font.setPointSize(18)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        layout.addWidget(header)
+
+        if not self.transcribed_clips:
+            warn = QLabel(
+                "This project has no transcribed clips. Run Analyze → Transcribe first."
+            )
+            warn.setWordWrap(True)
+            warn.setStyleSheet(f"color: {theme().accent_red};")
+            layout.addWidget(warn)
+            self._setup_no_transcripts = True
+        else:
+            info = QLabel(
+                f"Find clips that say specific phrases. "
+                f"{len(self.transcribed_clips)} transcribed clip(s) available. "
+                f"Each phrase contributes 1–5 matches by similarity."
+            )
+            info.setWordWrap(True)
+            layout.addWidget(info)
+            self._setup_no_transcripts = False
+
+        layout.addSpacing(12)
+
+        # Header row above phrase list
+        head_row = QHBoxLayout()
+        head_row.setContentsMargins(0, 0, 0, 0)
+        head_row.addWidget(QLabel("Phrase"), 1)
+        ct_label = QLabel("Matches per phrase")
+        ct_label.setFixedWidth(160)
+        head_row.addWidget(ct_label)
+        head_row.addSpacing(34)  # Align with × buttons below
+        layout.addLayout(head_row)
+
+        # Scrollable phrase list
+        self.phrase_container = QWidget()
+        self.phrase_layout = QVBoxLayout(self.phrase_container)
+        self.phrase_layout.setContentsMargins(0, 0, 0, 0)
+        self.phrase_layout.setSpacing(6)
+        self.phrase_layout.addStretch()  # Trailing stretch to keep rows top-aligned
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+        scroll.setWidget(self.phrase_container)
+        layout.addWidget(scroll, 1)
+
+        self.phrase_rows: list[_PhraseRow] = []
+        for _ in range(DEFAULT_PHRASE_ROWS):
+            self._add_phrase_row()
+
+        # Add row button
+        add_row = QHBoxLayout()
+        add_btn = QPushButton("+ Add phrase")
+        add_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        add_btn.clicked.connect(self._add_phrase_row)
+        add_row.addWidget(add_btn)
+        add_row.addStretch()
+        layout.addLayout(add_row)
+
+        return page
+
+    def _create_progress_page(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        layout.addStretch()
+
+        header = QLabel("Finding matches…")
+        header_font = QFont()
+        header_font.setPointSize(16)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        header.setAlignment(Qt.AlignCenter)
+        layout.addWidget(header)
+
+        self.progress_status = QLabel("")
+        self.progress_status.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.progress_status)
+
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setMinimum(0)
+        self.progress_bar.setMaximum(0)  # indeterminate
+        layout.addWidget(self.progress_bar)
+
+        layout.addStretch()
+        return page
+
+    def _create_review_page(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        header = QLabel("Review matches")
+        header_font = QFont()
+        header_font.setPointSize(16)
+        header_font.setBold(True)
+        header.setFont(header_font)
+        layout.addWidget(header)
+
+        self.review_summary = QLabel("")
+        layout.addWidget(self.review_summary)
+
+        layout.addSpacing(8)
+
+        # Scrollable list of phrase groups
+        self.review_container = QWidget()
+        self.review_layout = QVBoxLayout(self.review_container)
+        self.review_layout.setContentsMargins(0, 0, 0, 0)
+        self.review_layout.setSpacing(10)
+        self.review_layout.addStretch()
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+        scroll.setWidget(self.review_container)
+        layout.addWidget(scroll, 1)
+
+        return page
+
+    # ---------- Phrase row management ----------
+
+    def _add_phrase_row(self):
+        row = _PhraseRow()
+        row.text_changed.connect(self._update_next_btn_enabled)
+        row.remove_requested.connect(self._remove_phrase_row)
+        # Insert before the trailing stretch
+        self.phrase_layout.insertWidget(self.phrase_layout.count() - 1, row)
+        self.phrase_rows.append(row)
+        self._update_next_btn_enabled()
+
+    def _remove_phrase_row(self, row: QWidget):
+        if row in self.phrase_rows:
+            self.phrase_rows.remove(row)
+        self.phrase_layout.removeWidget(row)
+        row.deleteLater()
+        self._update_next_btn_enabled()
+
+    def _phrases_with_counts(self) -> list[tuple[str, int]]:
+        return [(r.phrase(), r.count()) for r in self.phrase_rows if r.phrase()]
+
+    # ---------- Navigation / state ----------
+
+    def _update_next_btn_enabled(self):
+        page = self.stack.currentIndex() if hasattr(self, "stack") else self.PAGE_SETUP
+        if page == self.PAGE_SETUP:
+            if self._setup_no_transcripts:
+                self.next_btn.setEnabled(False)
+                return
+            has_phrase = any(r.phrase() for r in getattr(self, "phrase_rows", []))
+            self.next_btn.setEnabled(has_phrase)
+        elif page == self.PAGE_REVIEW:
+            self.next_btn.setEnabled(self._any_match_enabled())
+        # Progress page button enable handled in _update_nav_buttons.
+
+    def _update_nav_buttons(self):
+        page = self.stack.currentIndex()
+        if page == self.PAGE_SETUP:
+            self.back_btn.setVisible(False)
+            self.next_btn.setText("Find Matches")
+            self._update_next_btn_enabled()
+        elif page == self.PAGE_PROGRESS:
+            self.back_btn.setVisible(False)
+            self.next_btn.setText("Please wait…")
+            self.next_btn.setEnabled(False)
+        elif page == self.PAGE_REVIEW:
+            self.back_btn.setVisible(True)
+            self.next_btn.setText("Generate Sequence")
+            self._update_next_btn_enabled()
+
+    def _on_next(self):
+        page = self.stack.currentIndex()
+        if page == self.PAGE_SETUP:
+            self._start_matching()
+        elif page == self.PAGE_REVIEW:
+            self._finish_with_sequence()
+
+    def _on_back(self):
+        if self.stack.currentIndex() == self.PAGE_REVIEW:
+            self.stack.setCurrentIndex(self.PAGE_SETUP)
+            self._update_nav_buttons()
+
+    def _on_cancel(self):
+        if self.worker and self.worker.isRunning():
+            self.worker.cancel()
+            self.worker.quit()
+            self.worker.wait(2000)
+        self.reject()
+
+    # ---------- Matching ----------
+
+    def _start_matching(self):
+        phrases = self._phrases_with_counts()
+        if not phrases:
+            return
+
+        self.stack.setCurrentIndex(self.PAGE_PROGRESS)
+        self._update_nav_buttons()
+        self.progress_status.setText(f"Matching {len(phrases)} phrase(s)…")
+
+        # Always create a fresh worker; never reuse across runs.
+        self.worker = CassetteTapeWorker(
+            phrases_with_counts=phrases,
+            clips=self.transcribed_clips,
+            parent=self,
+        )
+        self.worker.matches_ready.connect(self._on_matches_ready)
+        self.worker.error.connect(self._on_match_error)
+        self.worker.start()
+
+    def _on_matches_ready(self, results: dict):
+        self.matches_by_phrase = results
+        self._populate_review_page()
+        self.stack.setCurrentIndex(self.PAGE_REVIEW)
+        self._update_nav_buttons()
+
+    def _on_match_error(self, message: str):
+        logger.error("Cassette Tape error: %s", message)
+        self.progress_status.setText(f"Error: {message}")
+        self.stack.setCurrentIndex(self.PAGE_SETUP)
+        self._update_nav_buttons()
+
+    # ---------- Review page ----------
+
+    def _populate_review_page(self):
+        # Clear existing rows
+        while self.review_layout.count() > 1:  # keep trailing stretch
+            item = self.review_layout.takeAt(0)
+            w = item.widget()
+            if w:
+                w.deleteLater()
+        self._match_rows = []
+
+        clips_by_id = {c.id: c for c in self.all_clips}
+        total_matches = 0
+
+        for phrase, matches in self.matches_by_phrase.items():
+            group_label = QLabel(f"“{phrase}”  ({len(matches)} match{'es' if len(matches) != 1 else ''})")
+            group_font = QFont()
+            group_font.setBold(True)
+            group_font.setPointSize(13)
+            group_label.setFont(group_font)
+            self.review_layout.insertWidget(self.review_layout.count() - 1, group_label)
+
+            if not matches:
+                placeholder = QLabel("  no matches")
+                placeholder.setStyleSheet(f"color: {theme().text_muted};")
+                self.review_layout.insertWidget(self.review_layout.count() - 1, placeholder)
+                continue
+
+            for match in matches:
+                clip = clips_by_id.get(match.clip_id)
+                source = self.sources_by_id.get(clip.source_id) if clip else None
+                clip_name = clip.display_name(
+                    source.file_path.name if source and source.file_path else "",
+                    source.fps if source else 30.0,
+                ) if clip else match.clip_id
+                row = _MatchRow(match, clip_name)
+                row.checkbox.stateChanged.connect(lambda _: self._update_next_btn_enabled())
+                self._match_rows.append(row)
+                self.review_layout.insertWidget(self.review_layout.count() - 1, row)
+                total_matches += 1
+
+        self.review_summary.setText(
+            f"{total_matches} match{'es' if total_matches != 1 else ''} across "
+            f"{sum(1 for v in self.matches_by_phrase.values() if v)} phrase(s). "
+            f"Toggle off any you don't want before generating."
+        )
+
+    def _any_match_enabled(self) -> bool:
+        return any(r.is_enabled() for r in self._match_rows)
+
+    # ---------- Final emit ----------
+
+    def _finish_with_sequence(self):
+        from core.remix.cassette_tape import (
+            build_sequence_data,
+            flatten_matches_in_phrase_order,
+        )
+
+        enabled_keys = {
+            (r.match.phrase, r.match.clip_id, r.match.segment_index)
+            for r in self._match_rows
+            if r.is_enabled()
+        }
+        flat = flatten_matches_in_phrase_order(self.matches_by_phrase, enabled_keys)
+        clips_by_id = {c.id: c for c in self.all_clips}
+        sequence_data = build_sequence_data(flat, clips_by_id, self.sources_by_id)
+
+        if not sequence_data:
+            logger.warning("Cassette Tape: no enabled matches to emit")
+            self.reject()
+            return
+
+        logger.info("Cassette Tape: emitting %d sub-clips", len(sequence_data))
+        self.sequence_ready.emit(sequence_data)
+        self.accept()

--- a/ui/dialogs/cassette_tape_dialog.py
+++ b/ui/dialogs/cassette_tape_dialog.py
@@ -14,6 +14,7 @@ matching the convention used by Signature Style.
 from __future__ import annotations
 
 import logging
+from html import escape as html_escape
 from typing import Optional
 
 from PySide6.QtCore import Qt, Signal
@@ -37,9 +38,13 @@ from PySide6.QtWidgets import (
 
 from core.remix.cassette_tape import (
     MatchResult,
+    SLIDER_DEFAULT,
+    SLIDER_MAX,
+    SLIDER_MIN,
     build_sequence_data,
     flatten_matches_in_phrase_order,
     match_phrases,
+    safe_fps,
 )
 from models.clip import Clip
 from ui.theme import UISizes, theme
@@ -53,9 +58,8 @@ CONFIDENCE_HIGH = 80
 CONFIDENCE_MID = 50
 
 # Slider range
-SLIDER_MIN = 1
-SLIDER_MAX = 5
-SLIDER_DEFAULT = 3
+# Slider range constants live in core/remix/cassette_tape.py so the agent
+# tool and the dialog stay in sync. Imported above.
 DEFAULT_PHRASE_ROWS = 3
 
 
@@ -211,10 +215,10 @@ class _MatchRow(QWidget):
     def _score_color(score: int) -> str:
         t = theme()
         if score >= CONFIDENCE_HIGH:
-            return getattr(t, "accent_green", "#5cb85c")
+            return t.accent_green
         if score >= CONFIDENCE_MID:
-            return getattr(t, "accent_yellow", "#f0ad4e")
-        return getattr(t, "accent_red", "#d9534f")
+            return t.accent_orange  # mid-tier; theme has no separate yellow
+        return t.accent_red
 
     @staticmethod
     def _build_snippet_html(match: MatchResult) -> str:
@@ -223,22 +227,14 @@ class _MatchRow(QWidget):
         start = match.match_start
         end = match.match_end
         if 0 <= start < end <= len(text):
-            before = _escape_html(text[:start])
-            hit = _escape_html(text[start:end])
-            after = _escape_html(text[end:])
+            before = html_escape(text[:start])
+            hit = html_escape(text[start:end])
+            after = html_escape(text[end:])
             return f'{before}<b style="color: {theme().accent_blue};">{hit}</b>{after}'
-        return _escape_html(text)
+        return html_escape(text)
 
     def is_enabled(self) -> bool:
         return self.checkbox.isChecked()
-
-
-def _escape_html(text: str) -> str:
-    return (
-        text.replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-    )
 
 
 class CassetteTapeDialog(QDialog):
@@ -281,6 +277,9 @@ class CassetteTapeDialog(QDialog):
             c for c in clips
             if c.transcript and not c.disabled
         ]
+        self._setup_no_transcripts = not self.transcribed_clips
+        # Cache id->Clip lookup once; used by both review and finish paths.
+        self._clips_by_id = {c.id: c for c in clips}
 
         self.setWindowTitle("Cassette Tape")
         self.setMinimumSize(700, 600)
@@ -337,14 +336,13 @@ class CassetteTapeDialog(QDialog):
         header.setFont(header_font)
         layout.addWidget(header)
 
-        if not self.transcribed_clips:
+        if self._setup_no_transcripts:
             warn = QLabel(
                 "This project has no transcribed clips. Run Analyze → Transcribe first."
             )
             warn.setWordWrap(True)
             warn.setStyleSheet(f"color: {theme().accent_red};")
             layout.addWidget(warn)
-            self._setup_no_transcripts = True
         else:
             info = QLabel(
                 f"Find clips that say specific phrases. "
@@ -353,7 +351,6 @@ class CassetteTapeDialog(QDialog):
             )
             info.setWordWrap(True)
             layout.addWidget(info)
-            self._setup_no_transcripts = False
 
         layout.addSpacing(12)
 
@@ -472,15 +469,17 @@ class CassetteTapeDialog(QDialog):
         row.deleteLater()
         self._update_next_btn_enabled()
 
-    def _phrases_with_counts(self) -> list[tuple[str, int]]:
-        """Collect non-empty phrase rows, deduping by phrase text.
+    def _collect_phrase_entries(self) -> tuple[list[tuple[str, int]], bool]:
+        """Single-pass collect of non-empty phrase rows, deduping case-insensitively.
 
-        Two rows reading the same phrase (case-insensitive) would otherwise
-        collide on the dict key in match_phrases and silently drop one row's
-        intent. Merge them into a single entry, taking the *max* of the two
-        counts (the user gets at least what the larger slider asked for).
+        Returns ``(entries, had_duplicates)`` where ``entries`` preserves the
+        first-occurrence original-case spelling and merges duplicate phrases
+        with ``max(count)``, and ``had_duplicates`` is True when at least one
+        row was merged into an earlier one. The merge prevents the dict-key
+        collision in match_phrases that would otherwise silently drop a row.
         """
-        merged: dict[str, int] = {}
+        merged: dict[str, list] = {}  # casefold -> [original_phrase, max_count]
+        had_duplicates = False
         for row in self.phrase_rows:
             phrase = row.phrase()
             if not phrase:
@@ -488,35 +487,16 @@ class CassetteTapeDialog(QDialog):
             key = phrase.casefold()
             count = row.count()
             if key in merged:
-                merged[key] = max(merged[key], count)
+                merged[key][1] = max(merged[key][1], count)
+                had_duplicates = True
             else:
-                merged[key] = count
-        # Preserve the original-case spelling of the first occurrence by
-        # walking the rows again in order.
-        seen: set[str] = set()
-        out: list[tuple[str, int]] = []
-        for row in self.phrase_rows:
-            phrase = row.phrase()
-            if not phrase:
-                continue
-            key = phrase.casefold()
-            if key in seen:
-                continue
-            seen.add(key)
-            out.append((phrase, merged[key]))
-        return out
+                merged[key] = [phrase, count]
+        return [(orig, cnt) for orig, cnt in merged.values()], had_duplicates
 
-    def _has_duplicate_phrase_rows(self) -> bool:
-        seen: set[str] = set()
-        for row in self.phrase_rows:
-            phrase = row.phrase()
-            if not phrase:
-                continue
-            key = phrase.casefold()
-            if key in seen:
-                return True
-            seen.add(key)
-        return False
+    def _phrases_with_counts(self) -> list[tuple[str, int]]:
+        """Public-shape compatibility wrapper for tests / external callers."""
+        entries, _ = self._collect_phrase_entries()
+        return entries
 
     # ---------- Navigation / state ----------
 
@@ -592,11 +572,11 @@ class CassetteTapeDialog(QDialog):
     # ---------- Matching ----------
 
     def _start_matching(self):
-        phrases = self._phrases_with_counts()
+        phrases, had_duplicates = self._collect_phrase_entries()
         if not phrases:
             return
 
-        if self._has_duplicate_phrase_rows():
+        if had_duplicates:
             QMessageBox.information(
                 self,
                 "Cassette Tape — duplicate phrases",
@@ -620,14 +600,11 @@ class CassetteTapeDialog(QDialog):
         self.worker.start()
 
     def _on_matches_ready(self, results):
-        # results is list[tuple[str, list[MatchResult]]] ordered by user input.
-        # Store as dict (Python dicts preserve insertion order) so downstream
-        # code that iterates .items() / .values() sees the user's phrase order.
-        if isinstance(results, dict):
-            # Defensive: tolerate the legacy dict shape if any caller still uses it.
-            self.matches_by_phrase = results
-        else:
-            self.matches_by_phrase = dict(results)
+        # results is list[tuple[str, list[MatchResult]]] from the worker.
+        # Rebuild a dict (insertion-ordered) so downstream iteration preserves
+        # the user's phrase entry order — see the matches_ready signal note
+        # above for why a dict can't be sent across the thread boundary.
+        self.matches_by_phrase = dict(results)
         self._populate_review_page()
         self.stack.setCurrentIndex(self.PAGE_REVIEW)
         self._update_nav_buttons()
@@ -645,17 +622,16 @@ class CassetteTapeDialog(QDialog):
     # ---------- Review page ----------
 
     def _populate_review_page(self):
-        # Clear existing rows
-        while self.review_layout.count() > 1:  # keep trailing stretch
-            item = self.review_layout.takeAt(0)
+        # Clear existing rows. Take from the back to avoid the O(n²) index
+        # shifts that takeAt(0) would cause; keep the trailing stretch.
+        while self.review_layout.count() > 1:
+            item = self.review_layout.takeAt(self.review_layout.count() - 2)
             w = item.widget()
             if w:
                 w.deleteLater()
         self._match_rows = []
 
-        clips_by_id = {c.id: c for c in self.all_clips}
         total_matches = 0
-
         for phrase, matches in self.matches_by_phrase.items():
             group_label = QLabel(f"“{phrase}”  ({len(matches)} match{'es' if len(matches) != 1 else ''})")
             group_font = QFont()
@@ -671,13 +647,7 @@ class CassetteTapeDialog(QDialog):
                 continue
 
             for match in matches:
-                clip = clips_by_id.get(match.clip_id)
-                source = self.sources_by_id.get(clip.source_id) if clip else None
-                clip_name = clip.display_name(
-                    source.file_path.name if source and source.file_path else "",
-                    source.fps if source else 30.0,
-                ) if clip else match.clip_id
-                row = _MatchRow(match, clip_name)
+                row = _MatchRow(match, self._clip_display_name(match))
                 row.checkbox.stateChanged.connect(lambda _: self._update_next_btn_enabled())
                 self._match_rows.append(row)
                 self.review_layout.insertWidget(self.review_layout.count() - 1, row)
@@ -688,6 +658,14 @@ class CassetteTapeDialog(QDialog):
             f"{sum(1 for v in self.matches_by_phrase.values() if v)} phrase(s). "
             f"Toggle off any you don't want before generating."
         )
+
+    def _clip_display_name(self, match: MatchResult) -> str:
+        clip = self._clips_by_id.get(match.clip_id)
+        if clip is None:
+            return match.clip_id
+        source = self.sources_by_id.get(clip.source_id)
+        file_name = source.file_path.name if source and source.file_path else ""
+        return clip.display_name(file_name, safe_fps(source))
 
     def _any_match_enabled(self) -> bool:
         return any(r.is_enabled() for r in self._match_rows)
@@ -701,8 +679,7 @@ class CassetteTapeDialog(QDialog):
             if r.is_enabled()
         }
         flat = flatten_matches_in_phrase_order(self.matches_by_phrase, enabled_keys)
-        clips_by_id = {c.id: c for c in self.all_clips}
-        sequence_data = build_sequence_data(flat, clips_by_id, self.sources_by_id)
+        sequence_data = build_sequence_data(flat, self._clips_by_id, self.sources_by_id)
 
         if not sequence_data:
             logger.warning("Cassette Tape: no enabled matches to emit")

--- a/ui/dialogs/cassette_tape_dialog.py
+++ b/ui/dialogs/cassette_tape_dialog.py
@@ -254,7 +254,13 @@ class CassetteTapeDialog(QDialog):
     PAGE_PROGRESS = 1
     PAGE_REVIEW = 2
 
-    def __init__(self, clips, sources_by_id, project, parent=None):
+    def __init__(
+        self,
+        clips: list[Clip],
+        sources_by_id: dict,
+        project,
+        parent=None,
+    ):
         super().__init__(parent)
         self.all_clips = clips
         self.sources_by_id = sources_by_id
@@ -292,6 +298,7 @@ class CassetteTapeDialog(QDialog):
         # Navigation
         nav = QHBoxLayout()
         self.back_btn = QPushButton("Back")
+        self.back_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
         self.back_btn.clicked.connect(self._on_back)
         self.back_btn.setVisible(False)
         nav.addWidget(self.back_btn)
@@ -299,10 +306,12 @@ class CassetteTapeDialog(QDialog):
         nav.addStretch()
 
         self.cancel_btn = QPushButton("Cancel")
+        self.cancel_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
         self.cancel_btn.clicked.connect(self._on_cancel)
         nav.addWidget(self.cancel_btn)
 
         self.next_btn = QPushButton("Find Matches")
+        self.next_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
         self.next_btn.clicked.connect(self._on_next)
         nav.addWidget(self.next_btn)
         layout.addLayout(nav)
@@ -604,7 +613,7 @@ class CassetteTapeDialog(QDialog):
         self.worker.error.connect(self._on_match_error)
         self.worker.start()
 
-    def _on_matches_ready(self, results: dict):
+    def _on_matches_ready(self, results: dict[str, list[MatchResult]]):
         self.matches_by_phrase = results
         self._populate_review_page()
         self.stack.setCurrentIndex(self.PAGE_REVIEW)

--- a/ui/dialogs/cassette_tape_dialog.py
+++ b/ui/dialogs/cassette_tape_dialog.py
@@ -68,7 +68,11 @@ class CassetteTapeWorker(CancellableWorker):
     suppressing the post-completion signal.
     """
 
-    matches_ready = Signal(dict)  # phrase -> [MatchResult]
+    # Emit a list of (phrase, [MatchResult]) tuples — NOT a dict.
+    # PySide6 marshals dict across thread-boundary signals as QVariantMap
+    # (a QMap, sorted alphabetically by key), which would silently reorder
+    # the user's phrase entries on the review screen.
+    matches_ready = Signal(list)
 
     def __init__(
         self,
@@ -91,7 +95,9 @@ class CassetteTapeWorker(CancellableWorker):
             if self.is_cancelled():
                 self._log_cancelled()
                 return
-            self.matches_ready.emit(results)
+            # Convert to ordered list of tuples for the cross-thread signal.
+            ordered = list(results.items())
+            self.matches_ready.emit(ordered)
             self._log_complete()
         except Exception as exc:
             if self.is_cancelled():
@@ -613,8 +619,15 @@ class CassetteTapeDialog(QDialog):
         self.worker.error.connect(self._on_match_error)
         self.worker.start()
 
-    def _on_matches_ready(self, results: dict[str, list[MatchResult]]):
-        self.matches_by_phrase = results
+    def _on_matches_ready(self, results):
+        # results is list[tuple[str, list[MatchResult]]] ordered by user input.
+        # Store as dict (Python dicts preserve insertion order) so downstream
+        # code that iterates .items() / .values() sees the user's phrase order.
+        if isinstance(results, dict):
+            # Defensive: tolerate the legacy dict shape if any caller still uses it.
+            self.matches_by_phrase = results
+        else:
+            self.matches_by_phrase = dict(results)
         self._populate_review_page()
         self.stack.setCurrentIndex(self.PAGE_REVIEW)
         self._update_nav_buttons()

--- a/ui/dialogs/cassette_tape_dialog.py
+++ b/ui/dialogs/cassette_tape_dialog.py
@@ -458,7 +458,50 @@ class CassetteTapeDialog(QDialog):
         self._update_next_btn_enabled()
 
     def _phrases_with_counts(self) -> list[tuple[str, int]]:
-        return [(r.phrase(), r.count()) for r in self.phrase_rows if r.phrase()]
+        """Collect non-empty phrase rows, deduping by phrase text.
+
+        Two rows reading the same phrase (case-insensitive) would otherwise
+        collide on the dict key in match_phrases and silently drop one row's
+        intent. Merge them into a single entry, taking the *max* of the two
+        counts (the user gets at least what the larger slider asked for).
+        """
+        merged: dict[str, int] = {}
+        for row in self.phrase_rows:
+            phrase = row.phrase()
+            if not phrase:
+                continue
+            key = phrase.casefold()
+            count = row.count()
+            if key in merged:
+                merged[key] = max(merged[key], count)
+            else:
+                merged[key] = count
+        # Preserve the original-case spelling of the first occurrence by
+        # walking the rows again in order.
+        seen: set[str] = set()
+        out: list[tuple[str, int]] = []
+        for row in self.phrase_rows:
+            phrase = row.phrase()
+            if not phrase:
+                continue
+            key = phrase.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append((phrase, merged[key]))
+        return out
+
+    def _has_duplicate_phrase_rows(self) -> bool:
+        seen: set[str] = set()
+        for row in self.phrase_rows:
+            phrase = row.phrase()
+            if not phrase:
+                continue
+            key = phrase.casefold()
+            if key in seen:
+                return True
+            seen.add(key)
+        return False
 
     # ---------- Navigation / state ----------
 
@@ -537,6 +580,15 @@ class CassetteTapeDialog(QDialog):
         phrases = self._phrases_with_counts()
         if not phrases:
             return
+
+        if self._has_duplicate_phrase_rows():
+            QMessageBox.information(
+                self,
+                "Cassette Tape — duplicate phrases",
+                "Two or more phrase rows have the same text. They will be "
+                "merged into a single search using the larger 'matches per "
+                "phrase' value.",
+            )
 
         self.stack.setCurrentIndex(self.PAGE_PROGRESS)
         self._update_nav_buttons()

--- a/ui/dialogs/cassette_tape_dialog.py
+++ b/ui/dialogs/cassette_tape_dialog.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from PySide6.QtCore import Qt, Signal, QThread
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -25,6 +25,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QMessageBox,
     QProgressBar,
     QPushButton,
     QScrollArea,
@@ -34,8 +35,15 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
-from core.remix.cassette_tape import MatchResult, match_phrases
+from core.remix.cassette_tape import (
+    MatchResult,
+    build_sequence_data,
+    flatten_matches_in_phrase_order,
+    match_phrases,
+)
+from models.clip import Clip
 from ui.theme import UISizes, theme
+from ui.workers.base import CancellableWorker
 
 logger = logging.getLogger(__name__)
 
@@ -51,33 +59,46 @@ SLIDER_DEFAULT = 3
 DEFAULT_PHRASE_ROWS = 3
 
 
-class CassetteTapeWorker(QThread):
-    """Background worker that runs phrase matching off the UI thread."""
+class CassetteTapeWorker(CancellableWorker):
+    """Background worker that runs phrase matching off the UI thread.
 
-    progress = Signal(int, int)  # (current, total)
+    Inherits ``cancel()`` / ``is_cancelled()`` / ``error`` from
+    ``CancellableWorker``; the cancel flag is plumbed into ``match_phrases``
+    so a long-running scoring pass can actually abort instead of just
+    suppressing the post-completion signal.
+    """
+
     matches_ready = Signal(dict)  # phrase -> [MatchResult]
-    error = Signal(str)
 
-    def __init__(self, phrases_with_counts: list[tuple[str, int]],
-                 clips: list, parent=None):
+    def __init__(
+        self,
+        phrases_with_counts: list[tuple[str, int]],
+        clips: list[Clip],
+        parent=None,
+    ):
         super().__init__(parent)
         self.phrases_with_counts = phrases_with_counts
         self.clips = clips
-        self._cancelled = False
 
     def run(self):
+        self._log_start()
         try:
-            self.progress.emit(0, len(self.phrases_with_counts))
-            results = match_phrases(self.phrases_with_counts, self.clips)
-            if not self._cancelled:
-                self.matches_ready.emit(results)
+            results = match_phrases(
+                self.phrases_with_counts,
+                self.clips,
+                is_cancelled=self.is_cancelled,
+            )
+            if self.is_cancelled():
+                self._log_cancelled()
+                return
+            self.matches_ready.emit(results)
+            self._log_complete()
         except Exception as exc:
-            if not self._cancelled:
-                logger.exception("Cassette Tape matching failed")
-                self.error.emit(str(exc))
-
-    def cancel(self):
-        self._cancelled = True
+            if self.is_cancelled():
+                self._log_cancelled()
+                return
+            logger.exception("Cassette Tape matching failed")
+            self.error.emit(f"{type(exc).__name__}: {exc}")
 
 
 class _PhraseRow(QWidget):
@@ -481,11 +502,34 @@ class CassetteTapeDialog(QDialog):
             self._update_nav_buttons()
 
     def _on_cancel(self):
+        self._stop_worker_if_running()
+        self.reject()
+
+    def closeEvent(self, event):
+        """Window-X / ESC must also stop the worker — never tear down a
+        running QThread parented to this dialog."""
+        self._stop_worker_if_running()
+        super().closeEvent(event)
+
+    def _stop_worker_if_running(self):
         if self.worker and self.worker.isRunning():
             self.worker.cancel()
+            # Disconnect signals so a late delivery doesn't try to populate
+            # an already-closing dialog.
+            try:
+                self.worker.matches_ready.disconnect(self._on_matches_ready)
+            except (RuntimeError, TypeError):
+                pass
+            try:
+                self.worker.error.disconnect(self._on_match_error)
+            except (RuntimeError, TypeError):
+                pass
             self.worker.quit()
-            self.worker.wait(2000)
-        self.reject()
+            # Unbounded wait — the cooperative cancel returns within one
+            # phrase iteration, which is sub-second on typical projects.
+            self.worker.wait()
+            self.worker.deleteLater()
+            self.worker = None
 
     # ---------- Matching ----------
 
@@ -516,9 +560,13 @@ class CassetteTapeDialog(QDialog):
 
     def _on_match_error(self, message: str):
         logger.error("Cassette Tape error: %s", message)
-        self.progress_status.setText(f"Error: {message}")
         self.stack.setCurrentIndex(self.PAGE_SETUP)
         self._update_nav_buttons()
+        QMessageBox.warning(
+            self,
+            "Cassette Tape — matching failed",
+            f"Could not finish matching:\n\n{message}",
+        )
 
     # ---------- Review page ----------
 
@@ -573,11 +621,6 @@ class CassetteTapeDialog(QDialog):
     # ---------- Final emit ----------
 
     def _finish_with_sequence(self):
-        from core.remix.cassette_tape import (
-            build_sequence_data,
-            flatten_matches_in_phrase_order,
-        )
-
         enabled_keys = {
             (r.match.phrase, r.match.clip_id, r.match.segment_index)
             for r in self._match_rows

--- a/ui/tabs/sequence_tab.py
+++ b/ui/tabs/sequence_tab.py
@@ -1280,24 +1280,41 @@ class SequenceTab(BaseTab):
 
     @Slot(list)
     def _apply_signature_style_sequence(self, sequence_data: list):
-        """Apply the sequence from Signature Style dialog.
+        """Apply the sequence from Signature Style dialog."""
+        self._apply_dialog_sequence_trimmed(
+            sequence_data,
+            algorithm_key="signature_style",
+            display_label="Signature Style",
+            allow_repeats=True,
+        )
 
-        The dialog emits (Clip, Source, in_point, out_point) tuples
-        to support clip trimming based on drawing segment durations.
+    def _apply_dialog_sequence_trimmed(
+        self,
+        sequence_data: list,
+        *,
+        algorithm_key: str,
+        display_label: str,
+        allow_repeats: bool,
+    ):
+        """Apply a dialog sequence emitted as ``(Clip, Source, in_point, out_point)`` tuples.
+
+        Shared by Signature Style and Cassette Tape — both dialogs trim sub-clips
+        with frame offsets relative to ``clip.start_frame``. Adds clips to track 0
+        in order, sets the algorithm metadata on the sequence, and refreshes the
+        chromatic bar / dropdown / preview.
         """
         if not sequence_data:
-            logger.warning("No clips in Signature Style sequence")
+            logger.warning("No clips in %s sequence", display_label)
             return
 
         try:
-            from models.sequence import SequenceClip
+            from core.remix.cassette_tape import safe_fps
 
-            self._create_and_activate_sequence("signature_style")
+            self._create_and_activate_sequence(algorithm_key)
             self.timeline.clear_timeline()
 
             first_clip, first_source, _, _ = sequence_data[0]
-            fps = first_source.fps
-            self.timeline.set_fps(fps)
+            self.timeline.set_fps(safe_fps(first_source))
             self.video_player.load_video(first_source.file_path)
 
             current_frame = 0
@@ -1311,37 +1328,34 @@ class SequenceTab(BaseTab):
                     out_point=clip.start_frame + out_point,
                     thumbnail_path=str(clip.thumbnail_path) if clip.thumbnail_path else None,
                 )
-                duration_frames = out_point - in_point
-                current_frame += duration_frames
+                current_frame += out_point - in_point
                 self.clip_added.emit(clip, source)
 
-            # Build (Clip, Source) list for timeline preview
             preview_clips = [(clip, source) for clip, source, _, _ in sequence_data]
             self.timeline_preview.set_clips(preview_clips, self._sources)
             self.timeline._on_zoom_fit()
 
             self.algorithm_dropdown.blockSignals(True)
-            display_label = "Signature Style"
             if self.algorithm_dropdown.findText(display_label) == -1:
                 self.algorithm_dropdown.addItem(display_label)
             self.algorithm_dropdown.setCurrentText(display_label)
             self.algorithm_dropdown.blockSignals(False)
 
-            self._current_algorithm = "signature_style"
+            self._current_algorithm = algorithm_key
 
             sequence = self.timeline.get_sequence()
-            sequence.algorithm = "signature_style"
-            sequence.allow_repeats = True
-            self._apply_chromatic_bar_to_sequence("signature_style")
-            self._update_chromatic_bar_controls("signature_style")
+            sequence.algorithm = algorithm_key
+            sequence.allow_repeats = allow_repeats
+            self._apply_chromatic_bar_to_sequence(algorithm_key)
+            self._update_chromatic_bar_controls(algorithm_key)
             self._emit_chromatic_bar_setting_changed()
 
             self._set_state(self.STATE_TIMELINE)
 
-            logger.info(f"Applied {len(sequence_data)} clips from Signature Style")
+            logger.info("Applied %d clips from %s", len(sequence_data), display_label)
 
         except Exception as e:
-            logger.error(f"Error applying Signature Style sequence: {e}")
+            logger.error("Error applying %s sequence: %s", display_label, e)
             QMessageBox.critical(self, "Error", f"Failed to apply sequence: {e}")
 
         finally:
@@ -1367,74 +1381,14 @@ class SequenceTab(BaseTab):
         dialog.exec()
 
     @Slot(list)
-    def _apply_cassette_tape_sequence(self, sequence_data: list[tuple]):
-        """Apply the sequence from the Cassette Tape dialog.
-
-        The dialog emits ``(Clip, Source, in_point, out_point)`` tuples where
-        in/out are frame offsets relative to ``clip.start_frame`` — same
-        convention as Signature Style.
-        """
-        if not sequence_data:
-            logger.warning("No clips in Cassette Tape sequence")
-            return
-
-        try:
-            self._create_and_activate_sequence("cassette_tape")
-            self.timeline.clear_timeline()
-
-            first_clip, first_source, _, _ = sequence_data[0]
-            # Defensive: a Source with fps<=0 (corrupted metadata, failed probe)
-            # would propagate divide-by-zero into the timeline scene.
-            # build_sequence_data has the same fallback; mirror it here.
-            fps = first_source.fps if first_source.fps and first_source.fps > 0 else 30.0
-            self.timeline.set_fps(fps)
-            self.video_player.load_video(first_source.file_path)
-
-            current_frame = 0
-            for clip, source, in_point, out_point in sequence_data:
-                self.timeline.scene.add_clip_to_track(
-                    track_index=0,
-                    source_clip_id=clip.id,
-                    source_id=source.id,
-                    start_frame=current_frame,
-                    in_point=clip.start_frame + in_point,
-                    out_point=clip.start_frame + out_point,
-                    thumbnail_path=str(clip.thumbnail_path) if clip.thumbnail_path else None,
-                )
-                duration_frames = out_point - in_point
-                current_frame += duration_frames
-                self.clip_added.emit(clip, source)
-
-            preview_clips = [(clip, source) for clip, source, _, _ in sequence_data]
-            self.timeline_preview.set_clips(preview_clips, self._sources)
-            self.timeline._on_zoom_fit()
-
-            self.algorithm_dropdown.blockSignals(True)
-            display_label = "Cassette Tape"
-            if self.algorithm_dropdown.findText(display_label) == -1:
-                self.algorithm_dropdown.addItem(display_label)
-            self.algorithm_dropdown.setCurrentText(display_label)
-            self.algorithm_dropdown.blockSignals(False)
-
-            self._current_algorithm = "cassette_tape"
-
-            sequence = self.timeline.get_sequence()
-            sequence.algorithm = "cassette_tape"
-            sequence.allow_repeats = False
-            self._apply_chromatic_bar_to_sequence("cassette_tape")
-            self._update_chromatic_bar_controls("cassette_tape")
-            self._emit_chromatic_bar_setting_changed()
-
-            self._set_state(self.STATE_TIMELINE)
-
-            logger.info(f"Applied {len(sequence_data)} sub-clips from Cassette Tape")
-
-        except Exception as e:
-            logger.error(f"Error applying Cassette Tape sequence: {e}")
-            QMessageBox.critical(self, "Error", f"Failed to apply sequence: {e}")
-
-        finally:
-            self._algorithm_running = False
+    def _apply_cassette_tape_sequence(self, sequence_data: list):
+        """Apply the sequence from the Cassette Tape dialog."""
+        self._apply_dialog_sequence_trimmed(
+            sequence_data,
+            algorithm_key="cassette_tape",
+            display_label="Cassette Tape",
+            allow_repeats=False,
+        )
 
     def _show_rose_hobart_dialog(self, clips: list):
         """Show the Rose Hobart dialog for face-filter sequencing.

--- a/ui/tabs/sequence_tab.py
+++ b/ui/tabs/sequence_tab.py
@@ -1367,7 +1367,7 @@ class SequenceTab(BaseTab):
         dialog.exec()
 
     @Slot(list)
-    def _apply_cassette_tape_sequence(self, sequence_data: list):
+    def _apply_cassette_tape_sequence(self, sequence_data: list[tuple]):
         """Apply the sequence from the Cassette Tape dialog.
 
         The dialog emits ``(Clip, Source, in_point, out_point)`` tuples where
@@ -1383,7 +1383,10 @@ class SequenceTab(BaseTab):
             self.timeline.clear_timeline()
 
             first_clip, first_source, _, _ = sequence_data[0]
-            fps = first_source.fps
+            # Defensive: a Source with fps<=0 (corrupted metadata, failed probe)
+            # would propagate divide-by-zero into the timeline scene.
+            # build_sequence_data has the same fallback; mirror it here.
+            fps = first_source.fps if first_source.fps and first_source.fps > 0 else 30.0
             self.timeline.set_fps(fps)
             self.video_player.load_video(first_source.file_path)
 

--- a/ui/tabs/sequence_tab.py
+++ b/ui/tabs/sequence_tab.py
@@ -23,7 +23,7 @@ from .base_tab import BaseTab
 from ui.video_player import VideoPlayer
 from ui.timeline import TimelineWidget
 from ui.widgets import SortingCardGrid, TimelinePreview, CostEstimatePanel
-from ui.dialogs import ExquisiteCorpusDialog, StorytellerDialog, MissingDescriptionsDialog, ReferenceGuideDialog, SignatureStyleDialog, RoseHobartDialog, DiceRollDialog, FreeAssociationDialog
+from ui.dialogs import ExquisiteCorpusDialog, StorytellerDialog, MissingDescriptionsDialog, ReferenceGuideDialog, SignatureStyleDialog, RoseHobartDialog, DiceRollDialog, FreeAssociationDialog, CassetteTapeDialog
 from ui.theme import theme, Spacing, TypeScale, UISizes
 from ui.workers.sequence_worker import SequenceWorker
 from core.remix import generate_sequence
@@ -802,6 +802,9 @@ class SequenceTab(BaseTab):
             if algorithm == "free_association":
                 self._show_free_association_dialog(clips)
                 return
+            if algorithm == "cassette_tape":
+                self._show_cassette_tape_dialog(clips)
+                return
 
         # Compute cost estimates for this algorithm
         clip_objects = [clip for clip, source in clips]
@@ -1339,6 +1342,92 @@ class SequenceTab(BaseTab):
 
         except Exception as e:
             logger.error(f"Error applying Signature Style sequence: {e}")
+            QMessageBox.critical(self, "Error", f"Failed to apply sequence: {e}")
+
+        finally:
+            self._algorithm_running = False
+
+    def _show_cassette_tape_dialog(self, clips: list):
+        """Show the Cassette Tape dialog (transcript phrase matcher).
+
+        Args:
+            clips: List of (Clip, Source) tuples to process
+        """
+        clip_objects = [clip for clip, source in clips]
+        sources_by_id = {source.id: source for clip, source in clips}
+
+        dialog = CassetteTapeDialog(
+            clips=clip_objects,
+            sources_by_id=sources_by_id,
+            project=self._project,
+            parent=self,
+        )
+
+        dialog.sequence_ready.connect(self._apply_cassette_tape_sequence)
+        dialog.exec()
+
+    @Slot(list)
+    def _apply_cassette_tape_sequence(self, sequence_data: list):
+        """Apply the sequence from the Cassette Tape dialog.
+
+        The dialog emits ``(Clip, Source, in_point, out_point)`` tuples where
+        in/out are frame offsets relative to ``clip.start_frame`` — same
+        convention as Signature Style.
+        """
+        if not sequence_data:
+            logger.warning("No clips in Cassette Tape sequence")
+            return
+
+        try:
+            self._create_and_activate_sequence("cassette_tape")
+            self.timeline.clear_timeline()
+
+            first_clip, first_source, _, _ = sequence_data[0]
+            fps = first_source.fps
+            self.timeline.set_fps(fps)
+            self.video_player.load_video(first_source.file_path)
+
+            current_frame = 0
+            for clip, source, in_point, out_point in sequence_data:
+                self.timeline.scene.add_clip_to_track(
+                    track_index=0,
+                    source_clip_id=clip.id,
+                    source_id=source.id,
+                    start_frame=current_frame,
+                    in_point=clip.start_frame + in_point,
+                    out_point=clip.start_frame + out_point,
+                    thumbnail_path=str(clip.thumbnail_path) if clip.thumbnail_path else None,
+                )
+                duration_frames = out_point - in_point
+                current_frame += duration_frames
+                self.clip_added.emit(clip, source)
+
+            preview_clips = [(clip, source) for clip, source, _, _ in sequence_data]
+            self.timeline_preview.set_clips(preview_clips, self._sources)
+            self.timeline._on_zoom_fit()
+
+            self.algorithm_dropdown.blockSignals(True)
+            display_label = "Cassette Tape"
+            if self.algorithm_dropdown.findText(display_label) == -1:
+                self.algorithm_dropdown.addItem(display_label)
+            self.algorithm_dropdown.setCurrentText(display_label)
+            self.algorithm_dropdown.blockSignals(False)
+
+            self._current_algorithm = "cassette_tape"
+
+            sequence = self.timeline.get_sequence()
+            sequence.algorithm = "cassette_tape"
+            sequence.allow_repeats = False
+            self._apply_chromatic_bar_to_sequence("cassette_tape")
+            self._update_chromatic_bar_controls("cassette_tape")
+            self._emit_chromatic_bar_setting_changed()
+
+            self._set_state(self.STATE_TIMELINE)
+
+            logger.info(f"Applied {len(sequence_data)} sub-clips from Cassette Tape")
+
+        except Exception as e:
+            logger.error(f"Error applying Cassette Tape sequence: {e}")
             QMessageBox.critical(self, "Error", f"Failed to apply sequence: {e}")
 
         finally:

--- a/ui/widgets/sorting_card_grid.py
+++ b/ui/widgets/sorting_card_grid.py
@@ -72,7 +72,7 @@ class SortingCardGrid(QWidget):
             "shuffle", "sequential", "duration", "color",
             "brightness", "volume", "shot_type", "proximity",
             "similarity_chain", "match_cut", "exquisite_corpus", "storyteller",
-            "free_association", "reference_guided", "signature_style",
+            "free_association", "cassette_tape", "reference_guided", "signature_style",
             "rose_hobart", "staccato",
             "gaze_sort", "gaze_consistency", "eyes_without_a_face",
         ]


### PR DESCRIPTION
## Summary

- Adds a new dialog-based sequencer that finds clips saying user-supplied phrases and assembles a sequence of sub-clips trimmed to the matched transcript segments.
- Three-page modal UX: phrase entry with per-phrase 1–5 count slider → background matching via `rapidfuzz.fuzz.partial_ratio` → review screen with confidence badges and per-match toggle.
- Agent-equivalent `generate_cassette_tape` tool exposes the same workflow to the chat agent and MCP integration paths.

## Implementation units

- **U1** `core/remix/cassette_tape.py` — pure-logic matcher: `match_phrases()`, `build_sequence_data()`, `flatten_matches_in_phrase_order()`, `MatchResult` dataclass.
- **U2** `ui/algorithm_config.py` — register `cassette_tape` (`required_analysis: ["transcribe"]`, `is_dialog: True`, categories `["arrange", "audio"]`).
- **U3** `ui/dialogs/cassette_tape_dialog.py` — three-page `QDialog` + `CassetteTapeWorker`.
- **U4** `ui/tabs/sequence_tab.py` — dispatch + `_apply_cassette_tape_sequence` mirroring the `signature_style` 4-tuple pattern.
- **U5** `docs/user-guide/sequencers.md` — user-facing documentation.

## Code-review fixes applied

`/ce-code-review` ran 10 reviewers in parallel and surfaced 15 findings; all were addressed in 5 follow-up commits before this PR:

- **P1 #1, #2, #4** — Worker cancel/lifecycle: `CassetteTapeWorker` now inherits `CancellableWorker`, `match_phrases` is cooperatively cancellable between phrases, `closeEvent` routes through cancel, `wait()` is unbounded after cancel, and match errors surface via `QMessageBox.warning` instead of a hidden progress label.
- **P1 #3** — Identical phrase rows are deduped (case-insensitive, max-count merge) at the dialog before matching, with a one-shot info dialog so users understand the merge.
- **P1 #5** — Agent parity: `generate_cassette_tape` tool, `list_sorting_algorithms` entry, and `algo_availability` map updated.
- **P2 #6, #7, #11** — `partial_ratio_alignment` now uses `processor=str.lower` so highlight indices map back to the original-case text (Turkish dotted-I and similar Unicode-length quirks); redundant `partial_ratio` call dropped; bare `except` swallow gets a `logger.debug` breadcrumb.
- **P2 #8, #10, #15** — `BUTTON_MIN_HEIGHT` on nav buttons; `fps≤0` guard in the apply method; tightened type annotations on the dialog/worker public boundary.
- **P2 #9, P3 #12, #13, #14** — New `tests/test_cassette_tape_integration.py` covers `_apply_cassette_tape_sequence` end-to-end; sort-tuple comment fixed; dead `progress` signal removed; redundant lazy import dropped.

## Test plan

- [x] `pytest tests/test_cassette_tape.py tests/test_cassette_tape_dialog.py tests/test_cassette_tape_integration.py tests/test_algorithm_config.py tests/test_sorting_card_grid.py` — 65 tests pass.
- [x] Full repo suite — 2,121 tests pass (5 pre-existing failures excluded — unrelated to this branch).
- [ ] Manual smoke: open Cassette Tape from the Sequence tab on a project with transcribed clips; enter 2–3 phrases; verify the review screen shows correct snippets with highlighted matches; toggle a few off and Generate; confirm sub-clips appear on the timeline trimmed to the matched segments.
- [ ] Manual smoke: cancel during matching on a large project; verify no `QThread destroyed while still running` warnings.
- [ ] Manual smoke: agent path — ask the chat agent to "find clips that say X"; verify `generate_cassette_tape` is invoked and produces a sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)