### PR TITLE
Defer Cut tab rebuild + bundle clip thumbnails + 'include trimmed clips' toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,7 @@ test_clips/
 .cog/
 **/model/
 !models/  # Keep our models/ source directory
+
+# Local agent tooling artifacts
+.claude/scheduled_tasks.lock
+.context/

--- a/core/analysis/cinematography.py
+++ b/core/analysis/cinematography.py
@@ -316,6 +316,25 @@ left, right, up, down, forward, backward, clockwise, counterclockwise
 Return your analysis as a JSON object with these exact field names."""
 
 
+def _coerce_cinematography_payload(data: object) -> dict:
+    """Return a cinematography object from provider JSON payload variants."""
+    if isinstance(data, dict):
+        return data
+
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                logger.info(
+                    "Cinematography response was a JSON list; using first object item"
+                )
+                return item
+        raise ValueError("Cinematography response JSON list did not contain an object")
+
+    raise ValueError(
+        f"Cinematography response JSON must be an object, got {type(data).__name__}"
+    )
+
+
 def _parse_json_response(response_text: str) -> dict:
     """Parse JSON from VLM response, handling markdown code blocks.
 
@@ -332,7 +351,7 @@ def _parse_json_response(response_text: str) -> dict:
 
     # Try direct JSON parse first
     try:
-        return json.loads(text)
+        return _coerce_cinematography_payload(json.loads(text))
     except json.JSONDecodeError:
         pass
 
@@ -341,7 +360,7 @@ def _parse_json_response(response_text: str) -> dict:
     match = re.search(code_block_pattern, text, re.DOTALL)
     if match:
         try:
-            return json.loads(match.group(1).strip())
+            return _coerce_cinematography_payload(json.loads(match.group(1).strip()))
         except json.JSONDecodeError:
             pass
 
@@ -350,7 +369,7 @@ def _parse_json_response(response_text: str) -> dict:
     match = re.search(json_pattern, text, re.DOTALL)
     if match:
         try:
-            return json.loads(match.group(0))
+            return _coerce_cinematography_payload(json.loads(match.group(0)))
         except json.JSONDecodeError:
             pass
 

--- a/core/chat_tools.py
+++ b/core/chat_tools.py
@@ -7624,8 +7624,9 @@ def export_clips(
 @tools.register(
     description="Export the current project as a self-contained bundle folder. "
                 "The bundle includes the project file, thumbnails, and optionally "
-                "the source video files. Use lightweight=True to skip copying video "
-                "files (project file + thumbnails only). "
+                "source video files and trimmed clip media. Use lightweight=True to "
+                "skip copying video files and exporting trimmed clips (project file "
+                "+ thumbnails only). "
                 "Runs in background - may take significant time for large projects.",
     requires_project=True,
     modifies_gui_state=True,
@@ -7636,12 +7637,16 @@ def export_bundle(
     project,
     output_path: Optional[str] = None,
     lightweight: bool = False,
+    include_clips: Optional[bool] = None,
 ) -> dict:
     """Export the project as a self-contained bundle folder.
 
     Args:
         output_path: Destination directory path (optional, defaults to export_dir)
-        lightweight: If True, skip copying source video files (default False)
+        lightweight: If True, skip copying source video files and trimmed clips
+            by default.
+        include_clips: Whether to export trimmed clip media. Defaults to
+            not lightweight.
 
     Returns:
         Dict with _wait_for_worker marker for async execution
@@ -7673,9 +7678,14 @@ def export_bundle(
         return {"success": False, "error": "Bundle export already in progress"}
 
     include_videos = not lightweight
+    should_include_clips = not lightweight if include_clips is None else include_clips
 
     # Start async export via worker
-    started = main_window.start_agent_export_bundle(dest_dir, include_videos)
+    started = main_window.start_agent_export_bundle(
+        dest_dir,
+        include_videos,
+        should_include_clips,
+    )
     if not started:
         return {"success": False, "error": "Failed to start bundle export worker"}
 
@@ -7684,6 +7694,7 @@ def export_bundle(
         "_wait_for_worker": "export_bundle",
         "output_path": str(dest_dir),
         "include_videos": include_videos,
+        "include_clips": should_include_clips,
     }
 
 

--- a/core/project.py
+++ b/core/project.py
@@ -222,7 +222,7 @@ def save_project(
     if progress_callback:
         progress_callback(0.4, "Serializing clips...")
 
-    project_data["clips"] = [clip.to_dict() for clip in clips]
+    project_data["clips"] = [clip.to_dict(base_path=base_path) for clip in clips]
 
     # Copy/link pre-rendered clips into project folder
     if progress_callback:
@@ -537,7 +537,7 @@ def load_project(
     for clip_data in data.get("clips", []):
         source_id = clip_data.get("source_id", "")
         if source_id in sources_by_id:
-            clip = Clip.from_dict(clip_data)
+            clip = Clip.from_dict(clip_data, base_path=base_path)
             clips.append(clip)
         else:
             logger.warning(f"Skipping clip with missing source: {clip_data.get('id')}")

--- a/core/project_export.py
+++ b/core/project_export.py
@@ -38,11 +38,13 @@ class ExportResult:
     audio_sources_copied: int = 0
     clips_exported: int = 0
     clips_skipped: int = 0
+    thumbnails_copied: int = 0
     sources_skipped: list[str] = field(default_factory=list)
     frames_skipped: list[str] = field(default_factory=list)
     audio_sources_skipped: list[str] = field(default_factory=list)
     total_bytes: int = 0
     include_videos: bool = True
+    include_clips: bool = True
 
 
 def _build_filename_map(
@@ -98,6 +100,7 @@ def _strip_absolute_paths(project_json_path: Path) -> None:
     def _remove_absolute_paths(obj):
         if isinstance(obj, dict):
             obj.pop("_absolute_path", None)
+            obj.pop("_thumbnail_absolute_path", None)
             for value in obj.values():
                 _remove_absolute_paths(value)
         elif isinstance(obj, list):
@@ -114,6 +117,7 @@ def export_project_bundle(
     project: Project,
     dest_dir: Path,
     include_videos: bool = True,
+    include_clips: bool = True,
     progress_callback: Optional[Callable[[int, int, str], None]] = None,
     cancel_check: Optional[Callable[[], bool]] = None,
 ) -> ExportResult:
@@ -124,6 +128,7 @@ def export_project_bundle(
         dest_dir: Destination directory for the bundle. Must not exist
             (caller handles overwrite confirmation).
         include_videos: If True, copy source video files into the bundle.
+        include_clips: If True, export trimmed clip media into the bundle.
         progress_callback: Optional callback(current, total, filename) for
             progress reporting.
         cancel_check: Optional callable returning True if the user requested
@@ -139,18 +144,24 @@ def export_project_bundle(
     if dest_dir.exists():
         raise FileExistsError(f"Destination already exists: {dest_dir}")
 
-    result = ExportResult(dest_dir=dest_dir, include_videos=include_videos)
+    result = ExportResult(
+        dest_dir=dest_dir,
+        include_videos=include_videos,
+        include_clips=include_clips,
+    )
 
     # Create bundle directory structure
     sources_dir = dest_dir / "sources"
     frames_dir = dest_dir / "frames"
     audio_dir = dest_dir / "audio"
     clips_dir = dest_dir / "clips"
+    thumbnails_dir = dest_dir / "thumbnails"
     dest_dir.mkdir(parents=True)
     sources_dir.mkdir()
     frames_dir.mkdir()
     audio_dir.mkdir()
     clips_dir.mkdir()
+    thumbnails_dir.mkdir()
 
     try:
         # Build filename maps for collision resolution
@@ -163,7 +174,9 @@ def export_project_bundle(
         audio_name_map = _build_filename_map(audio_paths, "audio")
 
         # Count total files to process for progress
-        total_files = len(project.frames) + len(project.clips) + len(project.audio_sources)
+        total_files = len(project.frames) + len(project.audio_sources)
+        if include_clips:
+            total_files += len(project.clips)
         if include_videos:
             total_files += len(project.sources)
         current_file = 0
@@ -215,7 +228,7 @@ def export_project_bundle(
                 progress_callback(current_file, total_files, audio.file_path.name)
 
         # Export trimmed clips using FFmpeg
-        if project.clips:
+        if include_clips and project.clips:
             result = _export_trimmed_clips(
                 project, clips_dir, result,
                 current_file, total_files,
@@ -225,6 +238,8 @@ def export_project_bundle(
                 _cleanup_partial_bundle(dest_dir)
                 return result
             current_file += len(project.clips)
+
+        copied_source_paths: set[Path] = set()
 
         # Copy source video files (if requested)
         if include_videos:
@@ -240,6 +255,7 @@ def export_project_bundle(
                 dest_path = dest_dir / bundle_rel
                 if source.file_path.exists():
                     shutil.copy2(source.file_path, dest_path)
+                    copied_source_paths.add(source.file_path)
                     result.sources_copied += 1
                     result.total_bytes += source.file_path.stat().st_size
                 else:
@@ -257,10 +273,17 @@ def export_project_bundle(
         # Build rewritten Source objects pointing into bundle subdirectories
         rewritten_sources = []
         for source in project.sources:
-            bundle_rel = source_name_map.get(source.file_path, f"sources/{source.filename}")
+            if source.file_path in copied_source_paths:
+                bundle_rel = source_name_map.get(
+                    source.file_path,
+                    f"sources/{source.filename}",
+                )
+                file_path = Path(bundle_rel)
+            else:
+                file_path = source.file_path
             # Create a shallow copy with rewritten file_path
             from dataclasses import replace
-            rewritten = replace(source, file_path=Path(bundle_rel))
+            rewritten = replace(source, file_path=file_path)
             rewritten_sources.append(rewritten)
 
         # Build rewritten Frame objects
@@ -279,6 +302,28 @@ def export_project_bundle(
             rewritten = replace(audio, file_path=Path(bundle_rel))
             rewritten_audio_sources.append(rewritten)
 
+        # Copy clip thumbnails into the bundle and build rewritten Clip objects.
+        # Carries cached thumbnails across machines so re-opening a bundle skips
+        # the expensive _regenerate_missing_thumbnails pass.
+        from dataclasses import replace
+        rewritten_clips: list = []
+        for clip in project.clips:
+            new_thumb_path: Optional[Path] = None
+            src_thumb = clip.thumbnail_path
+            if src_thumb and src_thumb.exists():
+                bundle_rel = f"thumbnails/{clip.id}{src_thumb.suffix or '.jpg'}"
+                dest_thumb = dest_dir / bundle_rel
+                try:
+                    shutil.copy2(src_thumb, dest_thumb)
+                    result.thumbnails_copied += 1
+                    result.total_bytes += dest_thumb.stat().st_size
+                    new_thumb_path = Path(bundle_rel)
+                except OSError as e:
+                    logger.warning(
+                        "Failed to copy thumbnail for clip %s: %s", clip.id, e
+                    )
+            rewritten_clips.append(replace(clip, thumbnail_path=new_thumb_path))
+
         # Save the project file into the bundle
         project_name = project.metadata.name or "Untitled Project"
         project_filename = f"{project_name}.sceneripper"
@@ -294,6 +339,7 @@ def export_project_bundle(
             rewritten_sources,
             rewritten_frames,
             rewritten_audio_sources,
+            rewritten_clips,
         )
 
         # Strip _absolute_path fields from the exported JSON
@@ -389,6 +435,7 @@ def _write_bundle_project_file(
     rewritten_sources,
     rewritten_frames,
     rewritten_audio_sources,
+    rewritten_clips,
 ) -> None:
     """Write the project JSON with rewritten paths.
 
@@ -399,7 +446,7 @@ def _write_bundle_project_file(
     save_project(
         filepath=filepath,
         sources=rewritten_sources,
-        clips=project.clips,
+        clips=rewritten_clips,
         sequence=project.sequence,
         ui_state=project.ui_state,
         metadata=project.metadata,

--- a/core/transcription.py
+++ b/core/transcription.py
@@ -115,6 +115,15 @@ def _has_audio_stream(path: Path) -> Optional[bool]:
 
     return bool(result.stdout.strip())
 
+
+def _require_ffmpeg() -> str:
+    """Return the resolved FFmpeg path or raise a user-facing transcription error."""
+    ffmpeg_path = find_binary("ffmpeg")
+    if ffmpeg_path is None:
+        raise FFmpegNotFoundError()
+    return ffmpeg_path
+
+
 # Available model configurations
 WHISPER_MODELS = {
     "tiny.en": {"size": "39MB", "speed": "~32x", "accuracy": "Basic", "vram": "<1GB"},
@@ -147,6 +156,16 @@ class TranscriptionError(Exception):
     pass
 
 
+class FFmpegNotFoundError(TranscriptionError):
+    """Raised when FFmpeg is required but unavailable."""
+
+    def __init__(self):
+        super().__init__(
+            "FFmpeg is required for transcription but was not found. "
+            "Install FFmpeg from Settings > Dependencies and try again."
+        )
+
+
 class FasterWhisperNotInstalledError(TranscriptionError):
     """Raised when faster-whisper is not installed."""
     def __init__(self):
@@ -166,7 +185,7 @@ def is_faster_whisper_available() -> bool:
     global _faster_whisper_available
     if _faster_whisper_available is None:
         try:
-            import faster_whisper
+            import faster_whisper  # noqa: F401
             _faster_whisper_available = True
         except ImportError:
             _faster_whisper_available = False
@@ -468,7 +487,7 @@ def _transcribe_video_mlx(
         tmp_path = Path(tmp.name)
 
     try:
-        _ffmpeg = find_binary("ffmpeg") or "ffmpeg"
+        _ffmpeg = _require_ffmpeg()
         subprocess.run(
             [
                 _ffmpeg, "-y",
@@ -540,7 +559,7 @@ def transcribe_clip(
 
     try:
         # Extract audio segment with FFmpeg
-        _ffmpeg = find_binary("ffmpeg") or "ffmpeg"
+        _ffmpeg = _require_ffmpeg()
         subprocess.run(
             [
                 _ffmpeg, "-y",
@@ -595,6 +614,8 @@ def transcribe_clip(
 
         return results
 
+    except FileNotFoundError as e:
+        raise FFmpegNotFoundError() from e
     except subprocess.CalledProcessError as e:
         logger.warning(f"FFmpeg failed to extract audio: {e.stderr.decode() if e.stderr else e}")
         return []
@@ -693,7 +714,7 @@ def _transcribe_cloud_groq(
         with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
             tmp_path = Path(tmp.name)
         try:
-            _ffmpeg = find_binary("ffmpeg") or "ffmpeg"
+            _ffmpeg = _require_ffmpeg()
             subprocess.run(
                 [
                     _ffmpeg, "-y",

--- a/models/clip.py
+++ b/models/clip.py
@@ -178,6 +178,40 @@ class Source:
         )
 
 
+def _resolve_thumbnail_path(
+    data: dict,
+    base_path: Optional[Path],
+) -> Optional[Path]:
+    """Resolve a clip's persisted thumbnail_path against base_path.
+
+    Returns None when no path is stored, when path traversal is detected, or
+    when neither the resolved path nor the absolute fallback exists on disk.
+    A None result lets the loader regenerate or skip the missing thumbnail.
+    """
+    raw = data.get("thumbnail_path")
+    if not raw:
+        return None
+    candidate = Path(raw)
+    if base_path and not candidate.is_absolute():
+        resolved = (base_path / candidate).resolve()
+        try:
+            resolved.relative_to(base_path.resolve())
+        except ValueError:
+            logger.warning(
+                "Thumbnail path traversal detected, ignoring: %s", raw
+            )
+            return None
+        candidate = resolved
+    if candidate.exists():
+        return candidate
+    fallback = data.get("_thumbnail_absolute_path")
+    if fallback:
+        fallback_path = Path(fallback)
+        if fallback_path.exists():
+            return fallback_path
+    return None
+
+
 def _validate_optional_float(value, field_name: str) -> Optional[float]:
     """Validate that a deserialized value is a float or None."""
     if value is None:
@@ -348,8 +382,12 @@ class Clip:
                 seen.add(normalized)
         return " | ".join(unique_texts) if unique_texts else None
 
-    def to_dict(self) -> dict:
-        """Serialize to dictionary for JSON export."""
+    def to_dict(self, base_path: Optional[Path] = None) -> dict:
+        """Serialize to dictionary for JSON export.
+
+        Args:
+            base_path: If provided, store thumbnail_path relative to this directory.
+        """
         data = {
             "id": self.id,
             "source_id": self.source_id,
@@ -359,6 +397,18 @@ class Clip:
         # Custom name (only if set)
         if self.name:
             data["name"] = self.name
+        # Thumbnail path: prefer relative-to-base when possible so bundles are portable
+        if self.thumbnail_path:
+            if base_path:
+                try:
+                    data["thumbnail_path"] = (
+                        self.thumbnail_path.relative_to(base_path).as_posix()
+                    )
+                except ValueError:
+                    data["thumbnail_path"] = self.thumbnail_path.as_posix()
+                data["_thumbnail_absolute_path"] = self.thumbnail_path.as_posix()
+            else:
+                data["thumbnail_path"] = self.thumbnail_path.as_posix()
         # Colors as RGB objects
         if self.dominant_colors:
             data["dominant_colors"] = [
@@ -433,8 +483,13 @@ class Clip:
         return data
 
     @classmethod
-    def from_dict(cls, data: dict) -> "Clip":
-        """Deserialize from dictionary."""
+    def from_dict(cls, data: dict, base_path: Optional[Path] = None) -> "Clip":
+        """Deserialize from dictionary.
+
+        Args:
+            data: Dictionary from JSON
+            base_path: Base directory to resolve relative thumbnail_path against
+        """
         from core.transcription import TranscriptSegment
         from models.cinematography import CinematographyAnalysis
 
@@ -504,13 +559,15 @@ class Clip:
             if not face_embeddings:
                 face_embeddings = None
 
+        thumbnail_path = _resolve_thumbnail_path(data, base_path)
+
         return cls(
             id=data.get("id", str(uuid.uuid4())),
             source_id=data.get("source_id", ""),
             start_frame=data.get("start_frame", 0),
             end_frame=data.get("end_frame", 0),
             name=data.get("name", ""),  # Backwards compatible: defaults to empty
-            thumbnail_path=None,  # Regenerate on load
+            thumbnail_path=thumbnail_path,
             dominant_colors=colors,
             shot_type=data.get("shot_type"),
             transcript=transcript,

--- a/tests/test_analysis_pipeline.py
+++ b/tests/test_analysis_pipeline.py
@@ -368,7 +368,7 @@ def test_launch_worker_emits_pipeline_completion(
     assert harness.finished_ops == [expected_op]
 
 
-def test_shot_type_error_handler_shows_reason(monkeypatch):
+def test_shot_type_error_handler_records_reason():
     messages = []
 
     class Harness:
@@ -377,21 +377,15 @@ def test_shot_type_error_handler_shows_reason(monkeypatch):
             self._gui_state = SimpleNamespace(set_last_error=lambda value: messages.append(("last_error", value)))
             self.status_bar = SimpleNamespace(showMessage=lambda text, timeout=0: messages.append(("status", text, timeout)))
 
-    def _capture_warning(parent, title, message):
-        messages.append(("dialog", title, message))
-
-    monkeypatch.setattr("ui.main_window.QMessageBox.warning", _capture_warning)
-
     harness = Harness()
     MainWindow._on_shot_type_error(harness, "clip-1: torch import failed")
 
     assert harness._shot_type_run_error == "clip-1: torch import failed"
     assert ("last_error", "Shot type classification error: clip-1: torch import failed") in messages
     assert ("status", "Shot type classification finished with errors", 5000) in messages
-    assert ("dialog", "Shot Type Classification Error", "clip-1: torch import failed") in messages
 
 
-def test_description_error_handler_surfaces_first_error(monkeypatch):
+def test_description_error_handler_records_first_error():
     messages = []
 
     class Harness:
@@ -407,11 +401,6 @@ def test_description_error_handler_surfaces_first_error(monkeypatch):
 
         def _summarize_description_errors(self):
             return MainWindow._summarize_description_errors(self)
-
-    def _capture_warning(parent, title, message):
-        messages.append(("dialog", title, message))
-
-    monkeypatch.setattr("ui.main_window.QMessageBox.warning", _capture_warning)
 
     harness = Harness()
     MainWindow._on_description_error(harness, "clip-1", "401 Unauthorized")
@@ -422,10 +411,9 @@ def test_description_error_handler_surfaces_first_error(monkeypatch):
         "Description error: clip-1: 401 Unauthorized",
     ) in messages
     assert ("status", "Description generation finished with errors", 5000) in messages
-    assert ("dialog", "Description Error", "clip-1: 401 Unauthorized") in messages
 
 
-def test_description_error_handler_summarizes_multiple_failures(monkeypatch):
+def test_description_error_handler_summarizes_multiple_failures():
     messages = []
 
     class Harness:
@@ -442,8 +430,6 @@ def test_description_error_handler_summarizes_multiple_failures(monkeypatch):
         def _summarize_description_errors(self):
             return MainWindow._summarize_description_errors(self)
 
-    monkeypatch.setattr("ui.main_window.QMessageBox.warning", lambda *args: messages.append(("dialog", args[1], args[2])))
-
     harness = Harness()
     MainWindow._on_description_error(harness, "clip-1", "401 Unauthorized")
     MainWindow._on_description_error(harness, "clip-2", "429 Too Many Requests")
@@ -452,4 +438,39 @@ def test_description_error_handler_summarizes_multiple_failures(monkeypatch):
     assert "- clip-1: 401 Unauthorized" in harness._description_run_error
     assert "- clip-2: 429 Too Many Requests" in harness._description_run_error
     assert messages.count(("status", "Description generation finished with errors", 5000)) == 2
-    assert len([m for m in messages if m[0] == "dialog"]) == 1
+
+
+def test_analysis_error_summary_dialog_is_aggregated(monkeypatch):
+    messages = []
+
+    class Harness:
+        _color_run_error = None
+        _shot_type_run_error = None
+        _classification_run_error = None
+        _object_detection_run_error = None
+        _text_extraction_run_error = None
+        _transcription_run_error = "FFmpeg is required for transcription"
+        _description_run_error = "clip-1: 401 Unauthorized"
+        _cinematography_run_error = None
+
+        def _get_completed_analysis_error_details(self, completed_ops):
+            return MainWindow._get_completed_analysis_error_details(self, completed_ops)
+
+    monkeypatch.setattr(
+        "ui.main_window.QMessageBox.warning",
+        lambda _parent, title, message: messages.append((title, message)),
+    )
+
+    harness = Harness()
+    MainWindow._show_completed_analysis_error_dialog(
+        harness,
+        ["transcribe", "describe"],
+    )
+
+    assert len(messages) == 1
+    title, message = messages[0]
+    assert title == "Analysis Finished With Errors"
+    assert "Transcription:" in message
+    assert "FFmpeg is required for transcription" in message
+    assert "Description:" in message
+    assert "clip-1: 401 Unauthorized" in message

--- a/tests/test_analysis_workers.py
+++ b/tests/test_analysis_workers.py
@@ -389,7 +389,10 @@ class TestTranscriptionWorkerTaskBuilding:
         clip_without = make_test_clip("c2")
 
         worker = TranscriptionWorker(
-            [clip_with, clip_without], source, skip_existing=True
+            [clip_with, clip_without],
+            source,
+            skip_existing=True,
+            backend="faster-whisper",
         )
         assert len(worker._tasks) == 1
         assert worker._tasks[0].clip_id == "c2"
@@ -401,7 +404,10 @@ class TestTranscriptionWorkerTaskBuilding:
         clip_without = make_test_clip("c2")
 
         worker = TranscriptionWorker(
-            [clip_with, clip_without], source, skip_existing=False
+            [clip_with, clip_without],
+            source,
+            skip_existing=False,
+            backend="faster-whisper",
         )
         assert len(worker._tasks) == 2
 
@@ -410,7 +416,7 @@ class TestTranscriptionWorkerTaskBuilding:
 
         clip = make_test_clip("c1", start_frame=300, end_frame=600)
 
-        worker = TranscriptionWorker([clip], source)
+        worker = TranscriptionWorker([clip], source, backend="faster-whisper")
         assert len(worker._tasks) == 1
         task = worker._tasks[0]
         assert task.start_time == 300 / 30.0  # 10.0 seconds
@@ -446,6 +452,72 @@ class TestTranscriptionWorkerTaskBuilding:
 
         worker = TranscriptionWorker([], source, parallelism=4, backend="auto")
         assert worker._parallelism == 1
+
+
+class TestTranscriptionWorkerErrors:
+    def test_missing_ffmpeg_emits_single_batch_error(self, source, monkeypatch):
+        from ui.workers.transcription_worker import TranscriptionWorker
+
+        clips = [make_test_clip("clip-1"), make_test_clip("clip-2")]
+        worker = TranscriptionWorker(
+            clips,
+            source,
+            backend="faster-whisper",
+            skip_existing=False,
+        )
+
+        monkeypatch.setattr("core.binary_resolver.find_binary", lambda _name: None)
+        monkeypatch.setattr(
+            "core.transcription.get_model",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("model should not load when ffmpeg is missing")
+            ),
+        )
+
+        errors = []
+        completed = []
+        worker.error.connect(errors.append)
+        worker.transcription_completed.connect(lambda: completed.append(True))
+
+        worker.run()
+
+        assert completed == [True]
+        assert len(errors) == 1
+        assert "FFmpeg is required for transcription" in errors[0]
+
+    def test_emits_aggregated_error_summary(self, source, monkeypatch):
+        from ui.workers.transcription_worker import TranscriptionWorker
+
+        clips = [make_test_clip("clip-1"), make_test_clip("clip-2")]
+        worker = TranscriptionWorker(
+            clips,
+            source,
+            parallelism=1,
+            backend="faster-whisper",
+            skip_existing=False,
+        )
+
+        monkeypatch.setattr("core.binary_resolver.find_binary", lambda _name: "/usr/bin/ffmpeg")
+        monkeypatch.setattr("core.transcription.get_model", lambda *_args, **_kwargs: object())
+        monkeypatch.setattr(
+            worker,
+            "_process_task",
+            lambda task: (task.clip_id, None, "audio extraction failed", False),
+        )
+
+        errors = []
+        completed = []
+        worker.error.connect(errors.append)
+        worker.transcription_completed.connect(lambda: completed.append(True))
+
+        worker.run()
+
+        assert completed == [True]
+        assert len(errors) == 1
+        assert "Transcription failed for 2 clips" in errors[0]
+        assert "clip-1" in errors[0]
+        assert "clip-2" in errors[0]
+        assert "audio extraction failed" in errors[0]
 
 
 # --- ClassificationWorker ---
@@ -637,6 +709,89 @@ class TestDescriptionWorkerTaskBuilding:
 
         worker = DescriptionWorker([clip], sources=sources_by_id)
         assert len(worker._tasks) == 0
+
+
+class TestDescriptionWorkerRetries:
+    def test_retries_transient_provider_500(
+        self,
+        monkeypatch,
+        thumbnail_path,
+        sources_by_id,
+    ):
+        from ui.workers.description_worker import DescriptionWorker
+
+        clip = _make_clip_with_thumb("clip-1", thumbnail_path)
+        worker = DescriptionWorker(
+            [clip],
+            sources=sources_by_id,
+            tier="cloud",
+            skip_existing=False,
+        )
+
+        attempts = []
+        sleeps = []
+
+        def _describe_frame(*_args, **_kwargs):
+            attempts.append(True)
+            if len(attempts) == 1:
+                raise RuntimeError(
+                    "Video description failed (gemini-3.1-flash-lite-preview): "
+                    "litellm.InternalServerError: 500 Internal error encountered."
+                )
+            return "Recovered description", "gemini-3.1-flash-lite-preview (video)"
+
+        monkeypatch.setattr("core.analysis.description.describe_frame", _describe_frame)
+        monkeypatch.setattr(
+            "ui.workers.description_worker.time.sleep",
+            lambda delay: sleeps.append(delay),
+        )
+
+        clip_id, description, model, error = worker._process_task(worker._tasks[0])
+
+        assert clip_id == "clip-1"
+        assert description == "Recovered description"
+        assert model == "gemini-3.1-flash-lite-preview (video)"
+        assert error is None
+        assert len(attempts) == 2
+        assert sleeps == [2]
+
+    def test_does_not_retry_auth_errors(
+        self,
+        monkeypatch,
+        thumbnail_path,
+        sources_by_id,
+    ):
+        from ui.workers.description_worker import DescriptionWorker
+
+        clip = _make_clip_with_thumb("clip-1", thumbnail_path)
+        worker = DescriptionWorker(
+            [clip],
+            sources=sources_by_id,
+            tier="cloud",
+            skip_existing=False,
+        )
+
+        attempts = []
+
+        def _describe_frame(*_args, **_kwargs):
+            attempts.append(True)
+            raise RuntimeError("Video description failed: authentication failed")
+
+        monkeypatch.setattr("core.analysis.description.describe_frame", _describe_frame)
+        monkeypatch.setattr(
+            "ui.workers.description_worker.time.sleep",
+            lambda _delay: (_ for _ in ()).throw(
+                AssertionError("auth errors should not sleep for retry")
+            ),
+        )
+
+        clip_id, description, model, error = worker._process_task(worker._tasks[0])
+
+        assert clip_id == "clip-1"
+        assert description is None
+        assert model is None
+        assert "authentication failed" in error
+        assert len(attempts) == 1
 
 
 # --- Settings round-trip ---

--- a/tests/test_chat_tools.py
+++ b/tests/test_chat_tools.py
@@ -1249,8 +1249,9 @@ class TestExportBundle:
         assert "_wait_for_worker" in result
         assert result["_wait_for_worker"] == "export_bundle"
         assert result["include_videos"] is True
+        assert result["include_clips"] is True
         main_window.start_agent_export_bundle.assert_called_once_with(
-            tmp_path / "test_bundle", True
+            tmp_path / "test_bundle", True, True
         )
 
     def test_export_bundle_lightweight(self, tmp_path):
@@ -1267,8 +1268,33 @@ class TestExportBundle:
 
         assert "_wait_for_worker" in result
         assert result["include_videos"] is False
+        assert result["include_clips"] is False
         main_window.start_agent_export_bundle.assert_called_once_with(
-            tmp_path / "test_bundle", False
+            tmp_path / "test_bundle", False, False
+        )
+
+    def test_export_bundle_can_skip_trimmed_clips(self, tmp_path):
+        """Test export_bundle can skip trimmed clip media independently."""
+        from core.chat_tools import export_bundle
+
+        project = _create_chat_test_project()
+        main_window = Mock()
+        main_window.export_bundle_worker = None
+        main_window.start_agent_export_bundle.return_value = True
+
+        dest = str(tmp_path / "test_bundle")
+        result = export_bundle(
+            main_window,
+            project,
+            output_path=dest,
+            include_clips=False,
+        )
+
+        assert "_wait_for_worker" in result
+        assert result["include_videos"] is True
+        assert result["include_clips"] is False
+        main_window.start_agent_export_bundle.assert_called_once_with(
+            tmp_path / "test_bundle", True, False
         )
 
     def test_export_bundle_worker_fails_to_start(self, tmp_path):

--- a/tests/test_cinematography_analysis.py
+++ b/tests/test_cinematography_analysis.py
@@ -1,0 +1,33 @@
+"""Regression tests for cinematography analysis parsing."""
+
+import pytest
+
+from core.analysis.cinematography import _parse_json_response
+
+
+def test_parse_json_response_accepts_list_wrapped_object():
+    payload = """
+    [
+      {
+        "shot_size": "CU",
+        "camera_angle": "eye_level",
+        "subject_position": "center",
+        "subject_count": "single",
+        "focus_type": "shallow",
+        "lighting_style": "natural",
+        "lighting_direction": "front",
+        "emotional_intensity": "medium",
+        "suggested_pacing": "medium"
+      }
+    ]
+    """
+
+    result = _parse_json_response(payload)
+
+    assert result["shot_size"] == "CU"
+    assert result["camera_angle"] == "eye_level"
+
+
+def test_parse_json_response_rejects_list_without_object():
+    with pytest.raises(ValueError, match="JSON list did not contain an object"):
+        _parse_json_response('["CU", "eye_level"]')

--- a/tests/test_clip_browser_selection.py
+++ b/tests/test_clip_browser_selection.py
@@ -60,6 +60,23 @@ def test_select_all_excludes_disabled_clips(qapp, source, monkeypatch):
     assert selected_ids == {"c2", "c4"}
 
 
+def test_add_clips_bulk_populates_lookup_once(qapp, source, monkeypatch):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clips = [make_test_clip("c1"), make_test_clip("c2"), make_test_clip("c3")]
+    rebuilds = []
+
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda: rebuilds.append(True))
+
+    browser.add_clips([(clip, source) for clip in clips])
+
+    assert [thumb.clip.id for thumb in browser.thumbnails] == ["c1", "c2", "c3"]
+    assert set(browser._thumbnail_by_id) == {"c1", "c2", "c3"}
+    assert all(browser.get_source_for_clip(clip.id) is source for clip in clips)
+    assert rebuilds == [True]
+
+
 def test_toggle_disabled_unselects_only_toggled_clip(qapp, source):
     from ui.clip_browser import ClipBrowser
 

--- a/tests/test_clip_browser_selection.py
+++ b/tests/test_clip_browser_selection.py
@@ -77,6 +77,26 @@ def test_add_clips_bulk_populates_lookup_once(qapp, source, monkeypatch):
     assert rebuilds == [True]
 
 
+def test_add_clips_defer_rebuild_skips_until_finalize(qapp, source, monkeypatch):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    rebuilds = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda: rebuilds.append(True))
+
+    # Three deferred batches must not trigger any rebuild.
+    for batch_idx in range(3):
+        clips = [make_test_clip(f"b{batch_idx}-{i}") for i in range(2)]
+        browser.add_clips([(c, source) for c in clips], defer_rebuild=True)
+
+    assert rebuilds == []
+    assert len(browser.thumbnails) == 6
+
+    # finalize_batch_load() flushes a single rebuild.
+    browser.finalize_batch_load()
+    assert rebuilds == [True]
+
+
 def test_toggle_disabled_unselects_only_toggled_clip(qapp, source):
     from ui.clip_browser import ClipBrowser
 

--- a/tests/test_project_export.py
+++ b/tests/test_project_export.py
@@ -250,7 +250,7 @@ class TestExportProjectBundle:
         assert result.sources_copied == 2
 
     def test_lightweight_export_skips_videos(self, tmp_path):
-        """Lightweight export writes source paths in JSON but doesn't copy files."""
+        """Lightweight export keeps original source paths when videos are not copied."""
         originals = tmp_path / "originals"
         originals.mkdir()
         source = _make_source(originals, "video.mp4", size=2048)
@@ -264,9 +264,10 @@ class TestExportProjectBundle:
         assert not (dest / "sources" / "video.mp4").exists()
         assert result.sources_copied == 0
 
-        # But JSON still references sources/video.mp4
+        # Source was not copied, so the JSON should not point at a missing
+        # bundle-local source path.
         project_json = json.loads((dest / "Light.sceneripper").read_text())
-        assert project_json["sources"][0]["file_path"] == "sources/video.mp4"
+        assert project_json["sources"][0]["file_path"] == source.file_path.as_posix()
 
     def test_lightweight_export_still_copies_frames(self, tmp_path):
         """Lightweight export copies frame files even when videos are excluded."""
@@ -282,6 +283,55 @@ class TestExportProjectBundle:
 
         assert (dest / "frames" / "f1.png").exists()
         assert result.frames_copied == 1
+
+    @patch("core.ffmpeg.FFmpegProcessor")
+    def test_export_can_skip_trimmed_clips(self, mock_ffmpeg_cls, tmp_path):
+        """Bundle export can preserve clip metadata without exporting media files."""
+        originals = tmp_path / "originals"
+        originals.mkdir()
+        source = _make_source(originals, "video.mp4")
+        clip = Clip(id="c1", source_id=source.id, start_frame=0, end_frame=90)
+
+        project = _make_project(sources=[source], clips=[clip], name="NoClipMedia")
+        dest = tmp_path / "NoClipMedia-export"
+
+        result = export_project_bundle(project, dest, include_clips=False)
+
+        assert result.include_clips is False
+        assert result.clips_exported == 0
+        assert not any((dest / "clips").iterdir())
+        mock_ffmpeg_cls.return_value.extract_clip.assert_not_called()
+
+        data = json.loads((dest / "NoClipMedia.sceneripper").read_text())
+        assert data["clips"][0]["id"] == "c1"
+
+    @patch("core.ffmpeg.FFmpegProcessor")
+    def test_lightweight_export_can_skip_videos_and_trimmed_clips(
+        self,
+        mock_ffmpeg_cls,
+        tmp_path,
+    ):
+        """Lightweight bundles can omit both source videos and trimmed clip media."""
+        originals = tmp_path / "originals"
+        originals.mkdir()
+        source = _make_source(originals, "video.mp4")
+        clip = Clip(id="c1", source_id=source.id, start_frame=0, end_frame=90)
+
+        project = _make_project(sources=[source], clips=[clip], name="LightNoClips")
+        dest = tmp_path / "LightNoClips-export"
+
+        result = export_project_bundle(
+            project,
+            dest,
+            include_videos=False,
+            include_clips=False,
+        )
+
+        assert result.sources_copied == 0
+        assert result.clips_exported == 0
+        assert not (dest / "sources" / "video.mp4").exists()
+        assert not any((dest / "clips").iterdir())
+        mock_ffmpeg_cls.return_value.extract_clip.assert_not_called()
 
     def test_missing_source_skipped_with_warning(self, tmp_path, caplog):
         """Missing source videos are skipped and logged."""
@@ -300,6 +350,9 @@ class TestExportProjectBundle:
         assert len(result.sources_skipped) == 1
         assert "nonexistent.mp4" in result.sources_skipped[0]
 
+        project_json = json.loads((dest / "MissingSrc.sceneripper").read_text())
+        assert project_json["sources"][0]["file_path"] == source.file_path.as_posix()
+
     def test_missing_frame_skipped_with_warning(self, tmp_path, caplog):
         """Missing frame files are skipped and logged."""
         frame = Frame(
@@ -315,6 +368,90 @@ class TestExportProjectBundle:
         assert result.frames_copied == 0
         assert len(result.frames_skipped) == 1
         assert "nonexistent.png" in result.frames_skipped[0]
+
+    def test_clip_thumbnails_copied_into_bundle(self, tmp_path):
+        """Clip thumbnails are copied into bundle/thumbnails/ and JSON paths rewritten."""
+        originals = tmp_path / "originals"
+        originals.mkdir()
+        cache = tmp_path / "thumb-cache"
+        cache.mkdir()
+
+        source = _make_source(originals, "video.mp4")
+
+        thumb_a = cache / "thumb_a.jpg"
+        thumb_a.write_bytes(b"\xff\xd8\xff\xe0jpgA")
+        clip_a = Clip(
+            id="c-a",
+            source_id=source.id,
+            start_frame=0,
+            end_frame=90,
+            thumbnail_path=thumb_a,
+        )
+
+        # Clip with a thumbnail_path that no longer exists on disk — should be
+        # silently skipped; export must not crash and JSON should drop the path.
+        clip_b = Clip(
+            id="c-b",
+            source_id=source.id,
+            start_frame=90,
+            end_frame=180,
+            thumbnail_path=cache / "missing.jpg",
+        )
+
+        project = _make_project(
+            sources=[source],
+            clips=[clip_a, clip_b],
+            name="ThumbBundle",
+        )
+        dest = tmp_path / "ThumbBundle-export"
+
+        result = export_project_bundle(project, dest, include_clips=False)
+
+        # Only the existing thumbnail is copied into the bundle.
+        assert result.thumbnails_copied == 1
+        copied = dest / "thumbnails" / "c-a.jpg"
+        assert copied.exists()
+        assert copied.read_bytes() == thumb_a.read_bytes()
+
+        # JSON references the relative bundle path, no absolute fallback leaks.
+        data = json.loads((dest / "ThumbBundle.sceneripper").read_text())
+        clips_by_id = {c["id"]: c for c in data["clips"]}
+        assert clips_by_id["c-a"]["thumbnail_path"] == "thumbnails/c-a.jpg"
+        assert "_thumbnail_absolute_path" not in clips_by_id["c-a"]
+        assert "thumbnail_path" not in clips_by_id["c-b"]
+
+        # In-memory project state is not mutated by the export.
+        assert clip_a.thumbnail_path == thumb_a
+        assert clip_b.thumbnail_path == cache / "missing.jpg"
+
+    def test_clip_thumbnails_round_trip_through_load(self, tmp_path):
+        """A bundled thumbnail is restored to the loaded Clip without regeneration."""
+        originals = tmp_path / "originals"
+        originals.mkdir()
+        cache = tmp_path / "cache"
+        cache.mkdir()
+
+        source = _make_source(originals, "video.mp4")
+        thumb = cache / "thumb_xyz.jpg"
+        thumb.write_bytes(b"\xff\xd8\xff\xe0RT")
+        clip = Clip(
+            id="c-rt",
+            source_id=source.id,
+            start_frame=0,
+            end_frame=60,
+            thumbnail_path=thumb,
+        )
+        project = _make_project(
+            sources=[source], clips=[clip], name="RoundTrip",
+        )
+        dest = tmp_path / "RoundTrip-export"
+
+        export_project_bundle(project, dest, include_clips=False)
+
+        _, clips, *_ = load_project(dest / "RoundTrip.sceneripper")
+        assert clips[0].thumbnail_path is not None
+        assert clips[0].thumbnail_path.exists()
+        assert clips[0].thumbnail_path.read_bytes() == thumb.read_bytes()
 
     def test_dest_already_exists_raises(self, tmp_path):
         """Export raises FileExistsError if destination already exists."""
@@ -566,8 +703,8 @@ class TestExportThenLoadRoundTrip:
         # Verify metadata
         assert metadata.name == "RoundTrip"
 
-    def test_lightweight_round_trip_triggers_missing_callback(self, tmp_path):
-        """Loading a lightweight bundle triggers missing_source_callback."""
+    def test_lightweight_round_trip_keeps_original_source_path(self, tmp_path):
+        """Loading a lightweight bundle resolves the original source path."""
         originals = tmp_path / "originals"
         originals.mkdir()
         source = _make_source(originals, "video.mp4")
@@ -577,7 +714,8 @@ class TestExportThenLoadRoundTrip:
 
         export_project_bundle(project, dest, include_videos=False)
 
-        # Load the lightweight bundle — source video won't exist in bundle
+        # Load the lightweight bundle. The source video was not copied, so the
+        # exported project should keep using the original source path.
         project_file = dest / "LightRT.sceneripper"
         missing_callback = Mock(return_value=None)
 
@@ -586,7 +724,6 @@ class TestExportThenLoadRoundTrip:
             missing_source_callback=missing_callback,
         )
 
-        # Callback should have been called for the missing source
-        assert missing_callback.called
-        # Source was skipped (callback returned None)
-        assert len(loaded_sources) == 0
+        assert not missing_callback.called
+        assert len(loaded_sources) == 1
+        assert loaded_sources[0].file_path == source.file_path

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -2,7 +2,9 @@
 
 from pathlib import Path
 
-from core.transcription import transcribe_clip, transcribe_video
+import pytest
+
+from core.transcription import FFmpegNotFoundError, transcribe_clip, transcribe_video
 
 
 def test_transcribe_clip_skips_video_without_audio(monkeypatch):
@@ -41,3 +43,24 @@ def test_transcribe_video_skips_video_without_audio(monkeypatch):
 
     assert result == []
     assert progress == [(1.0, "No audio track found")]
+
+
+def test_transcribe_clip_missing_ffmpeg_raises_clear_error(monkeypatch):
+    """Missing FFmpeg should fail before subprocess tries the literal command."""
+    monkeypatch.setattr("core.transcription._has_audio_stream", lambda _path: None)
+    monkeypatch.setattr("core.transcription._resolve_backend", lambda _backend: "faster-whisper")
+    monkeypatch.setattr("core.transcription.find_binary", lambda _name: None)
+    monkeypatch.setattr(
+        "core.transcription.subprocess.run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("subprocess should not run without ffmpeg")
+        ),
+    )
+
+    with pytest.raises(FFmpegNotFoundError, match="FFmpeg is required for transcription"):
+        transcribe_clip(
+            Path("/tmp/video.mp4"),
+            start_time=0.0,
+            end_time=5.0,
+            backend="faster-whisper",
+        )

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -7,7 +7,45 @@ from typing import Optional
 
 import numpy as np
 
+from PySide6.QtCore import Qt, Signal, QMimeData, QRect, QTimer
+from PySide6.QtGui import QPixmap, QDrag, QPainter, QColor, QKeyEvent, QAction
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QHBoxLayout,
+    QScrollArea,
+    QGridLayout,
+    QLabel,
+    QFrame,
+    QApplication,
+    QComboBox,
+    QLineEdit,
+    QPushButton,
+    QMenu,
+    QToolButton,
+    QGraphicsOpacityEffect,
+    QRubberBand,
+)
+
+from core.analysis.color import (
+    get_primary_hue,
+    classify_color_palette,
+    get_palette_display_name,
+    COLOR_PALETTES,
+)
+from core.analysis.gaze import GAZE_CATEGORY_DISPLAY
+from core.analysis.shots import get_display_name, SHOT_TYPES
 from core.filter_state import FilterState
+from core.film_glossary import get_badge_tooltip
+from models.clip import Clip, Source
+from models.cinematography import CinematographyAnalysis
+from ui.gradient_glow import paint_gradient_glow, paint_card_body, RoundedTopLabel
+from ui.theme import theme, UISizes, TypeScale, Spacing, Radii
+from ui.widgets.range_slider import RangeSlider
+from ui.widgets.source_group_header import SourceGroupHeader
+
+# Reverse map: display label -> internal key (built once at module load)
+_GAZE_DISPLAY_TO_KEY = {v: k for k, v in GAZE_CATEGORY_DISPLAY.items()}
 
 # Resolve the has-analysis-of-type predicate at module load so the hot
 # `_matches_filter` loop doesn't re-import on every clip check, and so that
@@ -41,42 +79,6 @@ def _combo_text_for_enum(value_set, *, fallback):
     if len(value_set) == 1:
         return next(iter(value_set))
     return fallback
-
-
-from PySide6.QtWidgets import (
-    QWidget,
-    QVBoxLayout,
-    QHBoxLayout,
-    QScrollArea,
-    QGridLayout,
-    QLabel,
-    QFrame,
-    QApplication,
-    QComboBox,
-    QLineEdit,
-    QPushButton,
-    QMenu,
-    QToolButton,
-    QGraphicsOpacityEffect,
-    QRubberBand,
-)
-from PySide6.QtCore import Qt, Signal, QMimeData, QRect, QTimer
-from PySide6.QtGui import QPixmap, QDrag, QPainter, QColor, QKeyEvent, QAction
-
-from ui.widgets.range_slider import RangeSlider
-from ui.widgets.source_group_header import SourceGroupHeader
-
-from models.clip import Clip, Source
-from models.cinematography import CinematographyAnalysis
-from core.analysis.color import get_primary_hue, classify_color_palette, get_palette_display_name, COLOR_PALETTES
-from core.analysis.gaze import GAZE_CATEGORY_DISPLAY
-
-# Reverse map: display label -> internal key (built once at module load)
-_GAZE_DISPLAY_TO_KEY = {v: k for k, v in GAZE_CATEGORY_DISPLAY.items()}
-from core.analysis.shots import get_display_name, SHOT_TYPES
-from core.film_glossary import get_badge_tooltip
-from ui.theme import theme, UISizes, TypeScale, Spacing, Radii
-from ui.gradient_glow import paint_gradient_glow, paint_card_body, RoundedTopLabel
 
 logger = logging.getLogger(__name__)
 
@@ -1056,8 +1058,8 @@ class ClipBrowser(QWidget):
             self.grid.removeWidget(self.empty_label)
             self._empty_label_in_grid = False
 
-    def add_clip(self, clip: Clip, source: Source):
-        """Add a clip to the browser."""
+    def _create_thumbnail(self, clip: Clip, source: Source) -> ClipThumbnail:
+        """Create and wire a thumbnail widget for a clip."""
         # Store source reference
         self._source_lookup[clip.id] = source
 
@@ -1070,6 +1072,14 @@ class ClipBrowser(QWidget):
         thumb.export_requested.connect(self._on_export_requested)
         thumb.find_similar_requested.connect(self._activate_similarity)
 
+        return thumb
+
+    def add_clip(self, clip: Clip, source: Source):
+        """Add a clip to the browser."""
+        if clip.id in self._thumbnail_by_id:
+            return
+
+        thumb = self._create_thumbnail(clip, source)
         self.thumbnails.append(thumb)
         self._thumbnail_by_id[clip.id] = thumb  # O(1) lookup
 
@@ -1081,6 +1091,26 @@ class ClipBrowser(QWidget):
         self._rebuild_grid()
 
         # Update duration range for spinboxes
+        self._update_duration_range()
+
+    def add_clips(self, clip_source_pairs: list[tuple[Clip, Source]]) -> None:
+        """Add multiple clips with one filter sync and one grid rebuild."""
+        added: list[Clip] = []
+        for clip, source in clip_source_pairs:
+            if clip.id in self._thumbnail_by_id:
+                continue
+            thumb = self._create_thumbnail(clip, source)
+            self.thumbnails.append(thumb)
+            self._thumbnail_by_id[clip.id] = thumb
+            added.append(clip)
+
+        if not added:
+            return
+
+        self._sync_custom_query_filter_options()
+        for clip in added:
+            self._incremental_filter_enable(clip)
+        self._rebuild_grid()
         self._update_duration_range()
 
     def clear(self):

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -1093,8 +1093,17 @@ class ClipBrowser(QWidget):
         # Update duration range for spinboxes
         self._update_duration_range()
 
-    def add_clips(self, clip_source_pairs: list[tuple[Clip, Source]]) -> None:
-        """Add multiple clips with one filter sync and one grid rebuild."""
+    def add_clips(
+        self,
+        clip_source_pairs: list[tuple[Clip, Source]],
+        defer_rebuild: bool = False,
+    ) -> None:
+        """Add multiple clips with one filter sync and one grid rebuild.
+
+        When called repeatedly during batched project loads, set
+        `defer_rebuild=True` to skip the per-batch grid rebuild and duration
+        refresh, then call `finalize_batch_load()` once after the final batch.
+        """
         added: list[Clip] = []
         for clip, source in clip_source_pairs:
             if clip.id in self._thumbnail_by_id:
@@ -1110,6 +1119,12 @@ class ClipBrowser(QWidget):
         self._sync_custom_query_filter_options()
         for clip in added:
             self._incremental_filter_enable(clip)
+        if not defer_rebuild:
+            self._rebuild_grid()
+            self._update_duration_range()
+
+    def finalize_batch_load(self) -> None:
+        """Flush deferred rebuilds after a series of `add_clips(defer_rebuild=True)` calls."""
         self._rebuild_grid()
         self._update_duration_range()
 

--- a/ui/dialogs/export_bundle_dialog.py
+++ b/ui/dialogs/export_bundle_dialog.py
@@ -18,8 +18,6 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QFileDialog,
 )
-from PySide6.QtCore import Qt
-
 from core.project import Project
 from core.settings import format_size
 from ui.theme import theme, TypeScale, Spacing, UISizes
@@ -88,6 +86,11 @@ class ExportBundleDialog(QDialog):
         self._include_videos_cb.toggled.connect(self._update_summary)
         layout.addWidget(self._include_videos_cb)
 
+        self._include_clips_cb = QCheckBox("Include trimmed clips")
+        self._include_clips_cb.setChecked(True)
+        self._include_clips_cb.toggled.connect(self._update_summary)
+        layout.addWidget(self._include_clips_cb)
+
         # Summary label
         self._summary_label = QLabel()
         self._summary_label.setWordWrap(True)
@@ -126,6 +129,7 @@ class ExportBundleDialog(QDialog):
         clips = self._project.clips
         frames = self._project.frames
         include_videos = self._include_videos_cb.isChecked()
+        include_clips = self._include_clips_cb.isChecked()
 
         # Calculate video sizes
         video_size = 0
@@ -156,7 +160,8 @@ class ExportBundleDialog(QDialog):
             size_str = format_size(video_size) if include_videos else "excluded"
             parts.append(f"{len(sources)} source(s) ({size_str})")
         if clips:
-            parts.append(f"{len(clips)} trimmed clip(s)")
+            clip_str = "will be exported" if include_clips else "excluded"
+            parts.append(f"{len(clips)} trimmed clip(s) ({clip_str})")
         if frames:
             parts.append(f"{len(frames)} frame(s) ({format_size(frame_size)})")
 
@@ -169,7 +174,7 @@ class ExportBundleDialog(QDialog):
         total = frame_size + (video_size if include_videos else 0)
         if total > 0:
             summary += f"\nEstimated bundle size: {format_size(total)}"
-            if clips:
+            if clips and include_clips:
                 summary += " + trimmed clips"
 
         # Warnings for missing files
@@ -193,3 +198,7 @@ class ExportBundleDialog(QDialog):
     @property
     def include_videos(self) -> bool:
         return self._include_videos_cb.isChecked()
+
+    @property
+    def include_clips(self) -> bool:
+        return self._include_clips_cb.isChecked()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -818,6 +818,8 @@ class MainWindow(QMainWindow):
         self._text_extraction_run_error: Optional[str] = None
         self._cinematography_run_error: Optional[str] = None
         self._shot_type_run_error: Optional[str] = None
+        self._transcription_run_error: Optional[str] = None
+        self._transcription_run_errors: list[str] = []
         self._transcription_finished_handled = False
         self._text_extraction_finished_handled = False
         self._cinematography_finished_handled = False
@@ -4368,6 +4370,7 @@ class MainWindow(QMainWindow):
             self.status_bar.showMessage(
                 f"Analysis finished with errors ({', '.join(error_labels)}) - {clip_count} clips ({', '.join(completed)})"
             )
+            self._show_completed_analysis_error_dialog(completed)
         else:
             self.status_bar.showMessage(
                 f"Analysis complete - {clip_count} clips ({', '.join(completed)})"
@@ -4456,29 +4459,11 @@ class MainWindow(QMainWindow):
     def _on_transcription_error(self, error: str):
         """Handle transcription error."""
         logger.error(f"Transcription error: {error}")
+        if error not in self._transcription_run_errors:
+            self._transcription_run_errors.append(error)
+        self._transcription_run_error = self._summarize_transcription_errors()
         self._gui_state.set_last_error(f"Transcription error: {error}")
-        self.progress_bar.setVisible(False)
-
-        if "not installed" in error.lower():
-            QMessageBox.critical(
-                self,
-                "Transcription Error",
-                "The faster-whisper package is not installed.\n\n"
-                "Install it with: pip install faster-whisper"
-            )
-        elif "download" in error.lower() or "model" in error.lower():
-            QMessageBox.warning(
-                self,
-                "Model Download Error",
-                f"Failed to download or load the Whisper model:\n\n{error}\n\n"
-                "Check your internet connection and try again."
-            )
-        else:
-            QMessageBox.warning(
-                self,
-                "Transcription Error",
-                f"An error occurred during transcription:\n\n{error}"
-            )
+        self.status_bar.showMessage("Transcription finished with errors", 5000)
 
     @Slot(str)
     def _on_shot_type_error(self, error_msg: str):
@@ -4491,11 +4476,6 @@ class MainWindow(QMainWindow):
         self.status_bar.showMessage(
             "Shot type classification finished with errors",
             5000,
-        )
-        QMessageBox.warning(
-            self,
-            "Shot Type Classification Error",
-            error_msg,
         )
 
     def _on_classify_from_tab(self):
@@ -4528,12 +4508,6 @@ class MainWindow(QMainWindow):
             "Description generation finished with errors",
             5000,
         )
-        if len(self._description_run_errors) == 1:
-            QMessageBox.warning(
-                self,
-                "Description Error",
-                summary_line,
-            )
 
     @Slot(str)
     def _on_color_error(self, error_msg: str):
@@ -4574,6 +4548,11 @@ class MainWindow(QMainWindow):
         self._description_run_error = None
         self._description_run_errors = []
 
+    def _reset_transcription_run_errors(self) -> None:
+        """Clear accumulated transcription errors for a new run."""
+        self._transcription_run_error = None
+        self._transcription_run_errors = []
+
     def _summarize_description_errors(self) -> Optional[str]:
         """Return a compact summary of accumulated description errors."""
         if not self._description_run_errors:
@@ -4587,6 +4566,26 @@ class MainWindow(QMainWindow):
         summary = (
             f"Description failed for {len(self._description_run_errors)} clips:\n\n"
             f"{preview}"
+        )
+        if remaining > 0:
+            summary += f"\n\n... and {remaining} more"
+        return summary
+
+    def _summarize_transcription_errors(self) -> Optional[str]:
+        """Return a compact summary of accumulated transcription errors."""
+        if not self._transcription_run_errors:
+            return None
+
+        if len(self._transcription_run_errors) == 1:
+            return self._transcription_run_errors[0]
+
+        preview = "\n".join(
+            f"- {message}" for message in self._transcription_run_errors[:3]
+        )
+        remaining = len(self._transcription_run_errors) - 3
+        summary = (
+            f"Transcription failed in {len(self._transcription_run_errors)} "
+            f"batches:\n\n{preview}"
         )
         if remaining > 0:
             summary += f"\n\n... and {remaining} more"
@@ -4606,19 +4605,10 @@ class MainWindow(QMainWindow):
             setattr(self, attr_name, None)
         elif op_key == "describe":
             self._reset_description_run_errors()
+        elif op_key == "transcribe":
+            self._reset_transcription_run_errors()
         elif op_key == "shots":
             self._shot_type_run_error = None
-
-    # Map error handler attr names to analysis op keys for reinstall prompts
-    _ERROR_ATTR_TO_OP_KEY: dict[str, str] = {
-        "_color_run_error": "colors",
-        "_shot_type_run_error": "shots",
-        "_classification_run_error": "classify",
-        "_object_detection_run_error": "detect_objects",
-        "_text_extraction_run_error": "extract_text",
-        "_description_run_error": "describe",
-        "_cinematography_run_error": "cinematography",
-    }
 
     def _record_analysis_run_error(
         self,
@@ -4627,87 +4617,61 @@ class MainWindow(QMainWindow):
         error_msg: str,
         dialog_title: str,
     ) -> None:
-        """Persist and surface a summarized analysis error.
-
-        If the error looks like a missing module, offers to reinstall dependencies.
-        """
+        """Persist an analysis error for the end-of-run summary dialog."""
         first_error = getattr(self, attr_name) is None
         setattr(self, attr_name, error_msg)
         self._gui_state.set_last_error(f"{ui_label} error: {error_msg}")
         self.status_bar.showMessage(f"{ui_label} finished with errors", 5000)
         if first_error:
-            if self._is_missing_module_error(error_msg):
-                self._offer_dependency_reinstall(attr_name, ui_label, error_msg, dialog_title)
-            else:
-                QMessageBox.warning(self, dialog_title, error_msg)
-
-    @staticmethod
-    def _is_missing_module_error(error_msg: str) -> bool:
-        """Check if an error message indicates a missing Python module."""
-        lowered = error_msg.lower()
-        return (
-            "no module named" in lowered
-            or "runtime is incomplete" in lowered
-            or "cannot import name" in lowered
-            or "module" in lowered and "has no attribute" in lowered
-        )
-
-    def _offer_dependency_reinstall(
-        self,
-        attr_name: str,
-        ui_label: str,
-        error_msg: str,
-        dialog_title: str,
-    ) -> None:
-        """Show error with option to reinstall missing dependencies."""
-        op_key = self._ERROR_ATTR_TO_OP_KEY.get(attr_name)
-
-        reply = QMessageBox.question(
-            self,
-            dialog_title,
-            f"{error_msg}\n\n"
-            "This looks like a missing or corrupted package.\n"
-            "Would you like to reinstall the dependencies?",
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.Yes,
-        )
-
-        if reply != QMessageBox.Yes or not op_key:
-            return
-
-        from core.analysis_dependencies import get_operation_feature_candidates
-
-        candidates = get_operation_feature_candidates(op_key, self.settings)
-        if not candidates:
-            return
-
-        from ui.widgets.dependency_widgets import prompt_feature_download
-
-        feature_name = candidates[0]
-        if prompt_feature_download(feature_name, self):
-            self.status_bar.showMessage(
-                f"{ui_label} dependencies reinstalled. Try running the analysis again.",
-                5000,
+            logger.info(
+                "%s error dialog deferred until analysis completion: %s",
+                ui_label,
+                dialog_title,
             )
-            # Clear the error so the next run starts fresh
-            setattr(self, attr_name, None)
 
     def _get_completed_analysis_error_labels(self, completed_ops: list[str]) -> list[str]:
         """Return user-facing labels for analysis operations that finished with errors."""
-        labels: list[str] = []
+        return [
+            label
+            for _, _, label in self._get_completed_analysis_error_details(completed_ops)
+        ]
+
+    def _get_completed_analysis_error_details(
+        self,
+        completed_ops: list[str],
+    ) -> list[tuple[str, str, str]]:
+        """Return (op_key, error, label) for completed operations with errors."""
+        details: list[tuple[str, str, str]] = []
         op_errors = [
             ("colors", self._color_run_error, "colors"),
             ("shots", self._shot_type_run_error, "shot type"),
             ("classify", self._classification_run_error, "classification"),
             ("detect_objects", self._object_detection_run_error, "object detection"),
             ("extract_text", self._text_extraction_run_error, "text extraction"),
+            ("transcribe", self._transcription_run_error, "transcription"),
             ("describe", self._description_run_error, "description"),
             ("cinematography", self._cinematography_run_error, "cinematography"),
         ]
         for op_key, error_value, label in op_errors:
             if error_value and op_key in completed_ops:
-                labels.append(label)
-        return labels
+                details.append((op_key, error_value, label))
+        return details
+
+    def _show_completed_analysis_error_dialog(self, completed_ops: list[str]) -> None:
+        """Show one aggregated error dialog after an analysis run finishes."""
+        details = self._get_completed_analysis_error_details(completed_ops)
+        if not details:
+            return
+
+        sections = [
+            f"{label.title()}:\n{error_value}"
+            for _, error_value, label in details
+        ]
+        QMessageBox.warning(
+            self,
+            "Analysis Finished With Errors",
+            "Some analysis operations failed:\n\n" + "\n\n".join(sections),
+        )
 
     def _on_description_analysis_requested(self, clip_ids: list):
         """Handle description analysis request from Sequence tab (Storyteller).
@@ -6859,6 +6823,7 @@ class MainWindow(QMainWindow):
                 f"Frame analysis finished with errors ({', '.join(error_labels)})",
                 5000,
             )
+            self._show_completed_analysis_error_dialog(completed_ops)
         else:
             self.status_bar.showMessage("Frame analysis complete", 3000)
 

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -82,7 +82,7 @@ from core.analysis_operations import (
     OPERATIONS_BY_KEY,
     PHASE_ORDER,
 )
-from ui.workers.base import CancellableWorker
+from ui.workers.base import CancellableWorker, summarize_messages
 from ui.workers.cinematography_worker import CinematographyWorker
 from ui.workers.color_worker import ColorAnalysisWorker
 from ui.workers.shot_type_worker import ShotTypeWorker
@@ -4517,7 +4517,6 @@ class MainWindow(QMainWindow):
             "_color_run_error",
             "Color extraction",
             error_msg,
-            "Color Extraction Error",
         )
 
     @Slot(str)
@@ -4528,7 +4527,6 @@ class MainWindow(QMainWindow):
             "_classification_run_error",
             "Content classification",
             error_msg,
-            "Classification Error",
         )
 
     @Slot(str)
@@ -4537,10 +4535,8 @@ class MainWindow(QMainWindow):
         logger.warning(f"Object detection error: {error_msg}")
         self._record_analysis_run_error(
             "_object_detection_run_error",
-            error_msg=error_msg,
-            ui_label="Object detection",
-            dialog_title="Object Detection Error",
-            attr_name="_object_detection_run_error",
+            "Object detection",
+            error_msg,
         )
 
     def _reset_description_run_errors(self) -> None:
@@ -4557,39 +4553,22 @@ class MainWindow(QMainWindow):
         """Return a compact summary of accumulated description errors."""
         if not self._description_run_errors:
             return None
-
-        preview = "\n".join(f"- {message}" for message in self._description_run_errors[:3])
-        if len(self._description_run_errors) == 1:
-            return self._description_run_errors[0]
-
-        remaining = len(self._description_run_errors) - 3
-        summary = (
-            f"Description failed for {len(self._description_run_errors)} clips:\n\n"
-            f"{preview}"
+        return summarize_messages(
+            self._description_run_errors,
+            header=f"Description failed for {len(self._description_run_errors)} clips:",
         )
-        if remaining > 0:
-            summary += f"\n\n... and {remaining} more"
-        return summary
 
     def _summarize_transcription_errors(self) -> Optional[str]:
         """Return a compact summary of accumulated transcription errors."""
         if not self._transcription_run_errors:
             return None
-
-        if len(self._transcription_run_errors) == 1:
-            return self._transcription_run_errors[0]
-
-        preview = "\n".join(
-            f"- {message}" for message in self._transcription_run_errors[:3]
+        return summarize_messages(
+            self._transcription_run_errors,
+            header=(
+                f"Transcription failed in {len(self._transcription_run_errors)} "
+                "batches:"
+            ),
         )
-        remaining = len(self._transcription_run_errors) - 3
-        summary = (
-            f"Transcription failed in {len(self._transcription_run_errors)} "
-            f"batches:\n\n{preview}"
-        )
-        if remaining > 0:
-            summary += f"\n\n... and {remaining} more"
-        return summary
 
     def _reset_analysis_run_error(self, op_key: str) -> None:
         """Clear the stored error summary for an analysis operation."""
@@ -4615,19 +4594,11 @@ class MainWindow(QMainWindow):
         attr_name: str,
         ui_label: str,
         error_msg: str,
-        dialog_title: str,
     ) -> None:
         """Persist an analysis error for the end-of-run summary dialog."""
-        first_error = getattr(self, attr_name) is None
         setattr(self, attr_name, error_msg)
         self._gui_state.set_last_error(f"{ui_label} error: {error_msg}")
         self.status_bar.showMessage(f"{ui_label} finished with errors", 5000)
-        if first_error:
-            logger.info(
-                "%s error dialog deferred until analysis completion: %s",
-                ui_label,
-                dialog_title,
-            )
 
     def _get_completed_analysis_error_labels(self, completed_ops: list[str]) -> list[str]:
         """Return user-facing labels for analysis operations that finished with errors."""
@@ -4747,7 +4718,6 @@ class MainWindow(QMainWindow):
             "_text_extraction_run_error",
             "Text extraction",
             error_msg,
-            "Text Extraction Error",
         )
 
     def _on_cinematography_from_tab(self):
@@ -4801,7 +4771,6 @@ class MainWindow(QMainWindow):
             "_cinematography_run_error",
             "Cinematography analysis",
             error_msg,
-            "Cinematography Error",
         )
 
     # Agent-triggered analysis completion handlers

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -10019,23 +10019,10 @@ class MainWindow(QMainWindow):
         self.cut_tab.set_source(self.current_source)
         self.cut_tab.clear_clips()
         self.cut_tab.set_clips(self.clips)
-
-        # Add clips to Cut tab browser with their correct source
-        for clip in self.clips:
-            clip_source = self.sources_by_id.get(clip.source_id)
-            if not clip_source:
-                logging.warning(f"Clip {clip.id} references unknown source {clip.source_id}")
-                continue
-            self.cut_tab.add_clip(clip, clip_source)
-            # Update colors and shot type if present
-            if clip.dominant_colors:
-                self.cut_tab.update_clip_colors(clip.id, clip.dominant_colors)
-            if clip.shot_type:
-                self.cut_tab.update_clip_shot_type(clip.id, clip.shot_type)
-            if clip.gaze_category:
-                self.cut_tab.update_clip_gaze(clip.id, clip.gaze_category)
-            if clip.transcript:
-                self.cut_tab.update_clip_transcript(clip.id, clip.transcript)
+        self._populate_cut_tab_clip_browser_incrementally(
+            filepath,
+            on_finished=self._regenerate_missing_thumbnails,
+        )
 
         # Set project reference on sequence tab and restore timeline state
         self.sequence_tab.set_project(self.project)
@@ -10063,8 +10050,59 @@ class MainWindow(QMainWindow):
             f"Project loaded: {filepath.name} ({len(self.clips)} clips)"
         )
 
-        # Regenerate missing thumbnails
-        self._regenerate_missing_thumbnails()
+    def _populate_cut_tab_clip_browser_incrementally(
+        self,
+        filepath: Path,
+        *,
+        on_finished=None,
+    ) -> None:
+        """Populate the Cut tab clip grid in small UI-thread batches."""
+        clip_source_pairs = []
+        for clip in self.clips:
+            clip_source = self.sources_by_id.get(clip.source_id)
+            if not clip_source:
+                logger.warning(
+                    "Clip %s references unknown source %s",
+                    clip.id,
+                    clip.source_id,
+                )
+                continue
+            clip_source_pairs.append((clip, clip_source))
+
+        total = len(clip_source_pairs)
+        if total == 0:
+            if on_finished:
+                on_finished()
+            return
+
+        generation = getattr(self, "_project_load_generation", 0) + 1
+        self._project_load_generation = generation
+        batch_size = 75
+
+        def add_batch(start: int = 0) -> None:
+            if getattr(self, "_project_load_generation", None) != generation:
+                return
+
+            batch = clip_source_pairs[start:start + batch_size]
+            if batch:
+                self.cut_tab.clip_browser.add_clips(batch)
+
+            loaded = min(start + len(batch), total)
+            if loaded < total:
+                self.status_bar.showMessage(
+                    f"Loading clip browser: {loaded}/{total} clips..."
+                )
+                QTimer.singleShot(0, lambda: add_batch(loaded))
+                return
+
+            self.status_bar.showMessage(
+                f"Project loaded: {filepath.name} ({len(self.clips)} clips)"
+            )
+            if on_finished:
+                on_finished()
+
+        self.status_bar.showMessage(f"Loading clip browser: 0/{total} clips...")
+        QTimer.singleShot(0, add_batch)
 
     def _clear_project_state(self):
         """Clear current project state.
@@ -10077,6 +10115,7 @@ class MainWindow(QMainWindow):
         # Stop playback and timers first
         self._stop_playback()
         self._auto_save_timer.stop()
+        self._project_load_generation = getattr(self, "_project_load_generation", 0) + 1
 
         # Stop any running workers
         self._stop_all_workers()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -7090,12 +7090,18 @@ class MainWindow(QMainWindow):
         self.export_worker.start()
         return True
 
-    def start_agent_export_bundle(self, dest_dir: Path, include_videos: bool = True) -> bool:
+    def start_agent_export_bundle(
+        self,
+        dest_dir: Path,
+        include_videos: bool = True,
+        include_clips: bool = True,
+    ) -> bool:
         """Start a bundle export triggered by agent.
 
         Args:
             dest_dir: Destination directory for the bundle
             include_videos: Whether to include source video files
+            include_clips: Whether to export trimmed clip media files
 
         Returns:
             True if export started, False if already in progress
@@ -7114,6 +7120,7 @@ class MainWindow(QMainWindow):
             project=self.project,
             dest_dir=dest_dir,
             include_videos=include_videos,
+            include_clips=include_clips,
             parent=self,
         )
         self.export_bundle_worker.progress.connect(self._on_export_bundle_progress)
@@ -9590,6 +9597,7 @@ class MainWindow(QMainWindow):
 
         dest_dir = dialog.dest_dir
         include_videos = dialog.include_videos
+        include_clips = dialog.include_clips
 
         if not dest_dir or str(dest_dir).strip() == "":
             return
@@ -9612,6 +9620,7 @@ class MainWindow(QMainWindow):
             project=self.project,
             dest_dir=dest_dir,
             include_videos=include_videos,
+            include_clips=include_clips,
             parent=self,
         )
         self.export_bundle_worker.progress.connect(self._on_export_bundle_progress)
@@ -9670,6 +9679,7 @@ class MainWindow(QMainWindow):
                     "sources_copied": result.sources_copied,
                     "clips_exported": result.clips_exported,
                     "frames_copied": result.frames_copied,
+                    "include_clips": result.include_clips,
                     "message": msg,
                 }
             }
@@ -10084,17 +10094,21 @@ class MainWindow(QMainWindow):
                 return
 
             batch = clip_source_pairs[start:start + batch_size]
-            if batch:
-                self.cut_tab.clip_browser.add_clips(batch)
-
             loaded = min(start + len(batch), total)
-            if loaded < total:
+            is_last_batch = loaded >= total
+            if batch:
+                self.cut_tab.clip_browser.add_clips(
+                    batch, defer_rebuild=not is_last_batch
+                )
+
+            if not is_last_batch:
                 self.status_bar.showMessage(
                     f"Loading clip browser: {loaded}/{total} clips..."
                 )
                 QTimer.singleShot(0, lambda: add_batch(loaded))
                 return
 
+            self.cut_tab.clip_browser.finalize_batch_load()
             self.status_bar.showMessage(
                 f"Project loaded: {filepath.name} ({len(self.clips)} clips)"
             )

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -7101,7 +7101,7 @@ class MainWindow(QMainWindow):
         Args:
             dest_dir: Destination directory for the bundle
             include_videos: Whether to include source video files
-            include_clips: Whether to export trimmed clip media files
+            include_clips: Whether to export trimmed clip media
 
         Returns:
             True if export started, False if already in progress

--- a/ui/workers/base.py
+++ b/ui/workers/base.py
@@ -5,10 +5,86 @@ Provides common functionality for cancellable QThread workers.
 
 import logging
 import threading
+from typing import Iterable
 
 from PySide6.QtCore import QThread, Signal
 
 logger = logging.getLogger(__name__)
+
+
+def is_transient_provider_error(message: str) -> bool:
+    """Return True for transient cloud/provider failures worth retrying.
+
+    Covers rate limits (429), gateway/server errors (500/502/503/504), and
+    network/timeout failures. Used by VLM/LLM workers (description, custom
+    query) that retry transient failures with exponential backoff.
+    """
+    normalized = message.lower()
+    return (
+        "429" in normalized
+        or "rate limit" in normalized
+        or "too many requests" in normalized
+        or "500" in normalized
+        or "502" in normalized
+        or "503" in normalized
+        or "504" in normalized
+        or "internalservererror" in normalized
+        or "internal error" in normalized
+        or "temporarily unavailable" in normalized
+        or "service unavailable" in normalized
+        or "timeout" in normalized
+        or "timed out" in normalized
+        or "connection" in normalized
+        or "network" in normalized
+    )
+
+
+def summarize_clip_errors(
+    errors: list[tuple[str, str]],
+    *,
+    operation_label: str,
+    preview_count: int = 3,
+) -> str:
+    """Return a compact user-facing summary for a batch of per-clip failures.
+
+    Used by analysis workers that collect (clip_id, message) pairs and need a
+    single string to surface to the user. When only one error is present, the
+    raw message is returned verbatim so callers don't see a redundant header.
+    """
+    if len(errors) == 1:
+        return errors[0][1]
+
+    preview = "\n".join(
+        f"- {clip_id}: {message}" for clip_id, message in errors[:preview_count]
+    )
+    remaining = len(errors) - preview_count
+    summary = f"{operation_label} failed for {len(errors)} clips:\n\n{preview}"
+    if remaining > 0:
+        summary += f"\n\n... and {remaining} more"
+    return summary
+
+
+def summarize_messages(
+    messages: Iterable[str],
+    *,
+    header: str,
+    preview_count: int = 3,
+) -> str:
+    """Return a compact summary for a list of pre-formatted error messages.
+
+    The single-message case returns the message verbatim. ``header`` is used
+    only when more than one message needs to be aggregated.
+    """
+    items = list(messages)
+    if len(items) == 1:
+        return items[0]
+
+    preview = "\n".join(f"- {message}" for message in items[:preview_count])
+    remaining = len(items) - preview_count
+    summary = f"{header}\n\n{preview}"
+    if remaining > 0:
+        summary += f"\n\n... and {remaining} more"
+    return summary
 
 
 class CancellableWorker(QThread):

--- a/ui/workers/cinematography_worker.py
+++ b/ui/workers/cinematography_worker.py
@@ -14,22 +14,14 @@ from PySide6.QtCore import Signal
 
 from core.analysis.cinematography import analyze_cinematography
 from models.cinematography import CinematographyAnalysis
-from ui.workers.base import CancellableWorker
+from ui.workers.base import CancellableWorker, summarize_clip_errors
 
 logger = logging.getLogger(__name__)
 
 
 def _summarize_errors(errors: list[tuple[str, str]]) -> str:
     """Return a compact user-facing summary for a batch failure."""
-    preview = "\n".join(f"- {clip_id}: {message}" for clip_id, message in errors[:3])
-    if len(errors) == 1:
-        return errors[0][1]
-
-    remaining = len(errors) - 3
-    summary = f"Cinematography analysis failed for {len(errors)} clips:\n\n{preview}"
-    if remaining > 0:
-        summary += f"\n\n... and {remaining} more"
-    return summary
+    return summarize_clip_errors(errors, operation_label="Cinematography analysis")
 
 
 @dataclass(frozen=True)

--- a/ui/workers/classification_worker.py
+++ b/ui/workers/classification_worker.py
@@ -12,22 +12,14 @@ from typing import Optional
 
 from PySide6.QtCore import Signal
 
-from ui.workers.base import CancellableWorker
+from ui.workers.base import CancellableWorker, summarize_clip_errors
 
 logger = logging.getLogger(__name__)
 
 
 def _summarize_errors(errors: list[tuple[str, str]]) -> str:
     """Return a compact user-facing summary for a batch failure."""
-    preview = "\n".join(f"- {clip_id}: {message}" for clip_id, message in errors[:3])
-    if len(errors) == 1:
-        return errors[0][1]
-
-    remaining = len(errors) - 3
-    summary = f"Content classification failed for {len(errors)} clips:\n\n{preview}"
-    if remaining > 0:
-        summary += f"\n\n... and {remaining} more"
-    return summary
+    return summarize_clip_errors(errors, operation_label="Content classification")
 
 
 @dataclass(frozen=True)

--- a/ui/workers/color_worker.py
+++ b/ui/workers/color_worker.py
@@ -13,22 +13,14 @@ from typing import Optional
 
 from PySide6.QtCore import Signal
 
-from ui.workers.base import CancellableWorker
+from ui.workers.base import CancellableWorker, summarize_clip_errors
 
 logger = logging.getLogger(__name__)
 
 
 def _summarize_errors(errors: list[tuple[str, str]]) -> str:
     """Return a compact user-facing summary for a batch failure."""
-    preview = "\n".join(f"- {clip_id}: {message}" for clip_id, message in errors[:3])
-    if len(errors) == 1:
-        return errors[0][1]
-
-    remaining = len(errors) - 3
-    summary = f"Color extraction failed for {len(errors)} clips:\n\n{preview}"
-    if remaining > 0:
-        summary += f"\n\n... and {remaining} more"
-    return summary
+    return summarize_clip_errors(errors, operation_label="Color extraction")
 
 
 @dataclass(frozen=True)

--- a/ui/workers/custom_query_worker.py
+++ b/ui/workers/custom_query_worker.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 from PySide6.QtCore import Signal
 
-from ui.workers.base import CancellableWorker
+from ui.workers.base import CancellableWorker, is_transient_provider_error
 
 logger = logging.getLogger(__name__)
 
@@ -172,11 +172,10 @@ class CustomQueryWorker(CancellableWorker):
                 return task.clip_id, task.query, match, confidence, model, None
             except Exception as e:
                 last_error = str(e)
-                is_rate_limit = "429" in last_error or "rate" in last_error.lower()
-                if is_rate_limit and attempt < _MAX_RETRIES:
+                if is_transient_provider_error(last_error) and attempt < _MAX_RETRIES:
                     delay = _RETRY_DELAYS[attempt]
                     logger.warning(
-                        f"Rate limit for {task.clip_id}, "
+                        f"Transient query failure for {task.clip_id}, "
                         f"retry {attempt + 1}/{_MAX_RETRIES} in {delay}s"
                     )
                     time.sleep(delay)

--- a/ui/workers/description_worker.py
+++ b/ui/workers/description_worker.py
@@ -14,35 +14,13 @@ from typing import Optional
 from PySide6.QtCore import Signal
 
 from core.settings import load_settings
-from ui.workers.base import CancellableWorker
+from ui.workers.base import CancellableWorker, is_transient_provider_error
 
 logger = logging.getLogger(__name__)
 
 # Retry configuration for cloud API rate limits
 _MAX_RETRIES = 3
 _RETRY_DELAYS = [2, 5, 10]  # seconds
-
-
-def _is_retryable_description_error(message: str) -> bool:
-    """Return True for transient cloud/provider failures worth retrying."""
-    normalized = message.lower()
-    return (
-        "429" in normalized
-        or "rate limit" in normalized
-        or "too many requests" in normalized
-        or "500" in normalized
-        or "502" in normalized
-        or "503" in normalized
-        or "504" in normalized
-        or "internalservererror" in normalized
-        or "internal error" in normalized
-        or "temporarily unavailable" in normalized
-        or "service unavailable" in normalized
-        or "timeout" in normalized
-        or "timed out" in normalized
-        or "connection" in normalized
-        or "network" in normalized
-    )
 
 
 @dataclass(frozen=True)
@@ -205,7 +183,7 @@ class DescriptionWorker(CancellableWorker):
                     return task.clip_id, None, None, description
             except Exception as e:
                 last_error = str(e)
-                if _is_retryable_description_error(last_error) and attempt < _MAX_RETRIES:
+                if is_transient_provider_error(last_error) and attempt < _MAX_RETRIES:
                     delay = _RETRY_DELAYS[attempt]
                     logger.warning(
                         f"Transient description failure for {task.clip_id}, "

--- a/ui/workers/description_worker.py
+++ b/ui/workers/description_worker.py
@@ -23,6 +23,28 @@ _MAX_RETRIES = 3
 _RETRY_DELAYS = [2, 5, 10]  # seconds
 
 
+def _is_retryable_description_error(message: str) -> bool:
+    """Return True for transient cloud/provider failures worth retrying."""
+    normalized = message.lower()
+    return (
+        "429" in normalized
+        or "rate limit" in normalized
+        or "too many requests" in normalized
+        or "500" in normalized
+        or "502" in normalized
+        or "503" in normalized
+        or "504" in normalized
+        or "internalservererror" in normalized
+        or "internal error" in normalized
+        or "temporarily unavailable" in normalized
+        or "service unavailable" in normalized
+        or "timeout" in normalized
+        or "timed out" in normalized
+        or "connection" in normalized
+        or "network" in normalized
+    )
+
+
 @dataclass(frozen=True)
 class DescriptionTask:
     """Immutable task data for thread pool execution."""
@@ -183,12 +205,10 @@ class DescriptionWorker(CancellableWorker):
                     return task.clip_id, None, None, description
             except Exception as e:
                 last_error = str(e)
-                # Retry on rate-limit errors
-                is_rate_limit = "429" in last_error or "rate" in last_error.lower()
-                if is_rate_limit and attempt < _MAX_RETRIES:
+                if _is_retryable_description_error(last_error) and attempt < _MAX_RETRIES:
                     delay = _RETRY_DELAYS[attempt]
                     logger.warning(
-                        f"Rate limit for {task.clip_id}, "
+                        f"Transient description failure for {task.clip_id}, "
                         f"retry {attempt + 1}/{_MAX_RETRIES} in {delay}s"
                     )
                     time.sleep(delay)

--- a/ui/workers/export_worker.py
+++ b/ui/workers/export_worker.py
@@ -32,12 +32,14 @@ class ExportBundleWorker(CancellableWorker):
         project: Project,
         dest_dir: Path,
         include_videos: bool = True,
+        include_clips: bool = True,
         parent=None,
     ):
         super().__init__(parent)
         self._project = project
         self._dest_dir = dest_dir
         self._include_videos = include_videos
+        self._include_clips = include_clips
 
     def run(self):
         self._log_start()
@@ -48,6 +50,7 @@ class ExportBundleWorker(CancellableWorker):
                 project=self._project,
                 dest_dir=self._dest_dir,
                 include_videos=self._include_videos,
+                include_clips=self._include_clips,
                 progress_callback=lambda c, t, f: self.progress.emit(c, t, f),
                 cancel_check=self.is_cancelled,
             )

--- a/ui/workers/object_detection_worker.py
+++ b/ui/workers/object_detection_worker.py
@@ -12,22 +12,14 @@ from typing import Optional
 
 from PySide6.QtCore import Signal
 
-from ui.workers.base import CancellableWorker
+from ui.workers.base import CancellableWorker, summarize_clip_errors
 
 logger = logging.getLogger(__name__)
 
 
 def _summarize_errors(errors: list[tuple[str, str]]) -> str:
     """Return a compact user-facing summary for a batch failure."""
-    preview = "\n".join(f"- {clip_id}: {message}" for clip_id, message in errors[:3])
-    if len(errors) == 1:
-        return errors[0][1]
-
-    remaining = len(errors) - 3
-    summary = f"Object detection failed for {len(errors)} clips:\n\n{preview}"
-    if remaining > 0:
-        summary += f"\n\n... and {remaining} more"
-    return summary
+    return summarize_clip_errors(errors, operation_label="Object detection")
 
 
 @dataclass(frozen=True)

--- a/ui/workers/text_extraction_worker.py
+++ b/ui/workers/text_extraction_worker.py
@@ -9,22 +9,14 @@ from typing import Optional
 
 from PySide6.QtCore import Signal
 
-from ui.workers.base import CancellableWorker
+from ui.workers.base import CancellableWorker, summarize_clip_errors
 
 logger = logging.getLogger(__name__)
 
 
 def _summarize_errors(errors: list[tuple[str, str]]) -> str:
     """Return a compact user-facing summary for a batch failure."""
-    preview = "\n".join(f"- {clip_id}: {message}" for clip_id, message in errors[:3])
-    if len(errors) == 1:
-        return errors[0][1]
-
-    remaining = len(errors) - 3
-    summary = f"Text extraction failed for {len(errors)} clips:\n\n{preview}"
-    if remaining > 0:
-        summary += f"\n\n... and {remaining} more"
-    return summary
+    return summarize_clip_errors(errors, operation_label="Text extraction")
 
 
 class TextExtractionWorker(CancellableWorker):

--- a/ui/workers/transcription_worker.py
+++ b/ui/workers/transcription_worker.py
@@ -13,22 +13,14 @@ from typing import Optional
 
 from PySide6.QtCore import Signal
 
-from ui.workers.base import CancellableWorker
+from ui.workers.base import CancellableWorker, summarize_clip_errors
 
 logger = logging.getLogger(__name__)
 
 
 def _summarize_errors(errors: list[tuple[str, str]]) -> str:
     """Return a compact user-facing summary for transcription failures."""
-    preview = "\n".join(f"- {clip_id}: {message}" for clip_id, message in errors[:3])
-    if len(errors) == 1:
-        return errors[0][1]
-
-    remaining = len(errors) - 3
-    summary = f"Transcription failed for {len(errors)} clips:\n\n{preview}"
-    if remaining > 0:
-        summary += f"\n\n... and {remaining} more"
-    return summary
+    return summarize_clip_errors(errors, operation_label="Transcription")
 
 
 @dataclass(frozen=True)
@@ -151,12 +143,10 @@ class TranscriptionWorker(CancellableWorker):
             return
 
         from core.binary_resolver import find_binary
+        from core.transcription import FFmpegNotFoundError
 
         if find_binary("ffmpeg") is None:
-            message = (
-                "FFmpeg is required for transcription but was not found. "
-                "Install FFmpeg from Settings > Dependencies and try again."
-            )
+            message = str(FFmpegNotFoundError())
             self._log_error(message)
             self.error.emit(message)
             self.transcription_completed.emit()

--- a/ui/workers/transcription_worker.py
+++ b/ui/workers/transcription_worker.py
@@ -18,6 +18,19 @@ from ui.workers.base import CancellableWorker
 logger = logging.getLogger(__name__)
 
 
+def _summarize_errors(errors: list[tuple[str, str]]) -> str:
+    """Return a compact user-facing summary for transcription failures."""
+    preview = "\n".join(f"- {clip_id}: {message}" for clip_id, message in errors[:3])
+    if len(errors) == 1:
+        return errors[0][1]
+
+    remaining = len(errors) - 3
+    summary = f"Transcription failed for {len(errors)} clips:\n\n{preview}"
+    if remaining > 0:
+        summary += f"\n\n... and {remaining} more"
+    return summary
+
+
 @dataclass(frozen=True)
 class TranscriptionTask:
     """Immutable task data for thread pool execution."""
@@ -107,6 +120,7 @@ class TranscriptionWorker(CancellableWorker):
         try:
             from core.transcription import (
                 transcribe_clip,
+                FFmpegNotFoundError,
                 FasterWhisperNotInstalledError,
                 ModelDownloadError,
             )
@@ -120,7 +134,7 @@ class TranscriptionWorker(CancellableWorker):
                 backend=self._backend,
             )
             return task.clip_id, segments, None, False
-        except (FasterWhisperNotInstalledError, ModelDownloadError) as e:
+        except (FFmpegNotFoundError, FasterWhisperNotInstalledError, ModelDownloadError) as e:
             return task.clip_id, None, str(e), True  # Critical error
         except Exception as e:
             return task.clip_id, None, str(e), False
@@ -132,6 +146,19 @@ class TranscriptionWorker(CancellableWorker):
         total = len(self._tasks)
         if total == 0:
             logger.info("No clips to process for transcription")
+            self.transcription_completed.emit()
+            self._log_complete()
+            return
+
+        from core.binary_resolver import find_binary
+
+        if find_binary("ffmpeg") is None:
+            message = (
+                "FFmpeg is required for transcription but was not found. "
+                "Install FFmpeg from Settings > Dependencies and try again."
+            )
+            self._log_error(message)
+            self.error.emit(message)
             self.transcription_completed.emit()
             self._log_complete()
             return
@@ -161,6 +188,7 @@ class TranscriptionWorker(CancellableWorker):
                 return
 
         completed = 0
+        errors: list[tuple[str, str]] = []
 
         with ThreadPoolExecutor(max_workers=self._parallelism) as executor:
             future_to_task = {
@@ -183,7 +211,7 @@ class TranscriptionWorker(CancellableWorker):
 
                     if error_msg and error_msg != "Cancelled":
                         self._log_error(error_msg, clip_id)
-                        self.error.emit(error_msg)
+                        errors.append((clip_id, error_msg))
                         if is_critical:
                             # Cancel all remaining work
                             for f in future_to_task:
@@ -193,8 +221,12 @@ class TranscriptionWorker(CancellableWorker):
                         self.transcript_ready.emit(clip_id, segments)
                 except Exception as e:
                     self._log_error(str(e), task.clip_id)
+                    errors.append((task.clip_id, str(e)))
 
                 self.progress.emit(completed, total)
+
+        if errors:
+            self.error.emit(_summarize_errors(errors))
 
         self.transcription_completed.emit()
         self._log_complete()


### PR DESCRIPTION
## Summary

Two related changes for project bundle export and large-project responsiveness.

**1. Defer `_rebuild_grid()` per batch**
Loading a project with 1485 clips was freezing the UI because each 75-clip batch in `_populate_cut_tab_clip_browser_incrementally` ended with a full `ClipBrowser._rebuild_grid()` over the growing thumbnail set — ~20 rebuilds doing O(N²) layout work. `add_clips` now accepts `defer_rebuild=True`; `main_window` passes it for every batch except the last, then calls a new `finalize_batch_load()` to flush a single rebuild + duration refresh.

**2. Persist `Clip.thumbnail_path` and bundle thumbnails on export**
`Clip.to_dict`/`from_dict` now serialize `thumbnail_path` relative to the project's base path (with an `_thumbnail_absolute_path` fallback that's stripped on bundle export). `export_project_bundle` copies clip thumbnails into `bundle/thumbnails/<clip_id>.<ext>` and rewrites the path so reopening a bundle on another machine skips the expensive `_regenerate_missing_thumbnails` step entirely.

**3. 'Include trimmed clips' bundle toggle**
Trimmed-clip media can be hundreds of MB for large projects. The export dialog grows an "Include trimmed clips" checkbox (default on), `ExportBundleWorker` and `MainWindow.start_agent_export_bundle` forward `include_clips`, and `chat_tools.export_bundle` exposes `include_clips: Optional[bool]` (defaults to `not lightweight`).

## Test plan

- [x] `pytest tests/` — 2241 passed locally
- [x] New unit test: deferred `add_clips` × 3 produces zero rebuilds; `finalize_batch_load()` produces exactly one
- [x] New round-trip test: bundle export → `load_project` restores `Clip.thumbnail_path` to the bundled file
- [x] New chat tool test: `export_bundle(include_clips=False)` independent of `lightweight`
- [ ] Manual: open a 1500-clip project, confirm UI stays responsive and Cut tab fills in
- [ ] Manual: export bundle, move folder, reopen — thumbnails appear without an FFmpeg regen pass
- [ ] Manual: export with "Include trimmed clips" off — bundle excludes trimmed clip MP4s but keeps everything else

🤖 Generated with [Claude Code](https://claude.com/claude-code)