### PR TITLE
Code review followups: P1/P2/P3 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Scene Ripper analyzes video files to detect scene boundaries, enriches clips wit
 - Film language analysis with scene reports and editing suggestions
 - Integrated chat agent for AI-assisted editing
 - Thumbnail grid browser with collapsible source headers
-- Multiple sequencing modes with shot type filtering and direction control
+- 21 sequencing modes including sort, similarity, audio, text, gaze, reference, and drawing-guided workflows
 - Export individual clips or complete sequences
 - YouTube/Internet Archive import
 - Project save/load with full state persistence
@@ -139,7 +139,7 @@ The app uses a 5-tab workflow, though you can skip or revisit tabs as needed:
 1. **Collect**: Import a video file (drag-drop or file browser)
 2. **Cut**: Adjust sensitivity and click "Detect Scenes"
 3. **Analyze**: (Optional) Run analysis to add descriptions, transcripts, shot types
-4. **Sequence**: Add clips to timeline, use shuffle or Exquisite Corpus mode
+4. **Sequence**: Add clips to the timeline manually or generate one with a sequencer algorithm
 5. **Render**: Export as MP4 or EDL for external editors
 
 ## User Guides
@@ -223,8 +223,11 @@ Configure your preferred LLM provider (OpenAI, Anthropic, Gemini, Ollama) in Set
 Multiple ways to arrange clips:
 
 - **Manual**: Drag-drop clips to timeline
-- **Shuffle**: Randomize with constraints (no same-source consecutive)
-- **Exquisite Corpus**: Generate poetry from extracted text, then sequence clips by matching lines
+- **Arrange**: Sort by color, duration, brightness, volume, shot scale, gaze, or original order
+- **Connect**: Chain clips by visual similarity, match cut boundaries, follow a reference guide, or build LLM-guided associations
+- **Audio**: Cut to music with Staccato or pull spoken phrases with Cassette Tape
+- **Text and AI**: Generate poetry, story structures, transcript phrase sequences, or drawing-guided edits
+- **Find**: Filter a specific person with Rose Hobart or build gaze-based edits with Eyes Without a Face
 
 **Sorting options:**
 - **Shot Type**: Filter by Wide Shot, Full Shot, Medium Shot, Close-up, or Extreme Close-up
@@ -418,7 +421,7 @@ python -m cli.main --help
 - [x] Transcription (faster-whisper)
 - [x] Color analysis with direction control
 - [x] Integrated chat agent
-- [x] Exquisite Corpus sequencer
+- [x] 21 sequencer algorithms
 - [x] CLI for batch processing
 - [x] Project save/load
 - [x] Intention-first workflow
@@ -430,5 +433,5 @@ python -m cli.main --help
 
 **Future:**
 - [ ] FAISS vector similarity search
-- [ ] Similarity-based sequencing
+- [ ] Model/view timeline virtualization
 - [ ] Motion-based ordering

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,17 +1,5 @@
 """Core video processing modules."""
 
-from core.scene_detect import SceneDetector
-from core.ffmpeg import FFmpegProcessor
-from core.thumbnail import ThumbnailGenerator
-from core.downloader import VideoDownloader
-from core.scene_report import (
-    generate_sequence_report,
-    generate_clips_report,
-    report_to_html,
-    REPORT_SECTIONS,
-    DEFAULT_SECTIONS,
-)
-
 __all__ = [
     "SceneDetector",
     "FFmpegProcessor",
@@ -24,3 +12,33 @@ __all__ = [
     "REPORT_SECTIONS",
     "DEFAULT_SECTIONS",
 ]
+
+
+def __getattr__(name: str):
+    if name == "SceneDetector":
+        from core.scene_detect import SceneDetector
+
+        return SceneDetector
+    if name == "FFmpegProcessor":
+        from core.ffmpeg import FFmpegProcessor
+
+        return FFmpegProcessor
+    if name == "ThumbnailGenerator":
+        from core.thumbnail import ThumbnailGenerator
+
+        return ThumbnailGenerator
+    if name == "VideoDownloader":
+        from core.downloader import VideoDownloader
+
+        return VideoDownloader
+    if name in {
+        "generate_sequence_report",
+        "generate_clips_report",
+        "report_to_html",
+        "REPORT_SECTIONS",
+        "DEFAULT_SECTIONS",
+    }:
+        from core import scene_report
+
+        return getattr(scene_report, name)
+    raise AttributeError(f"module 'core' has no attribute {name!r}")

--- a/core/project.py
+++ b/core/project.py
@@ -1327,6 +1327,36 @@ class Project:
 
     # --- Persistence ---
 
+    def snapshot_for_save(self) -> dict:
+        """Return a deep-copied snapshot of all save-relevant project state.
+
+        Used by `SaveProjectWorker` so the background thread serializes a
+        stable view of the project even if the main thread mutates the live
+        project mid-save. The snapshot returns the same kwargs `save_project()`
+        already accepts plus the `extra_data` payload `Project.save()` builds.
+        """
+        import copy
+
+        non_active = [
+            s for i, s in enumerate(self.sequences)
+            if i != self.active_sequence_index and s
+        ]
+        extra_data = {
+            "_all_sequences": list(self.sequences),
+            "active_sequence_index": self.active_sequence_index,
+            "_additional_sequences": non_active,
+        }
+        return {
+            "sources": copy.deepcopy(self._sources),
+            "clips": copy.deepcopy(self._clips),
+            "sequence": copy.deepcopy(self.sequence),
+            "ui_state": copy.deepcopy(self.ui_state),
+            "metadata": copy.deepcopy(self.metadata),
+            "frames": copy.deepcopy(self._frames),
+            "extra_data": copy.deepcopy(extra_data),
+            "audio_sources": copy.deepcopy(self._audio_sources),
+        }
+
     def save(
         self,
         path: Optional[Path] = None,

--- a/core/scene_detect.py
+++ b/core/scene_detect.py
@@ -1,12 +1,20 @@
 """Scene detection module wrapping PySceneDetect."""
 
 import logging
+import sys
 from pathlib import Path
 from typing import Callable, Optional
 from dataclasses import dataclass
 
 import cv2
 import numpy as np
+
+# PySceneDetect eagerly imports its PyAV backend from scenedetect.backends,
+# which loads PyAV's bundled FFmpeg dylibs. Scene Ripper uses the OpenCV
+# backend explicitly, so keep PyAV out of the GUI process unless transcription
+# actually needs it.
+sys.modules.setdefault("scenedetect.backends.pyav", None)
+
 from scenedetect import detect, AdaptiveDetector, ContentDetector
 from scenedetect.scene_manager import SceneManager
 from scenedetect.backends.opencv import VideoStreamCv2

--- a/core/transcription.py
+++ b/core/transcription.py
@@ -13,6 +13,7 @@ Backend selection:
 """
 
 import contextlib
+import importlib.util
 import logging
 import os
 import platform
@@ -181,14 +182,12 @@ class ModelDownloadError(TranscriptionError):
 
 
 def is_faster_whisper_available() -> bool:
-    """Check if faster-whisper is installed."""
+    """Check if faster-whisper is installed without importing PyAV."""
     global _faster_whisper_available
     if _faster_whisper_available is None:
-        try:
-            import faster_whisper  # noqa: F401
-            _faster_whisper_available = True
-        except ImportError:
-            _faster_whisper_available = False
+        _faster_whisper_available = (
+            importlib.util.find_spec("faster_whisper") is not None
+        )
     return _faster_whisper_available
 
 

--- a/docs/learning/error_memory.json
+++ b/docs/learning/error_memory.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-05-05T02:36:53.147763+00:00",
+  "updated_at": "2026-05-05T02:47:21.599303+00:00",
   "patterns": [
     {
       "signature": "unknown-component|unknown-cause|linux-pyside6-distribution-packaging",
@@ -147,6 +147,21 @@
       "symptom_examples": [
         "Cut tab hides new clips when thumbnail generation fails with rational FFmpeg seek time",
         "Cut tab source group disappears after analysis refresh"
+      ],
+      "playbook_skill": null
+    },
+    {
+      "signature": "macos-runtime|duplicate-native-ffmpeg-runtime|avfframereceiver-libmpv-pyav-dylib-collision",
+      "title": "macOS libmpv and PyAV load duplicate FFmpeg dylibs",
+      "problem_type": "runtime_error",
+      "occurrences": 1,
+      "first_seen": "2026-05-05T02:47:21.599217+00:00",
+      "last_seen": "2026-05-05T02:47:21.599291+00:00",
+      "solution_refs": [
+        "docs/solutions/runtime-errors/macos-libmpv-pyav-ffmpeg-dylib-collision-20260504.md"
+      ],
+      "symptom_examples": [
+        "macOS libmpv and PyAV load duplicate FFmpeg dylibs"
       ],
       "playbook_skill": null
     }

--- a/docs/plans/2026-05-04-clip-browser-model-view-virtualization-plan.md
+++ b/docs/plans/2026-05-04-clip-browser-model-view-virtualization-plan.md
@@ -1,0 +1,37 @@
+# Clip Browser Model/View Virtualization Plan
+
+## Problem
+
+Cut and Analyze both use `ui.clip_browser.ClipBrowser`. The current virtual mode keeps clip data separate from widgets, but it still realizes cards as a `QGridLayout` full of `ClipThumbnail` widgets. Scrolling large projects can still block the UI because row rebuilds run on the main thread, card widgets are created or removed during scroll, and thumbnails can be decoded and scaled repeatedly.
+
+## Best Fix
+
+Replace the widget grid with a Qt model/view implementation:
+
+- Store clip/source rows in a `QAbstractListModel` or `QAbstractTableModel`.
+- Render cards with a `QStyledItemDelegate` instead of one QWidget tree per card.
+- Use a `QListView` or `QTableView` configured for icon/grid layout, uniform item sizes, and batched layout.
+- Keep selection, drag, context menu, and details/export signals as browser-level APIs so Cut and Analyze do not need to know about the backing view.
+- Keep filtering/sorting in a proxy model or in a dedicated data index, not in paint or scroll handlers.
+- Use an LRU thumbnail pixmap cache shared by the delegate.
+
+This removes most QWidget allocation, layout churn, stylesheet recalculation, and per-scroll object deletion. Qt item views are designed to scroll thousands of rows by painting visible items, which is the behavior the current custom virtual grid is approximating.
+
+## Migration Shape
+
+1. Introduce `ClipBrowserModel` with roles for clip id, source id, thumbnail path, duration, badges, disabled state, and selected/hover affordances.
+2. Introduce `ClipCardDelegate` to paint the thumbnail, duration, badges, selected glow, disabled dimming, and optional transcript/analysis indicators.
+3. Build `ModelViewClipBrowser` behind the existing `ClipBrowser` public methods.
+4. Port selection, drag, double-click, context menu, source grouping, and filters.
+5. Switch Cut and Analyze to the model/view browser after parity tests pass.
+
+## Interim Patch
+
+Until the model/view rewrite lands, the current widget grid should avoid work during scroll:
+
+- Cache virtual display rows and invalidate them only when data, filters, sort, expansion, or column count changes.
+- Debounce scroll-driven realization to roughly one frame.
+- Reuse a bounded set of virtual `ClipThumbnail` widgets.
+- Cache scaled thumbnail pixmaps by path, mtime, and target size.
+
+These changes reduce pinwheels for 500+ clips while keeping the existing browser API intact.

--- a/docs/solutions/runtime-errors/macos-libmpv-pyav-ffmpeg-dylib-collision-20260504.md
+++ b/docs/solutions/runtime-errors/macos-libmpv-pyav-ffmpeg-dylib-collision-20260504.md
@@ -49,6 +49,28 @@ Keep native media runtimes out of startup imports and avoid broad dynamic-librar
 5. Prevent PySceneDetect from importing its PyAV backend during `core.scene_detect` import, because Scene Ripper uses the OpenCV backend explicitly.
 6. Change `is_faster_whisper_available()` to use `importlib.util.find_spec()` so availability checks do not import `faster_whisper` or PyAV.
 
+## Note on `faster_whisper` and PyAV
+
+`faster_whisper` 1.x eagerly imports `av` at the top of `faster_whisper/audio.py`,
+and `faster_whisper/__init__.py` re-exports `decode_audio` from that module.
+That means **any** code path that does `import faster_whisper` (or
+`from faster_whisper import ...`) will load PyAV's bundled FFmpeg dylibs.
+
+Scene Ripper handles this by deferring the `from faster_whisper import WhisperModel`
+import until transcription actually runs (`ensure_faster_whisper_runtime_available()`
+inside `get_model()`), and by using `importlib.util.find_spec()` for availability
+checks. The `tests/test_transcription_runtime_imports.py` suite locks down this
+boundary: `import core.transcription` must not pull `av` into `sys.modules`.
+
+The `sys.modules.setdefault("scenedetect.backends.pyav", None)` sentinel only
+blocks PySceneDetect's pyav backend; it does **not** prevent `faster_whisper`
+(or any other library) from importing `av` directly. We deliberately do not
+install a `sys.meta_path` finder that hard-blocks `av`, because transcription
+legitimately needs PyAV at runtime. The defense is the import boundary —
+`faster_whisper` is loaded lazily only when the user runs transcription, which
+keeps PyAV out of the GUI process for the common case of users who never use
+transcription.
+
 ## Verification
 
 Use import-boundary tests to ensure startup does not load `mpv`, `av`, or `scenedetect` unnecessarily:
@@ -60,7 +82,7 @@ python -m pytest tests/test_video_player_runtime.py tests/test_transcription_run
 Useful manual check:
 
 ```bash
-python -c "import sys; import ui.video_player; import core.scene_detect; print('mpv' in sys.modules, 'av' in sys.modules)"
+python -c "import sys; import ui.video_player; import core.scene_detect; import core.transcription; print('mpv' in sys.modules, 'av' in sys.modules)"
 ```
 
 Expected output is `False False`.

--- a/docs/solutions/runtime-errors/macos-libmpv-pyav-ffmpeg-dylib-collision-20260504.md
+++ b/docs/solutions/runtime-errors/macos-libmpv-pyav-ffmpeg-dylib-collision-20260504.md
@@ -1,0 +1,66 @@
+---
+module: Scene Ripper
+date: 2026-05-04
+problem_type: runtime_error
+component: macos_runtime
+symptoms:
+  - "Class AVFFrameReceiver is implemented in both av/.dylibs/libavdevice and Homebrew ffmpeg/libavdevice"
+  - "Class AVFAudioReceiver is implemented in both av/.dylibs/libavdevice and Homebrew ffmpeg/libavdevice"
+  - "This may cause spurious casting failures and mysterious crashes"
+root_cause: duplicate_native_ffmpeg_runtime
+resolution_type: code_fix
+severity: high
+tags: [macos, libmpv, pyav, ffmpeg, dyld, startup-imports]
+---
+
+# Troubleshooting: macOS libmpv/PyAV FFmpeg Dylib Collision
+
+## Problem
+
+Scene Ripper could emit Objective-C duplicate-class warnings on macOS when both Homebrew FFmpeg libraries and PyAV's bundled FFmpeg libraries were loaded into the same Python process.
+
+The warning appeared as:
+
+```text
+objc: Class AVFFrameReceiver is implemented in both .../site-packages/av/.dylibs/libavdevice... and /opt/homebrew/Cellar/ffmpeg/.../libavdevice...
+objc: Class AVFAudioReceiver is implemented in both .../site-packages/av/.dylibs/libavdevice... and /opt/homebrew/Cellar/ffmpeg/.../libavdevice...
+```
+
+## Root Cause
+
+`main.py` prepended `/opt/homebrew/lib` or `/usr/local/lib` to `DYLD_LIBRARY_PATH` so `python-mpv` could find `libmpv.dylib`. That made every Homebrew FFmpeg dylib visible to the process.
+
+At the same time, startup package imports were too eager:
+
+- `ui/__init__.py` imported `ui.main_window`.
+- `core/__init__.py` imported `core.scene_detect`.
+- `scenedetect.backends` imported its PyAV backend, which imported `av`.
+
+That meant ordinary submodule imports could load PyAV's bundled FFmpeg, and `python-mpv` could load Homebrew FFmpeg. Loading both native runtimes defines the same AVFoundation Objective-C classes twice.
+
+## Solution
+
+Keep native media runtimes out of startup imports and avoid broad dynamic-library path mutation:
+
+1. Remove the global macOS `DYLD_LIBRARY_PATH` mutation from `main.py`.
+2. Make `ui.video_player` import `python-mpv` lazily when playback initializes.
+3. Make `ui.video_player` point `ctypes.util.find_library("mpv")` at one exact `libmpv.dylib` path instead of exposing all of Homebrew's library directory.
+4. Convert `ui/__init__.py` and `core/__init__.py` package exports to lazy `__getattr__` lookups.
+5. Prevent PySceneDetect from importing its PyAV backend during `core.scene_detect` import, because Scene Ripper uses the OpenCV backend explicitly.
+6. Change `is_faster_whisper_available()` to use `importlib.util.find_spec()` so availability checks do not import `faster_whisper` or PyAV.
+
+## Verification
+
+Use import-boundary tests to ensure startup does not load `mpv`, `av`, or `scenedetect` unnecessarily:
+
+```bash
+python -m pytest tests/test_video_player_runtime.py tests/test_transcription_runtime_imports.py -v
+```
+
+Useful manual check:
+
+```bash
+python -c "import sys; import ui.video_player; import core.scene_detect; print('mpv' in sys.modules, 'av' in sys.modules)"
+```
+
+Expected output is `False False`.

--- a/docs/user-guide/agent-tools.md
+++ b/docs/user-guide/agent-tools.md
@@ -240,6 +240,16 @@ Call `get_available_dimensions` before `generate_reference_guided` to see which 
 | `export_dataset` | Export clip data as JSON | "Export a dataset of all clip metadata" |
 | `export_bundle` | Export a self-contained project bundle | "Export a portable project bundle" |
 
+**Bundle export parameters:**
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `output_path` | string | Optional destination directory. Defaults to `<export_dir>/<project_name>_bundle`. Existing destination is replaced. |
+| `lightweight` | boolean | When `true`, skips both source video files and trimmed clip media (project file + thumbnails only). Defaults to `false`. |
+| `include_clips` | boolean | Independent override for trimmed-clip media export. When omitted, defaults to `not lightweight` (clips included unless `lightweight=true`). Set explicitly to `true` or `false` to control trimmed-clip output regardless of `lightweight`. |
+
+Use `include_clips` when you want a "videos but no trimmed clips" or "trimmed clips but no source videos" bundle — for example, "Export a lightweight bundle but still include the trimmed clips" sets `lightweight=true` and `include_clips=true`.
+
 ---
 
 ## Plans

--- a/docs/user-guide/agent-tools.md
+++ b/docs/user-guide/agent-tools.md
@@ -1,6 +1,6 @@
 # Agent Tools Reference
 
-The Scene Ripper chat agent has access to 106 tools organized by category. You don't need to call these by name — just describe what you want in natural language and the agent will use the right tool. This reference is for understanding what's possible.
+The Scene Ripper chat agent has access to 117 tools organized by category. You don't need to call these by name — just describe what you want in natural language and the agent will use the right tool. This reference is for understanding what's possible.
 
 > Type `/help` in the chat panel to see a condensed version of this list.
 
@@ -106,10 +106,15 @@ See [Audio Sources](audio-sources.md) for the full audio import / transcription 
 
 | Tool | What it does | Example prompt |
 |------|-------------|----------------|
-| `generate_remix` | Generate a sequence with any algorithm | "Arrange clips by color, warm to cool" |
+| `generate_remix` | Generate a direct sort/arrange sequence | "Arrange clips by color, warm to cool" |
 | `generate_staccato` | Beat-driven sequence from music | "Create a staccato sequence using this song" |
 | `generate_rose_hobart` | Filter clips by a person's face | "Show only clips with this person" |
 | `generate_reference_guided` | Match clips to a reference edit | "Match my clips to the reference video's structure" |
+| `generate_eyes_without_a_face` | Gaze-based eyeline, filter, or rotation sequence | "Build a shot-reverse-shot sequence from gaze" |
+| `generate_exquisite_corpus` | Poem sequence from extracted text | "Make an Exquisite Corpus poem sequence" |
+| `generate_storyteller` | Narrative sequence from descriptions | "Tell a three-act story with these clips" |
+| `generate_cassette_tape` | Phrase sequence from transcripts | "Find clips saying these phrases" |
+| `generate_signature_style` | Image/drawing-guided sequence | "Make a sequence based on this drawing" |
 | `list_sorting_algorithms` | See available algorithms | "What sequencing algorithms can I use?" |
 | `get_available_dimensions` | See matching dimensions | "What dimensions are available for reference matching?" |
 | `get_remix_state` | Get current sequence tab state | "What algorithm is currently active?" |
@@ -130,8 +135,27 @@ See [Audio Sources](audio-sources.md) for the full audio import / transcription 
 | `sequential` | Time Capsule | "Keep clips in original order" |
 | `gaze_sort` | Gaze Sort | "Sort clips by gaze direction, left to right" |
 | `gaze_consistency` | Gaze Consistency | "Group clips by gaze direction" |
-| `exquisite_corpus` | Exquisite Corpus | "Create a poem from the on-screen text" |
-| `storyteller` | Storyteller | "Tell a story with these clips" |
+
+`generate_remix` is the right tool for these 12 direct arrange/connect algorithms. Dialog-heavy sequencers with extra parameters use their own tools instead: `generate_reference_guided`, `generate_staccato`, `generate_rose_hobart`, `generate_eyes_without_a_face`, `generate_cassette_tape`, `generate_signature_style`, `generate_exquisite_corpus`, and `generate_storyteller`. Free Association is currently GUI-only.
+
+**Reference Guide parameters:**
+
+| Parameter | Type | Notes |
+|-----------|------|-------|
+| `reference_source_id` | string | Source ID of the reference video. Use `list_sources` first. |
+| `weights` | object | Optional dimension weights from `0.0` to `1.0`. Valid keys: `color`, `brightness`, `shot_scale`, `audio`, `embedding`, `description`, `transcript`, `movement`, `duration`. Defaults to `{"embedding": 1.0, "brightness": 0.4, "duration": 0.6}`. |
+| `allow_repeats` | boolean | When false, each candidate clip can be used once. When true, clips can fill multiple reference positions. |
+
+Call `get_available_dimensions` before `generate_reference_guided` to see which dimensions have analysis data. Description and transcript matching use token-frequency text similarity, not semantic LLM matching. Visual Match uses DINOv2 embedding cosine distance. Duration affects matching only; matched clips are not trimmed to the guide clip length.
+
+**Trim-aware sequencers:**
+
+| Tool | Output timing |
+|------|---------------|
+| `generate_staccato` | Trims or loops clips to beat slots |
+| `generate_cassette_tape` | Trims to matched transcript segments |
+| `generate_signature_style` | Trims longer clips to drawing/image segment durations |
+| `generate_reference_guided` | Does not trim to the reference clip length |
 
 ### Sequence Editing
 

--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -125,7 +125,9 @@ Most agent capabilities work regardless of which provider you choose for the cha
 | Describe clips | Yes (Qwen3-VL / Moondream) | Optional (cloud tier) |
 | Text extraction (OCR) | Yes (PaddleOCR) | Optional (VLM fallback) |
 | Cinematography analysis | Yes (Apple Silicon) | Optional (cloud tier) |
-| Storyteller / Exquisite Corpus | No | Yes |
+| Storyteller / Exquisite Corpus / Free Association | No | Yes |
+| Signature Style Parametric mode | Yes | No |
+| Signature Style VLM mode | No | Yes |
 | Scene detection | Yes | No |
 | Export | Yes | No |
 

--- a/docs/user-guide/analysis.md
+++ b/docs/user-guide/analysis.md
@@ -198,7 +198,7 @@ On Apple Silicon Macs, transcription runs on the GPU via MLX for significantly f
 - **Language** — English, Auto-detect, or a specific language code
 - **Backend** — Auto (recommended), faster-whisper, mlx-whisper, or Groq (cloud)
 
-**Used by:** Storyteller sequencer, transcript search, SRT export.
+**Used by:** Cassette Tape, Reference Guide's Transcript dimension, transcript search, SRT export.
 
 ---
 
@@ -224,7 +224,7 @@ Two input modes are available for cloud descriptions:
 - **Cloud model** — Gemini, Claude, or GPT-4o variant
 - **Input mode** — Frame or Video (cloud only, Gemini only)
 
-**Used by:** Chat agent search, Storyteller sequencer, clip filtering.
+**Used by:** Chat agent search, Storyteller, Reference Guide's Description dimension, Free Association, clip filtering.
 
 <details>
 <summary><strong>Prompt used</strong></summary>
@@ -275,7 +275,7 @@ Two input modes are available:
 - **Local model** — Qwen2.5-VL-7B (Apple Silicon only, ~4 GB)
 - **Input mode** — Frame or Video
 
-**Used by:** Focal Ladder (uses the detailed shot size), clip filtering by any cinematography field.
+**Used by:** Focal Ladder and Up Close and Personal (detailed shot size), Reference Guide's Shot Scale and Movement dimensions, clip filtering by any cinematography field.
 
 > **Tip:** Rich Analysis provides a more detailed shot size classification (10 types) than Shot Classification (5 types). If you run both, the Rich Analysis values take precedence for sequencer algorithms that use shot size.
 
@@ -416,7 +416,7 @@ The detector samples one frame per second through each clip, so it catches faces
 **Runs:** Locally (InsightFace, no API key needed)
 **Speed:** Moderate (processes sequentially to manage memory)
 
-**Used by:** Rose Hobart sequencer (filters clips to only those containing a specific person).
+**Used by:** Rose Hobart sequencer and agent tool. The GUI can compute missing face embeddings inside the Rose Hobart dialog and cache them on clips.
 
 > **Note:** Face detection requires a C/C++ compiler for initial installation of the InsightFace library (Xcode Command Line Tools on macOS).
 
@@ -434,7 +434,7 @@ Extracts a 768-dimensional DINOv2 visual feature vector from each clip's thumbna
 **Runs:** Locally (DINOv2 via transformers, no API key needed). Downloads ~450 MB of model files on first use.
 **Speed:** Moderate (processes in batches on GPU if available, otherwise CPU).
 
-**Used by:** Human Centipede (similarity chaining), Staccato, Reference Guide (when the embedding dimension is active), and Free Association (for local candidate shortlisting).
+**Used by:** Human Centipede (similarity chaining), Staccato, Reference Guide's Visual Match dimension, and Free Association candidate shortlisting. The same DINOv2 runtime also powers Match Cut's first/last-frame boundary embeddings.
 
 > **Tip:** If you haven't run this explicitly and try to use a sequencer that needs embeddings, the app will auto-compute them as a side effect of running the sequencer. Running Generate Embeddings up front is faster when you plan to use multiple embedding-based sequencers on the same clips.
 

--- a/docs/user-guide/api-keys.md
+++ b/docs/user-guide/api-keys.md
@@ -19,7 +19,8 @@ You don't need all of these. Most users need just one or two.
 | Classify shots | Any VLM provider |
 | Extract on-screen text | Any VLM provider |
 | Storyteller sequencer | Any LLM provider |
-| Exquisite Corpus sequencer | Any VLM provider |
+| Exquisite Corpus sequencer | Any LLM provider for poem generation; OCR can run locally or use a VLM fallback |
+| Free Association sequencer | Any LLM provider |
 | Signature Style sequencer (VLM mode) | Any VLM provider |
 | YouTube search and download | YouTube Data API |
 | Replicate models | Replicate |

--- a/docs/user-guide/local-models.md
+++ b/docs/user-guide/local-models.md
@@ -22,12 +22,12 @@ SigLIP 2 is a contrastive vision-language model from Google. Instead of generati
 
 ### DINOv2 — Visual Embeddings
 
-Generates a 768-dimensional embedding vector for each clip's thumbnail. These embeddings capture the visual content of a frame — similar-looking frames produce similar vectors. Several sequencer algorithms use these embeddings to find visual relationships between clips (match cuts, visual similarity sorting, etc.).
+Generates a 768-dimensional embedding vector for each clip's thumbnail. These embeddings capture the visual content of a frame — similar-looking frames produce similar vectors. Several sequencer algorithms use these embeddings to find visual relationships between clips.
 
 DINOv2 is a self-supervised vision transformer from Meta. It was trained without text labels, learning visual features purely from images. This makes it especially good at capturing structural and compositional similarity rather than semantic categories.
 
 **Model:** [facebook/dinov2-base](https://huggingface.co/facebook/dinov2-base) (~330 MB)
-**Used in:** Analyze tab > Compute Embeddings; Sequence tab (Match Cut, Similarity Sort, Exquisite Corpus)
+**Used in:** Analyze tab > Compute Embeddings; Sequence tab (Human Centipede, Staccato, Reference Guide's Visual Match dimension, and Free Association candidate shortlisting). The same DINOv2 runtime also powers Match Cut's first/last-frame boundary embeddings.
 **Try it:** [DINOv2 Demo Lab](https://dinov2.metademolab.com/)
 
 ---

--- a/docs/user-guide/prompts.md
+++ b/docs/user-guide/prompts.md
@@ -181,7 +181,7 @@ When creating plans, follow these tool dependency rules:
 2. If the user wants to search multiple topics, create a plan that interleaves
    search and download steps for each topic.
 
-3. SEQUENCE GENERATION: Use the generate_remix tool to create sequences with any of the 13 sorting algorithms. Use list_sorting_algorithms first to check which algorithms are available based on clip analysis state. For matching clips to a reference video's structure, use the generate_reference_guided tool instead.
+3. SEQUENCE GENERATION: Use the generate_remix tool for the 12 direct sorting/arranging algorithms. Use list_sorting_algorithms first to check which algorithms are available based on clip analysis state. Use specialized tools for dialog-heavy sequencers: generate_reference_guided, generate_staccato, generate_rose_hobart, generate_eyes_without_a_face, generate_cassette_tape, generate_signature_style, generate_exquisite_corpus, and generate_storyteller. Reference Guide duration matching does not trim matched clips to the guide clip length.
 ```
 
 ### Local/Ollama-Only Prompt Extension

--- a/docs/user-guide/sequencers.md
+++ b/docs/user-guide/sequencers.md
@@ -1,16 +1,58 @@
 # Sequencer Algorithms
 
-Scene Ripper includes 20 sequencer algorithms that arrange your clips into a sequence. Each algorithm uses a different creative logic to determine the order.
+Scene Ripper includes 21 sequencer algorithms that arrange your clips into a sequence. Each algorithm uses a different creative logic to determine the order, choose matches, or trim clips into timed slots.
 
 To use a sequencer, go to the **Sequence** tab, select an algorithm from the dropdown, and click **Generate**. Some algorithms require that you run specific analysis on your clips first (in the **Analyze** tab). Others open a dialog where you configure additional options before generating.
 
-> Some algorithms (like Storyteller and Exquisite Corpus) require a cloud API key. See the [API Keys Guide](api-keys.md) for setup instructions.
+> Some algorithms, modes, and agent workflows require an LLM or VLM API key. Storyteller, Exquisite Corpus, Free Association, and Signature Style's VLM mode are the main examples. See the [API Keys Guide](api-keys.md) for setup instructions.
+
+Most sequencers use the clips currently selected in the Cut or Analyze tab. If no clips are selected, select the clips you want to sequence first. Dialog-based sequencers may add their own setup steps, such as choosing a music track, reference video, phrase list, drawing, or face reference.
+
+## Timing and Trimming
+
+Most sequencers place each matched clip at its full detected clip length. They change order and selection, but they do not retime the source material.
+
+The main exceptions are:
+
+| Sequencer | Timing behavior |
+|-----------|-----------------|
+| **Staccato** | Trims or loops clips so each beat slot is filled |
+| **Signature Style** | Trims longer clips to the drawing segment duration; shorter clips play full length |
+| **Cassette Tape** | Trims clips to the matched transcript segment |
+
+Reference Guide uses duration as an optional matching dimension, but it does **not** trim a matched clip to the guide clip's length. If you enable Duration, it prefers clips with similar lengths; the output still uses the matched clip's own length.
 
 ---
 
+## Algorithm Index
+
+| Algorithm | Category | Requires first | Trims output? |
+|-----------|----------|----------------|---------------|
+| Chromatics | Arrange | Colors | No |
+| Tempo Shift | Arrange | None | No |
+| Into the Dark | Arrange | Brightness, auto-computed if missing | No |
+| Crescendo | Arrange / Audio | Volume, auto-computed if missing | No |
+| Focal Ladder | Arrange | Shot classification | No |
+| Up Close and Personal | Arrange | Shot classification or Rich Analysis shot size | No |
+| Gaze Sort | Arrange / Find | Gaze analysis | No |
+| Gaze Consistency | Find | Gaze analysis | No |
+| Hatchet Job | Arrange | None | No |
+| Time Capsule | Arrange | None | No |
+| Human Centipede | Connect | Visual embeddings, auto-computed if missing | No |
+| Match Cut | Connect | Boundary embeddings, auto-computed if missing | No |
+| Staccato | Audio | Audio source and visual embeddings | Yes |
+| Exquisite Corpus | Text | Extract Text plus an LLM | No |
+| Storyteller | Text | Describe plus an LLM | No |
+| Reference Guide | Connect / Audio / Text | Depends on enabled dimensions | No |
+| Signature Style | Connect | Colors; VLM mode benefits from shots/descriptions | Yes |
+| Rose Hobart | Find | Reference face image; face dependencies install on demand | No |
+| Eyes Without a Face | Find / Connect | Gaze analysis | No |
+| Free Association | Connect / Text | Describe and embeddings plus an LLM | No |
+| Cassette Tape | Text / Audio | Transcribe | Yes |
+
 ## Managing Multiple Sequences
 
-A project holds any number of named sequences — run 20 different algorithms and keep every result side by side for comparison. Every algorithm run creates a new sequence instead of overwriting the previous one.
+A project holds any number of named sequences — run 21 different algorithms and keep every result side by side for comparison. Every algorithm run creates a new sequence instead of overwriting the previous one.
 
 ### Sequence dropdown
 
@@ -108,9 +150,11 @@ If clips haven't been analyzed for volume yet, this algorithm will automatically
 
 ### Focal Ladder
 
-Arrange clips by camera shot scale, from wide establishing shots to tight close-ups (or reverse).
+Arrange clips by camera shot scale, from wide establishing shots to tight close-ups.
 
 **Required analysis:** Shots (shot type classification)
+
+Focal Ladder has no direction dropdown in the current UI. Use **Up Close and Personal** when you want an explicit far-to-close or close-to-far direction.
 
 ### Up Close and Personal
 
@@ -187,7 +231,7 @@ Randomly shuffle clips into a new order. Opens a dialog where you can optionally
 - **Random V-Flip:** Randomly flip some clips vertically
 - **Random Reverse:** Randomly play some clips in reverse
 
-When transforms are enabled, the dialog pre-renders each affected clip via FFmpeg before assembling the sequence. A progress bar shows rendering status.
+The shuffle uses a constrained shuffle that avoids placing clips from the same source back-to-back when possible. When transforms are enabled, the dialog pre-renders each affected clip via FFmpeg before assembling the sequence. A progress bar shows rendering status. Reverse pre-rendering is capped for long clips to keep render time bounded.
 
 ### Time Capsule
 
@@ -203,16 +247,19 @@ Keep clips in their original order. This is the simplest algorithm: clips appear
 
 Cut clips to the rhythm of a music track. Opens a dialog where you pick a project audio source, preview the waveform with beat markers, and generate a sequence where onset strength drives visual contrast — stronger beats trigger bigger visual jumps between consecutive clips.
 
-**Required analysis:** Embeddings (DINOv2, auto-computed if missing)
+**Required analysis:** Audio source, Embeddings (DINOv2, auto-computed in the dialog if dependencies and thumbnails are available)
 
 **Dialog workflow:**
 1. Pick an audio source from the **Audio source** dropdown. The dropdown is populated from your project's [audio library](audio-sources.md) — if you haven't imported audio yet, choose **Import new…** to import one without leaving the dialog.
 2. The audio is analyzed and a waveform is displayed with beat/onset markers overlaid
 3. Adjust the **Sensitivity** slider to control the number of cut points ("Fewer Cuts" to "More Cuts")
 4. Choose a **Beat Strategy** from the dropdown: Onsets (transients/hits), Beats (regular pulse), or Downbeats (strong beats only)
-5. Click **Generate** to match clips to beat intervals. Each clip is trimmed to fit its slot; clips shorter than their slot are looped. Clips can repeat when there are more beat slots than clips.
+5. Optional advanced onset controls let you choose an onset profile, minimum gap, timing mode, and analysis resolution when transient detection needs tuning
+6. Click **Generate** to match clips to beat intervals. Each clip is trimmed to fit its slot; clips shorter than their slot are looped. Clips can repeat when there are more beat slots than clips.
 
 The algorithm uses DINOv2 visual embeddings to measure similarity between clips. At each cut point, it measures the onset strength and selects a clip whose visual distance from the previous clip matches that strength — hard hits get jarring visual jumps, soft transitions get visually similar clips.
+
+Staccato exhausts the available clip pool before repeating clips. The resulting timeline stores the music path on the sequence and should closely match the generated beat-slot timing.
 
 ---
 
@@ -259,6 +306,24 @@ Match your clips to a reference video's structure. Opens a dialog.
 4. Optionally allow repeated clips with the "Allow Repeats" checkbox
 5. Click **Generate** to find the best-matching clip for each position in the reference
 
+**Matching details:**
+
+| Dimension | Data used | Match behavior |
+|-----------|-----------|----------------|
+| Color | Dominant color hue | Numeric distance after normalization |
+| Brightness | Average luminance | Numeric distance after normalization |
+| Shot Scale | Rich Analysis shot size, falling back to shot classification | Wide-to-close proximity distance |
+| Audio Energy | RMS volume | Numeric distance after normalization |
+| Visual Match | DINOv2 embedding | Cosine distance |
+| Description | Describe text | Token-frequency cosine distance |
+| Transcript | Transcribed speech text | Token-frequency cosine distance |
+| Movement | Rich Analysis camera movement | Exact categorical match |
+| Duration | Clip duration | Numeric distance after normalization |
+
+Reference Guide matches greedily from the first reference clip to the last. With **Allow Repeats** off, each candidate clip can be used once; if the matching pool runs out, later reference positions stay unmatched. With **Allow Repeats** on, the same candidate can fill multiple reference positions.
+
+Duration is only a matching signal. Matched clips are not trimmed to the guide clip duration.
+
 ### Signature Style
 
 Interpret a drawing as an editing guide. Opens a large canvas-based dialog.
@@ -266,16 +331,18 @@ Interpret a drawing as an editing guide. Opens a large canvas-based dialog.
 **Required analysis:** Colors
 
 **Dialog workflow:**
-1. Draw on the canvas (or import an image). The Y-axis maps to pacing (spiky = fast cuts, smooth = slow) and color maps to color matching against your clips
+1. Draw on the canvas (or import an image). In Parametric mode, the drawing is sampled left-to-right: the line's vertical changes map to pacing (spiky = fast cuts, smooth = slow), and ink color maps to color matching against your clips
 2. Set a target duration and FPS
 3. Choose between **Parametric** mode (pixel-level analysis with a granularity slider) or **VLM** mode (a vision model interprets the drawing's meaning)
 4. Click **Generate** to match your drawing to clips and assemble a timed sequence
+
+The matcher can reuse clips. Longer clips are center-trimmed to the target segment duration; clips shorter than a segment play at full length. Parametric mode mainly uses duration, color, brightness, and available shot metadata. VLM mode adds interpreted shot type, brightness, and energy targets when the vision model can infer them.
 
 ### Rose Hobart
 
 Isolate clips featuring a specific person. Named after Joseph Cornell's 1936 found-footage film. Opens a dialog.
 
-**Required analysis:** None (face detection runs in the dialog)
+**Required analysis:** None required ahead of time in the GUI. Face detection runs in the dialog and caches results on clips. The agent tool uses already computed face embeddings.
 
 **Dialog workflow:**
 1. Upload 1-3 reference photos of the person you want to find. Each image is analyzed for faces, and a green bounding box highlights the detected face
@@ -310,7 +377,7 @@ Clips without gaze data are always appended at the end of the sequence.
 
 Build a sequence one clip at a time with an LLM collaborator. The algorithm opens a dialog where you interactively accept, reject, or swap each proposed next clip, with a rationale from the LLM explaining each transition.
 
-**Required analysis:** Describe, Embeddings
+**Required analysis:** Describe, Embeddings, LLM provider
 
 **Dialog workflow:**
 
@@ -320,8 +387,6 @@ Build a sequence one clip at a time with an LLM collaborator. The algorithm open
 4. Repeat until you're satisfied or the pool is exhausted
 
 Embeddings power a local candidate shortlist so the LLM only sees the most similar clips at each step — this keeps prompts small and responses fast. Without embeddings the algorithm falls back to random sampling, which degrades proposal quality. Each accepted transition is saved as a rationale on the resulting SequenceClip, visible in exported SRTs.
-
-Requires a cloud LLM API key.
 
 ### Cassette Tape
 
@@ -342,4 +407,4 @@ Find clips that say specific phrases — the transcript-driven mixtape. This is 
 - Clips without transcripts are silently excluded. If the project has no transcribed clips, the dialog will tell you to run **Analyze → Transcribe** first.
 - Disabled clips are excluded automatically.
 
-Cassette Tape uses local string-similarity matching (RapidFuzz `partial_ratio`). It does not require a cloud API key.
+Cassette Tape uses local string-similarity matching (RapidFuzz `partial_ratio`). It does not require a cloud API key. It works at transcript-segment granularity, so it can trim the resulting sequence to the exact matched line instead of using the whole detected clip.

--- a/main.py
+++ b/main.py
@@ -80,17 +80,6 @@ if is_frozen():
     _setup_frozen_environment()
 
 import platform
-if platform.system() == "Darwin":
-    # Homebrew on Apple Silicon / Intel puts libs in different locations.
-    # python-mpv needs libmpv.dylib on the loader path.
-    for lib_dir in ("/opt/homebrew/lib", "/usr/local/lib"):
-        if os.path.isdir(lib_dir):
-            existing = os.environ.get("DYLD_LIBRARY_PATH", "")
-            if lib_dir not in existing:
-                os.environ["DYLD_LIBRARY_PATH"] = (
-                    f"{lib_dir}:{existing}" if existing else lib_dir
-                )
-            break
 
 # Pre-import torch BEFORE PySide6 to prevent "function '_has_torch_function'
 # already has a docstring" RuntimeError. This conflict occurs when torch's C
@@ -121,12 +110,10 @@ if platform.system() == "Darwin" and platform.machine() == "arm64":
 
 
 def _check_mpv_available() -> bool:
-    """Check if libmpv is available. Returns True if OK, False if missing."""
-    try:
-        import mpv  # noqa: F401
-        return True
-    except (ImportError, OSError):
-        return False
+    """Check if libmpv is discoverable without loading it into the process."""
+    from ui.video_player import _find_mpv_library
+
+    return _find_mpv_library() is not None
 
 
 def _show_mpv_missing_dialog(app: QApplication):

--- a/tests/test_analysis_pipeline.py
+++ b/tests/test_analysis_pipeline.py
@@ -48,20 +48,29 @@ def test_phase_advances_from_local_to_cloud_after_color_completion():
 
 
 def test_pipeline_complete_refreshes_cut_browser_after_analysis():
-    """Analysis completion should refresh data-backed Cut tab clip entries."""
+    """Analysis completion should refresh data-backed clip entries via project.update_clips.
+
+    The single project.update_clips() call replaces the previous duplicate path
+    that called update_clips directly on both browsers; both Cut and Analyze
+    tabs now refresh through the standard `clips_updated` observer chain.
+    """
     clip = make_test_clip("clip-1", source_id="src-1")
     source = Source(id="src-1", file_path=Path("/test/video.mp4"))
-    refreshed = []
-
-    class Browser:
-        def update_clips(self, clips):
-            refreshed.extend(clips)
+    project_updated = []
 
     class AnalyzeTab:
-        clip_browser = Browser()
+        clip_browser = SimpleNamespace(update_clips=lambda *_args, **_kwargs: None)
 
         def set_analyzing(self, _value):
             return None
+
+    class FakeProject:
+        def __init__(self):
+            self.sources_by_id = {source.id: source}
+            self.path = None
+
+        def update_clips(self, clips):
+            project_updated.extend(clips)
 
     class Harness:
         def __init__(self):
@@ -73,10 +82,14 @@ def test_pipeline_complete_refreshes_cut_browser_after_analysis():
             self._active_custom_query_text = "query"
             self._gui_state = SimpleNamespace(clear_processing=lambda _name: None)
             self.analyze_tab = AnalyzeTab()
-            self.cut_tab = SimpleNamespace(clip_browser=Browser())
+            self.cut_tab = SimpleNamespace(
+                clip_browser=SimpleNamespace(
+                    update_clips=lambda *_args, **_kwargs: None
+                )
+            )
             self.progress_bar = SimpleNamespace(setVisible=lambda _value: None)
             self.status_bar = SimpleNamespace(showMessage=lambda _message: None)
-            self.project = SimpleNamespace(sources_by_id={source.id: source}, path=None)
+            self.project = FakeProject()
             self.collect_tab = SimpleNamespace(update_source_has_analysis=lambda *_args: None)
 
         def _get_completed_analysis_error_labels(self, _completed):
@@ -89,7 +102,8 @@ def test_pipeline_complete_refreshes_cut_browser_after_analysis():
 
     MainWindow._on_analysis_pipeline_complete(harness)
 
-    assert refreshed == [clip, clip]
+    # Single project-level update notification (no duplicate per-browser calls).
+    assert project_updated == [clip]
     assert source.has_analysis is True
 
 

--- a/tests/test_clip_browser_selection.py
+++ b/tests/test_clip_browser_selection.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 import pytest
-from PySide6.QtCore import QRect
+from PySide6.QtCore import Qt, QRect
 from PySide6.QtTest import QTest
 
 from models.clip import Source
@@ -59,6 +59,165 @@ def test_select_all_excludes_disabled_clips(qapp, source, monkeypatch):
 
     selected_ids = {clip.id for clip in browser.get_selected_clips()}
     assert selected_ids == {"c2", "c4"}
+
+
+def test_select_source_replaces_selection_with_enabled_source_clips(qapp, source):
+    from ui.clip_browser import ClipBrowser
+
+    other_source = Source(
+        id="src-2",
+        file_path=Path("/test/other.mp4"),
+        duration_seconds=10.0,
+        fps=30.0,
+        width=1280,
+        height=720,
+    )
+    browser = ClipBrowser()
+    clips = [
+        make_test_clip("s1-a", source_id=source.id),
+        make_test_clip("s1-b", source_id=source.id),
+        make_test_clip("s2-a", source_id=other_source.id),
+        make_test_clip("s2-b", source_id=other_source.id),
+    ]
+    clips[3].disabled = True
+
+    browser.add_clips(
+        [(clips[0], source), (clips[1], source)]
+        + [(clips[2], other_source), (clips[3], other_source)]
+    )
+    browser.set_selection(["s1-a"])
+
+    browser.select_source(other_source.id)
+
+    selected_ids = {clip.id for clip in browser.get_selected_clips()}
+    assert selected_ids == {"s2-a"}
+
+
+def test_select_source_respects_active_filters(qapp, source):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clips = [
+        make_test_clip("wide", source_id=source.id, shot_type="wide shot"),
+        make_test_clip("close", source_id=source.id, shot_type="close-up"),
+    ]
+    browser.add_clips([(clip, source) for clip in clips])
+    browser._filter_state.shot_type = {"Close-up"}
+
+    browser.select_source(source.id)
+
+    selected_ids = {clip.id for clip in browser.get_selected_clips()}
+    assert selected_ids == {"close"}
+
+
+def test_source_header_select_button_selects_that_source(qapp, source):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clips = [make_test_clip("c1"), make_test_clip("c2")]
+    browser.add_clips([(clip, source) for clip in clips])
+    qapp.processEvents()
+
+    header = browser._source_headers[source.id]
+    QTest.mouseClick(header.select_button, Qt.LeftButton)
+
+    selected_ids = {clip.id for clip in browser.get_selected_clips()}
+    assert selected_ids == {"c1", "c2"}
+    assert header.is_expanded is True
+
+
+def test_select_source_updates_header_without_rebuilding_grid(qapp, source, monkeypatch):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clips = [make_test_clip("c1"), make_test_clip("c2")]
+    browser.add_clips([(clip, source) for clip in clips])
+    qapp.processEvents()
+
+    rebuilds = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda *a, **k: rebuilds.append(True))
+
+    browser.select_source(source.id)
+
+    assert rebuilds == []
+    assert browser._source_headers[source.id].count_label.text() == "(2 clips • 2 selected)"
+
+
+def test_virtual_select_source_uses_all_filtered_source_data(qapp, source):
+    from ui.clip_browser import ClipBrowser
+
+    other_source = Source(
+        id="src-2",
+        file_path=Path("/test/other.mp4"),
+        duration_seconds=10.0,
+        fps=30.0,
+        width=1280,
+        height=720,
+    )
+    browser = ClipBrowser()
+    clips = [make_test_clip(f"s1-{i}", source_id=source.id) for i in range(40)]
+    other_clips = [
+        make_test_clip(f"s2-{i}", source_id=other_source.id) for i in range(40)
+    ]
+    other_clips[5].disabled = True
+
+    browser.set_virtual_clips(
+        [(clip, source) for clip in clips]
+        + [(clip, other_source) for clip in other_clips]
+    )
+    qapp.processEvents()
+
+    browser.select_source(other_source.id)
+
+    selected_ids = {clip.id for clip in browser.get_selected_clips()}
+    assert selected_ids == {clip.id for clip in other_clips if not clip.disabled}
+
+
+def test_virtual_select_source_does_not_invalidate_rows_or_rebuild(
+    qapp, source, monkeypatch
+):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    browser.resize(700, 500)
+    clips = [make_test_clip(f"v{i}", source_id=source.id) for i in range(40)]
+
+    browser.set_virtual_clips([(clip, source) for clip in clips])
+    qapp.processEvents()
+    browser._get_virtual_rows()
+    browser._virtual_rows_dirty = False
+
+    rebuilds = []
+    invalidations = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda *a, **k: rebuilds.append(True))
+    monkeypatch.setattr(
+        browser, "_invalidate_virtual_rows", lambda: invalidations.append(True)
+    )
+
+    browser.select_source(source.id)
+
+    assert rebuilds == []
+    assert invalidations == []
+    assert browser._virtual_rows_dirty is False
+
+
+def test_virtual_header_selection_count_is_live_with_cached_rows(qapp, source):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    browser.resize(700, 500)
+    clips = [make_test_clip(f"v{i}", source_id=source.id) for i in range(8)]
+
+    browser.set_virtual_clips([(clip, source) for clip in clips])
+    qapp.processEvents()
+    rows = browser._get_virtual_rows()
+    header_row = next(payload for row_type, payload in rows if row_type == "header")
+    assert header_row[-1] == 0
+
+    browser.select_source(source.id)
+    browser._do_rebuild_virtual_grid()
+
+    assert browser._source_headers[source.id].count_label.text() == "(8 clips • 8 selected)"
 
 
 def test_add_clips_bulk_populates_lookup_once(qapp, source, monkeypatch):
@@ -285,6 +444,156 @@ def test_toggle_disabled_does_not_select_first_clip(qapp, source):
 
     assert browser.get_selected_clips() == []
     assert "c1" not in browser.selected_clips
+
+
+def test_virtual_toggle_disabled_updates_in_place_without_rebuild(
+    qapp, source, monkeypatch
+):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    browser.resize(700, 500)
+    clips = [make_test_clip(f"v{i}", source_id=source.id) for i in range(40)]
+
+    browser.set_virtual_clips([(clip, source) for clip in clips])
+    qapp.processEvents()
+    browser._get_virtual_rows()
+    browser._virtual_rows_dirty = False
+    browser.set_selection(["v3"])
+
+    rebuilds = []
+    invalidations = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda *a, **k: rebuilds.append(True))
+    monkeypatch.setattr(
+        browser, "_invalidate_virtual_rows", lambda: invalidations.append(True)
+    )
+
+    browser.toggle_disabled(["v3"])
+
+    assert clips[3].disabled is True
+    assert "v3" not in browser.selected_clips
+    assert rebuilds == []
+    assert invalidations == []
+    assert browser._virtual_rows_dirty is False
+
+
+def test_toggle_disabled_rebuilds_when_enabled_filter_changes_visibility(
+    qapp, source, monkeypatch
+):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clips = [make_test_clip("c1"), make_test_clip("c2")]
+    browser.add_clips([(clip, source) for clip in clips])
+    browser._filter_state.enabled_filter = True
+
+    rebuilds = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda *a, **k: rebuilds.append(True))
+
+    browser.toggle_disabled(["c1"])
+
+    assert rebuilds == [True]
+
+
+def test_update_clips_can_preserve_virtual_layout(qapp, source, monkeypatch):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    browser.resize(700, 500)
+    clips = [make_test_clip(f"v{i}", source_id=source.id) for i in range(20)]
+
+    browser.set_virtual_clips([(clip, source) for clip in clips])
+    qapp.processEvents()
+    browser._get_virtual_rows()
+    browser._virtual_rows_dirty = False
+    clips[2].disabled = True
+
+    rebuilds = []
+    invalidations = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda *a, **k: rebuilds.append(True))
+    monkeypatch.setattr(
+        browser, "_invalidate_virtual_rows", lambda: invalidations.append(True)
+    )
+
+    browser.update_clips([clips[2]], preserve_layout=True)
+
+    assert rebuilds == []
+    assert invalidations == []
+    assert browser._virtual_rows_dirty is False
+
+
+def test_update_clips_rebuilds_with_preserve_layout_when_enabled_filter_active(
+    qapp, source, monkeypatch
+):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clips = [make_test_clip("c1", source_id=source.id)]
+    browser.add_clips([(clips[0], source)])
+    browser._filter_state.enabled_filter = True
+    clips[0].disabled = True
+
+    rebuilds = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda *a, **k: rebuilds.append(True))
+
+    browser.update_clips([clips[0]], preserve_layout=True)
+
+    assert rebuilds == [True]
+
+
+def test_update_clip_gaze_updates_card_without_rebuild_when_unfiltered(
+    qapp, source, monkeypatch
+):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clip = make_test_clip("c1", source_id=source.id)
+    browser.add_clips([(clip, source)])
+
+    rebuilds = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda *a, **k: rebuilds.append(True))
+
+    browser.update_clip_gaze("c1", "looking_left")
+
+    assert rebuilds == []
+    assert browser._thumbnail_by_id["c1"].clip.gaze_category == "looking_left"
+
+
+def test_update_clip_gaze_rebuilds_when_gaze_filter_active(qapp, source, monkeypatch):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clip = make_test_clip("c1", source_id=source.id)
+    browser.add_clips([(clip, source)])
+    browser._filter_state.gaze_filter = "looking_left"
+
+    rebuilds = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda *a, **k: rebuilds.append(True))
+
+    browser.update_clip_gaze("c1", "looking_left")
+
+    assert rebuilds == [True]
+
+
+def test_update_clip_custom_queries_updates_badge_without_rebuild_when_unfiltered(
+    qapp, source, monkeypatch
+):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clip = make_test_clip("c1", source_id=source.id)
+    browser.add_clips([(clip, source)])
+
+    rebuilds = []
+    monkeypatch.setattr(browser, "_rebuild_grid", lambda *a, **k: rebuilds.append(True))
+
+    browser.update_clip_custom_queries(
+        "c1",
+        [{"query": "contains a face", "match": True, "confidence": 0.9}],
+    )
+
+    assert rebuilds == []
+    assert browser._thumbnail_by_id["c1"].clip.custom_queries[0]["query"] == "contains a face"
 
 
 def test_marquee_selection_replaces_previous_selection(qapp, source, monkeypatch):

--- a/tests/test_clip_browser_selection.py
+++ b/tests/test_clip_browser_selection.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 from PySide6.QtCore import QRect
+from PySide6.QtTest import QTest
 
 from models.clip import Source
 from tests.conftest import make_test_clip
@@ -209,6 +210,50 @@ def test_virtual_refresh_layout_skips_when_columns_unchanged(qapp, source, monke
     browser.refresh_layout()
 
     assert rebuilds == []
+
+
+def test_virtual_scroll_reuses_cached_rows(qapp, source, monkeypatch):
+    from ui.clip_browser import ClipBrowser, VIRTUAL_CARD_ROW_HEIGHT
+
+    browser = ClipBrowser()
+    browser.resize(700, 500)
+    clips = [make_test_clip(f"v{i}") for i in range(100)]
+    browser.set_virtual_clips([(clip, source) for clip in clips])
+    qapp.processEvents()
+
+    calls = []
+    original = browser._build_virtual_rows
+
+    def wrapped_build(*args, **kwargs):
+        calls.append(True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(browser, "_build_virtual_rows", wrapped_build)
+    browser.scroll.verticalScrollBar().setValue(VIRTUAL_CARD_ROW_HEIGHT * 3)
+    browser._on_scroll_changed(browser.scroll.verticalScrollBar().value())
+    QTest.qWait(25)
+    qapp.processEvents()
+
+    assert calls == []
+
+
+def test_virtual_scroll_reuses_cached_thumbnail_widgets(qapp, source):
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    browser.resize(700, 500)
+    clips = [make_test_clip(f"v{i}") for i in range(100)]
+    browser.set_virtual_clips([(clip, source) for clip in clips])
+    qapp.processEvents()
+
+    first_id = browser.thumbnails[0].clip.id
+    first_widget = browser.thumbnails[0]
+
+    browser._clear_realized_virtual_widgets()
+    reused = browser._get_virtual_thumbnail(clips[0], source)
+
+    assert reused is first_widget
+    assert browser._virtual_widget_cache[first_id] is first_widget
 
 
 def test_toggle_disabled_unselects_only_toggled_clip(qapp, source):

--- a/tests/test_clip_browser_selection.py
+++ b/tests/test_clip_browser_selection.py
@@ -682,6 +682,144 @@ def test_marquee_selection_skips_disabled_and_hidden_clips(qapp, source, monkeyp
     assert selected_ids == {"c1"}
 
 
+def test_toggle_disabled_emits_disabled_clips_changed_signal(qapp, source):
+    """ClipBrowser should signal toggle intent rather than reach into MainWindow."""
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    clips = [make_test_clip("c1"), make_test_clip("c2")]
+    browser.add_clips([(clip, source) for clip in clips])
+
+    received = []
+    browser.disabled_clips_changed.connect(lambda ids: received.append(list(ids)))
+
+    # Without an undo stack the fallback path runs (no signal expected).
+    browser.toggle_disabled(["c1"])
+    assert received == []
+
+    # Wire a fake window with an undo_stack so the signal path is taken.
+    class FakeUndoStack:
+        def __init__(self):
+            self.pushed = []
+
+        def push(self, command):
+            self.pushed.append(command)
+            command.redo()
+
+    fake_window = type(
+        "FakeWindow",
+        (),
+        {
+            "undo_stack": FakeUndoStack(),
+            "project": type("FakeProject", (), {
+                "clips_by_id": {clip.id: clip for clip in clips},
+                "_dirty": False,
+                "_notify_observers": lambda *_a, **_k: None,
+                "toggle_clips_disabled": lambda self, ids: [
+                    setattr(c, "disabled", not c.disabled)
+                    or c
+                    for c in [
+                        self.clips_by_id[i] for i in ids if i in self.clips_by_id
+                    ]
+                ],
+            })(),
+        },
+    )()
+    browser.window = lambda fw=fake_window: fw  # type: ignore[assignment]
+
+    browser.toggle_disabled(["c2"])
+    assert received == [["c2"]]
+
+
+def test_get_selected_clips_filters_hidden_in_non_virtual_mode(
+    qapp, source, monkeypatch
+):
+    """Selection result must include only visible clips regardless of mode.
+
+    Previously, virtual mode returned only visible clips while non-virtual
+    returned all selected clips. The same project crossing the
+    VIRTUALIZATION_THRESHOLD must not return different selection sets.
+    """
+    from core.analysis.shots import get_display_name
+    from ui.clip_browser import ClipBrowser
+
+    close_up_label = get_display_name("close-up")
+
+    browser = ClipBrowser()
+    clips = [
+        make_test_clip("c0", shot_type="close-up"),
+        make_test_clip("c1", shot_type="wide"),
+        make_test_clip("c2", shot_type="close-up"),
+    ]
+    browser.add_clips([(clip, source) for clip in clips])
+
+    browser.set_selection(["c0", "c1", "c2"])
+
+    # No filter: all selected clips visible.
+    assert {c.id for c in browser.get_selected_clips()} == {"c0", "c1", "c2"}
+
+    # Apply a filter that hides "c1".
+    browser._filter_state.shot_type = {close_up_label}
+
+    selected_visible = {c.id for c in browser.get_selected_clips()}
+    assert "c1" not in selected_visible
+    assert selected_visible == {"c0", "c2"}
+
+
+def test_virtual_add_clip_coalesces_consecutive_rebuilds(qapp, source, monkeypatch):
+    """Per-clip add_clip in virtual mode should coalesce into a single deferred rebuild."""
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    browser.resize(700, 500)
+
+    initial = [make_test_clip(f"v{i}", source_id=source.id) for i in range(5)]
+    browser.set_virtual_clips([(clip, source) for clip in initial])
+    qapp.processEvents()
+
+    # Replace _do_rebuild_grid so we can count how many real rebuilds run.
+    actual_rebuilds = []
+    original = browser._do_rebuild_grid
+    monkeypatch.setattr(
+        browser,
+        "_do_rebuild_grid",
+        lambda: actual_rebuilds.append(True) or original(),
+    )
+
+    new_clips = [make_test_clip(f"new-{i}", source_id=source.id) for i in range(10)]
+    for clip in new_clips:
+        browser.add_clip(clip, source)
+
+    # All 10 add_clip calls should coalesce: _rebuild_pending guards subsequent calls.
+    # Only one rebuild should be scheduled before processEvents flushes the timer.
+    qapp.processEvents()
+    assert len(actual_rebuilds) <= 2, (
+        f"Expected coalesced rebuild (<=2), got {len(actual_rebuilds)}"
+    )
+
+
+def test_virtual_clear_realized_widgets_reuses_source_headers(qapp, source):
+    """SourceGroupHeader widgets should be reused across rebuilds, not torn down."""
+    from ui.clip_browser import ClipBrowser
+
+    browser = ClipBrowser()
+    browser.resize(700, 500)
+
+    clips = [make_test_clip(f"v{i}", source_id=source.id) for i in range(50)]
+    browser.set_virtual_clips([(clip, source) for clip in clips])
+    qapp.processEvents()
+
+    assert source.id in browser._source_headers
+    header_before = browser._source_headers[source.id]
+
+    # Force a rebuild — header should still be the same widget afterwards.
+    browser.refresh_layout()
+    browser._rebuild_grid()
+    qapp.processEvents()
+
+    assert browser._source_headers.get(source.id) is header_before
+
+
 def test_export_request_forwards_clicked_clip_and_source(qapp, source):
     from ui.clip_browser import ClipBrowser
 

--- a/tests/test_lazy_init_attrs.py
+++ b/tests/test_lazy_init_attrs.py
@@ -1,0 +1,108 @@
+"""Tests that every name in lazy package ``__all__`` resolves cleanly.
+
+``core/__init__.py`` and ``ui/__init__.py`` use ``__getattr__`` to defer
+heavy submodule imports (mpv, PyAV, etc.) until first attribute access.
+That pattern is fragile: a name added to ``__all__`` without a matching
+``__getattr__`` branch silently fails only when the name is first used.
+These tests guard against that by walking every ``__all__`` entry and
+asserting it resolves without raising.
+
+The "no mpv / no PyAV" invariants are checked in a subprocess so that
+modules loaded by other tests in the same pytest run don't pollute
+``sys.modules`` and produce false failures.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_in_clean_interpreter(script: str) -> subprocess.CompletedProcess:
+    """Execute ``script`` in a fresh ``python`` subprocess and capture output."""
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_all_core_all_names_resolve_via_lazy_getattr():
+    """Every name in ``core.__all__`` must resolve through ``__getattr__``."""
+    import core
+
+    for name in core.__all__:
+        resolved = getattr(core, name)
+        assert resolved is not None, f"core.{name} resolved to None"
+
+
+def test_core_lazy_attrs_do_not_load_native_media_runtimes():
+    """Resolving every ``core.__all__`` name must not pull mpv or PyAV in.
+
+    Runs in a subprocess so it's immune to other tests in the pytest run
+    that may legitimately load these modules.
+    """
+    script = """
+        import sys, core
+        for name in core.__all__:
+            getattr(core, name)
+        assert 'mpv' not in sys.modules, f'mpv loaded by core.__all__: {sorted(k for k in sys.modules if "mpv" in k)}'
+        assert 'av' not in sys.modules, f'av loaded by core.__all__: {sorted(k for k in sys.modules if k == "av" or k.startswith("av."))}'
+    """
+    result = _run_in_clean_interpreter(script)
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_all_ui_all_names_resolve_via_lazy_getattr():
+    """Every name in ``ui.__all__`` must resolve through ``__getattr__``."""
+    import ui
+
+    for name in ui.__all__:
+        resolved = getattr(ui, name)
+        assert resolved is not None, f"ui.{name} resolved to None"
+
+
+def test_ui_lazy_attrs_do_not_load_native_media_runtimes():
+    """Resolving every ``ui.__all__`` name must not pull mpv or PyAV in.
+
+    ``MainWindow`` is imported as a class object; ``ui.video_player`` defers
+    its python-mpv import until playback initializes. So the class-level
+    resolve is safe — only constructing/showing the window would load mpv.
+    """
+    script = """
+        import sys, ui
+        for name in ui.__all__:
+            getattr(ui, name)
+        assert 'mpv' not in sys.modules, f'mpv loaded by ui.__all__: {sorted(k for k in sys.modules if "mpv" in k)}'
+        assert 'av' not in sys.modules, f'av loaded by ui.__all__: {sorted(k for k in sys.modules if k == "av" or k.startswith("av."))}'
+    """
+    result = _run_in_clean_interpreter(script)
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_core_unknown_name_raises_attribute_error():
+    """Sanity check: unknown names still raise ``AttributeError``."""
+    import core
+
+    try:
+        core.DoesNotExist  # noqa: B018 - intentional attribute access
+    except AttributeError:
+        pass
+    else:
+        raise AssertionError("expected AttributeError for unknown core attr")
+
+
+def test_ui_unknown_name_raises_attribute_error():
+    """Sanity check: unknown names still raise ``AttributeError``."""
+    import ui
+
+    try:
+        ui.DoesNotExist  # noqa: B018 - intentional attribute access
+    except AttributeError:
+        pass
+    else:
+        raise AssertionError("expected AttributeError for unknown ui attr")

--- a/tests/test_save_project_worker.py
+++ b/tests/test_save_project_worker.py
@@ -1,0 +1,131 @@
+"""Tests for SaveProjectWorker — concurrency safety and signal contract."""
+
+from pathlib import Path
+
+import pytest
+
+from core.project import Project
+from models.clip import Source
+from tests.conftest import make_test_clip
+
+
+@pytest.fixture
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _make_project_with_clip(tmp_dir: Path) -> Project:
+    """Build a small project ready for save."""
+    project = Project.new(name="save-worker-test")
+    source = Source(
+        id="src-1",
+        file_path=tmp_dir / "video.mp4",
+        duration_seconds=10.0,
+        fps=30.0,
+        width=640,
+        height=480,
+    )
+    project.add_source(source)
+    project.add_clips([make_test_clip("clip-1", source_id=source.id)])
+    return project
+
+
+def test_snapshot_for_save_is_independent_of_live_project(tmp_path):
+    """Snapshot must not see post-snapshot mutations on the live project."""
+    project = _make_project_with_clip(tmp_path)
+    snapshot = project.snapshot_for_save()
+
+    # Mutate the live project after snapshotting.
+    project.add_clips([make_test_clip("clip-2", source_id="src-1")])
+    project._clips[0].shot_type = "wide"
+
+    snapshot_clip_ids = {c.id for c in snapshot["clips"]}
+    assert snapshot_clip_ids == {"clip-1"}
+    assert snapshot["clips"][0].shot_type is None
+
+
+def test_save_worker_emits_success_signal(qapp, tmp_path):
+    """Successful save emits save_finished(True, path, '')."""
+    from ui.main_window import SaveProjectWorker
+
+    project = _make_project_with_clip(tmp_path)
+    target = tmp_path / "out.sceneripper"
+    snapshot = project.snapshot_for_save()
+
+    received = []
+    worker = SaveProjectWorker(snapshot, target)
+    worker.save_finished.connect(
+        lambda success, path, error: received.append((success, path, error))
+    )
+
+    worker.run()  # Run inline (no thread) so we can assert deterministically.
+
+    assert received, "save_finished was not emitted"
+    success, path, error = received[0]
+    assert success is True
+    assert path == str(target)
+    assert error == ""
+    assert target.exists()
+
+
+def test_save_worker_emits_failure_signal_on_exception(qapp, tmp_path, monkeypatch):
+    """When save_project raises, worker emits save_finished(False, path, error)."""
+    from ui import main_window
+    from ui.main_window import SaveProjectWorker
+
+    project = _make_project_with_clip(tmp_path)
+    target = tmp_path / "out.sceneripper"
+    snapshot = project.snapshot_for_save()
+
+    def boom(**_kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(main_window, "save_project", boom)
+
+    received = []
+    worker = SaveProjectWorker(snapshot, target)
+    worker.save_finished.connect(
+        lambda success, path, error: received.append((success, path, error))
+    )
+
+    worker.run()
+
+    assert received
+    success, path, error = received[0]
+    assert success is False
+    assert path == str(target)
+    assert "disk full" in error
+
+
+def test_save_worker_uses_snapshot_not_live_project(qapp, tmp_path, monkeypatch):
+    """Mutations on the live project must not leak into the worker's save call."""
+    from ui import main_window
+
+    project = _make_project_with_clip(tmp_path)
+    target = tmp_path / "out.sceneripper"
+    snapshot = project.snapshot_for_save()
+
+    captured = {}
+
+    def fake_save_project(**kwargs):
+        captured["clips"] = kwargs["clips"]
+        captured["sources"] = kwargs["sources"]
+        return True
+
+    monkeypatch.setattr(main_window, "save_project", fake_save_project)
+
+    # Mutate the live project AFTER snapshotting but BEFORE the worker runs.
+    project.add_clips([make_test_clip("clip-2", source_id="src-1")])
+
+    worker = main_window.SaveProjectWorker(snapshot, target)
+    worker.run()
+
+    saved_ids = {c.id for c in captured["clips"]}
+    assert saved_ids == {"clip-1"}, (
+        "Worker must serialize the snapshot, not the post-mutation live project"
+    )

--- a/tests/test_transcription_runtime_imports.py
+++ b/tests/test_transcription_runtime_imports.py
@@ -1,6 +1,41 @@
-"""Tests for transcription runtime import boundaries."""
+"""Tests for transcription runtime import boundaries.
+
+These tests defend the fix documented in
+``docs/solutions/runtime-errors/macos-libmpv-pyav-ffmpeg-dylib-collision-20260504.md``.
+Loading PyAV's bundled FFmpeg dylibs alongside Homebrew FFmpeg (pulled in
+transitively by libmpv) triggers AVFoundation duplicate-class warnings on
+macOS, so any startup or availability-check path that pulls in ``av`` is a
+regression.
+"""
 
 import sys
+
+
+def _purge_transcription_modules():
+    """Drop cached transcription/PyAV modules so re-imports run cleanly."""
+    for name in (
+        "core.transcription",
+        "faster_whisper",
+        "av",
+    ):
+        sys.modules.pop(name, None)
+
+
+def test_importing_core_transcription_does_not_load_pyav():
+    """``import core.transcription`` must not transitively load PyAV.
+
+    ``faster_whisper`` 1.x eagerly imports ``av`` from ``faster_whisper.audio``
+    at module load. The transcription module therefore has to defer importing
+    ``faster_whisper`` until transcription actually runs — otherwise the GUI
+    process loads PyAV's bundled FFmpeg dylibs alongside libmpv's Homebrew
+    FFmpeg dylibs and triggers the documented AVFoundation collision.
+    """
+    _purge_transcription_modules()
+
+    import core.transcription  # noqa: F401
+
+    assert "faster_whisper" not in sys.modules
+    assert "av" not in sys.modules
 
 
 def test_faster_whisper_availability_does_not_import_runtime_modules(monkeypatch):

--- a/tests/test_transcription_runtime_imports.py
+++ b/tests/test_transcription_runtime_imports.py
@@ -1,0 +1,31 @@
+"""Tests for transcription runtime import boundaries."""
+
+import sys
+
+
+def test_faster_whisper_availability_does_not_import_runtime_modules(monkeypatch):
+    """Availability checks should not import PyAV into the GUI process."""
+    import core.transcription as transcription
+
+    monkeypatch.setattr(transcription, "_faster_whisper_available", None)
+    sys.modules.pop("faster_whisper", None)
+    sys.modules.pop("av", None)
+
+    transcription.is_faster_whisper_available()
+
+    assert "faster_whisper" not in sys.modules
+    assert "av" not in sys.modules
+
+
+def test_scene_detect_uses_opencv_backend_without_importing_pyav():
+    """Scene detection imports should not load PyAV's FFmpeg dylibs."""
+    sys.modules.pop("core.scene_detect", None)
+    sys.modules.pop("scenedetect", None)
+    sys.modules.pop("scenedetect.backends", None)
+    sys.modules.pop("scenedetect.backends.pyav", None)
+    sys.modules.pop("av", None)
+
+    import core.scene_detect  # noqa: F401
+
+    assert "av" not in sys.modules
+    assert sys.modules.get("scenedetect.backends.pyav") is None

--- a/tests/test_video_player_runtime.py
+++ b/tests/test_video_player_runtime.py
@@ -1,8 +1,22 @@
 """Tests for frozen-runtime video player setup."""
 
 import ctypes.util
+import importlib
+import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
+
+
+def test_video_player_module_does_not_import_python_mpv_on_import():
+    """Importing the UI module should not load libmpv into the process."""
+    sys.modules.pop("ui.video_player", None)
+    sys.modules.pop("mpv", None)
+
+    video_player = importlib.import_module("ui.video_player")
+
+    assert video_player.mpv is None
+    assert "mpv" not in sys.modules
 
 
 def test_find_bundled_mpv_library_windows(tmp_path):
@@ -35,5 +49,26 @@ def test_prepare_frozen_mpv_import_patches_find_library(tmp_path):
             prepared = video_player._prepare_frozen_mpv_import()
             assert prepared == dylib_path
             assert ctypes.util.find_library("mpv") == str(dylib_path)
+    finally:
+        ctypes.util.find_library = original_find_library
+
+
+def test_prepare_system_mpv_import_uses_exact_env_library(tmp_path, monkeypatch):
+    """Source builds should avoid broad DYLD_LIBRARY_PATH mutations for mpv."""
+    dylib_path = tmp_path / "libmpv.dylib"
+    dylib_path.write_text("fake")
+
+    import ui.video_player as video_player
+
+    original_find_library = ctypes.util.find_library
+    try:
+        monkeypatch.setenv("SCENE_RIPPER_LIBMPV_DYLIB", str(dylib_path))
+        monkeypatch.setenv("DYLD_LIBRARY_PATH", "/existing")
+
+        assert video_player._find_system_mpv_library() == dylib_path
+        video_player._prepare_mpv_import(dylib_path)
+
+        assert ctypes.util.find_library("mpv") == str(dylib_path)
+        assert os.environ["DYLD_LIBRARY_PATH"] == "/existing"
     finally:
         ctypes.util.find_library = original_find_library

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,5 +1,11 @@
 """UI components for the application."""
 
-from ui.main_window import MainWindow
-
 __all__ = ["MainWindow"]
+
+
+def __getattr__(name: str):
+    if name == "MainWindow":
+        from ui.main_window import MainWindow
+
+        return MainWindow
+    raise AttributeError(f"module 'ui' has no attribute {name!r}")

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -1,7 +1,7 @@
 """Clip browser with thumbnail grid view."""
 
 import logging
-from collections import Counter
+from collections import Counter, OrderedDict
 from pathlib import Path
 from typing import Optional
 
@@ -86,6 +86,36 @@ logger = logging.getLogger(__name__)
 VIRTUALIZATION_THRESHOLD = 300
 VIRTUAL_CARD_ROW_HEIGHT = 246
 VIRTUAL_ROW_BUFFER = 4
+VIRTUAL_SCROLL_REBUILD_DELAY_MS = 16
+VIRTUAL_WIDGET_CACHE_LIMIT = 192
+THUMBNAIL_PIXMAP_CACHE_LIMIT = 512
+
+_THUMBNAIL_PIXMAP_CACHE: OrderedDict[tuple[str, int, int, int], QPixmap] = OrderedDict()
+
+
+def _scaled_thumbnail_from_cache(path: Path, width: int, height: int) -> QPixmap:
+    """Return a cached scaled thumbnail pixmap for card rendering."""
+    try:
+        stat = path.stat()
+        mtime_ns = stat.st_mtime_ns
+    except OSError:
+        mtime_ns = 0
+
+    key = (str(path), mtime_ns, width, height)
+    cached = _THUMBNAIL_PIXMAP_CACHE.get(key)
+    if cached is not None:
+        _THUMBNAIL_PIXMAP_CACHE.move_to_end(key)
+        return cached
+
+    pixmap = QPixmap(str(path))
+    if pixmap.isNull():
+        return pixmap
+
+    scaled = pixmap.scaled(width, height, Qt.KeepAspectRatio, Qt.SmoothTransformation)
+    _THUMBNAIL_PIXMAP_CACHE[key] = scaled
+    while len(_THUMBNAIL_PIXMAP_CACHE) > THUMBNAIL_PIXMAP_CACHE_LIMIT:
+        _THUMBNAIL_PIXMAP_CACHE.popitem(last=False)
+    return scaled
 
 
 def get_latest_custom_query_results(custom_queries: list[dict] | None) -> dict[str, dict]:
@@ -311,14 +341,9 @@ class ClipThumbnail(QFrame):
 
     def _load_thumbnail(self, path: Path):
         """Load thumbnail image."""
-        pixmap = QPixmap(str(path))
+        pixmap = _scaled_thumbnail_from_cache(path, 220, 124)
         if not pixmap.isNull():
-            scaled = pixmap.scaled(
-                220, 124,
-                Qt.KeepAspectRatio,
-                Qt.SmoothTransformation
-            )
-            self.thumbnail_label.setPixmap(scaled)
+            self.thumbnail_label.setPixmap(pixmap)
 
     def _format_duration(self, seconds: float) -> str:
         """Format duration as MM:SS.ms"""
@@ -882,6 +907,9 @@ class ClipBrowser(QWidget):
         self._virtual_top_spacer: QWidget | None = None
         self._virtual_bottom_spacer: QWidget | None = None
         self._virtual_render_range: tuple[int, int] | None = None
+        self._virtual_rows_dirty = True
+        self._virtual_rows_columns = 0
+        self._virtual_widget_cache: OrderedDict[str, ClipThumbnail] = OrderedDict()
 
         # Shared filter state — all filter values live here. Proxy properties
         # on this class (e.g., `_current_filter`, `_gaze_filter`) read/write
@@ -1055,7 +1083,7 @@ class ClipBrowser(QWidget):
             return
         if self._virtual_mode and self.thumbnails:
             current_columns = self._calculate_columns()
-            if current_columns == self._last_column_count:
+            if current_columns == self._last_column_count and not self._virtual_rows_dirty:
                 return
         self._last_column_count = 0
         self._rebuild_grid()
@@ -1069,7 +1097,10 @@ class ClipBrowser(QWidget):
                 )
                 if (first_row, last_row) == self._virtual_render_range:
                     return
-            self._rebuild_grid()
+            self._rebuild_grid(
+                invalidate_virtual_rows=False,
+                delay_ms=VIRTUAL_SCROLL_REBUILD_DELAY_MS,
+            )
 
     def _show_empty_state(self):
         """Show the empty state label in the grid."""
@@ -1135,6 +1166,7 @@ class ClipBrowser(QWidget):
             self._virtual_entries.append((clip, source))
             self._source_lookup[clip.id] = source
 
+        self._invalidate_virtual_rows()
         self._sync_custom_query_filter_options()
         for clip, _source in self._virtual_entries:
             self._incremental_filter_enable(clip)
@@ -1149,6 +1181,8 @@ class ClipBrowser(QWidget):
             if widget is None:
                 continue
             widget.setVisible(False)
+            if isinstance(widget, ClipThumbnail):
+                continue
             if widget is not self.empty_label:
                 widget.deleteLater()
 
@@ -1165,6 +1199,35 @@ class ClipBrowser(QWidget):
         spacer.setFixedHeight(max(0, height))
         spacer.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         return spacer
+
+    def _invalidate_virtual_rows(self) -> None:
+        """Mark cached virtual display rows stale."""
+        self._virtual_rows_dirty = True
+        self._virtual_render_range = None
+
+    def _get_virtual_thumbnail(self, clip: Clip, source: Source) -> ClipThumbnail:
+        """Return a cached virtual thumbnail widget for a clip."""
+        thumb = self._virtual_widget_cache.get(clip.id)
+        if thumb is not None and (thumb.clip is not clip or thumb.source.id != source.id):
+            self._virtual_widget_cache.pop(clip.id, None)
+            thumb.deleteLater()
+            thumb = None
+
+        if thumb is None:
+            thumb = self._create_thumbnail(clip, source)
+            self._virtual_widget_cache[clip.id] = thumb
+        else:
+            self._virtual_widget_cache.move_to_end(clip.id)
+            thumb.set_drag_enabled(self._drag_enabled)
+
+        while len(self._virtual_widget_cache) > VIRTUAL_WIDGET_CACHE_LIMIT:
+            evict_id, evict_thumb = self._virtual_widget_cache.popitem(last=False)
+            if evict_thumb.isVisible():
+                self._virtual_widget_cache[evict_id] = evict_thumb
+                break
+            evict_thumb.deleteLater()
+
+        return thumb
 
     def add_clip(self, clip: Clip, source: Source):
         """Add a clip to the browser."""
@@ -1257,9 +1320,15 @@ class ClipBrowser(QWidget):
 
     def clear(self):
         """Clear all clips."""
+        visible_virtual_widget_ids = {id(thumb) for thumb in self.thumbnails}
         for thumb in self.thumbnails:
             self.grid.removeWidget(thumb)
             thumb.deleteLater()
+
+        for thumb in self._virtual_widget_cache.values():
+            if id(thumb) not in visible_virtual_widget_ids:
+                thumb.deleteLater()
+        self._virtual_widget_cache.clear()
 
         # Clear source headers
         for header in self._source_headers.values():
@@ -1284,6 +1353,8 @@ class ClipBrowser(QWidget):
         self._virtual_top_spacer = None
         self._virtual_bottom_spacer = None
         self._virtual_render_range = None
+        self._virtual_rows_dirty = True
+        self._virtual_rows_columns = 0
         self.container.setMinimumHeight(0)
         self._selected_custom_queries = set()
         self._sync_custom_query_filter_options()
@@ -1910,15 +1981,22 @@ class ClipBrowser(QWidget):
         self._rebuild_grid()
         self.filters_changed.emit()
 
-    def _rebuild_grid(self):
+    def _rebuild_grid(
+        self,
+        *,
+        invalidate_virtual_rows: bool = True,
+        delay_ms: int = 0,
+    ):
         """Schedule a grid rebuild on the next event loop iteration.
 
         Coalesces multiple calls into a single rebuild, which also ensures
         Qt has processed layouts so viewport dimensions are correct.
         """
+        if self._virtual_mode and invalidate_virtual_rows:
+            self._invalidate_virtual_rows()
         if not getattr(self, '_rebuild_pending', False):
             self._rebuild_pending = True
-            QTimer.singleShot(0, self._do_rebuild_grid)
+            QTimer.singleShot(delay_ms, self._do_rebuild_grid)
 
     def _do_rebuild_grid(self):
         """Actually rebuild the grid layout with source grouping, current order, and filter."""
@@ -2072,11 +2150,11 @@ class ClipBrowser(QWidget):
             )
         return ordered
 
-    def _build_virtual_rows(self) -> list[tuple[str, object]]:
+    def _build_virtual_rows(self, columns: int | None = None) -> list[tuple[str, object]]:
         """Build row records for the virtual grid."""
         grouped = self._ordered_grouped_entries()
         rows: list[tuple[str, object]] = []
-        columns = self.COLUMNS
+        columns = columns or self.COLUMNS
         for source_id in sorted(
             grouped,
             key=lambda sid: grouped[sid][0][1].filename.lower() if grouped[sid] else "",
@@ -2106,6 +2184,19 @@ class ClipBrowser(QWidget):
                     rows.append(("clips", visible_entries[start:start + columns]))
         return rows
 
+    def _get_virtual_rows(self) -> list[tuple[str, object]]:
+        """Return cached virtual rows, rebuilding only when the data shape changes."""
+        columns = self.COLUMNS
+        if (
+            self._virtual_rows_dirty
+            or self._virtual_rows_columns != columns
+            or not self._virtual_display_rows
+        ):
+            self._virtual_display_rows = self._build_virtual_rows(columns)
+            self._virtual_rows_columns = columns
+            self._virtual_rows_dirty = False
+        return self._virtual_display_rows
+
     def _current_virtual_render_range(self, row_count: int) -> tuple[int, int]:
         """Calculate the virtual row range that should be realized."""
         viewport_height = max(1, self.scroll.viewport().height())
@@ -2124,57 +2215,69 @@ class ClipBrowser(QWidget):
             return
 
         self._last_column_count = self._calculate_columns()
-        self._clear_realized_virtual_widgets()
         if not self._virtual_entries:
+            self._clear_realized_virtual_widgets()
             self._show_empty_state()
             return
 
-        rows = self._build_virtual_rows()
-        self._virtual_display_rows = rows
+        rows = self._get_virtual_rows()
         if not rows:
+            self._clear_realized_virtual_widgets()
             self._show_empty_state()
             return
 
-        self._hide_empty_state()
         first_row, last_row = self._current_virtual_render_range(len(rows))
 
         row_height = VIRTUAL_CARD_ROW_HEIGHT
         total_height = len(rows) * row_height
         self.container.setMinimumHeight(total_height + (UISizes.GRID_MARGIN * 2))
-        self._virtual_render_range = (first_row, last_row)
 
-        grid_row = 0
-        top_height = first_row * row_height
-        if top_height:
-            self._virtual_top_spacer = self._make_virtual_spacer(top_height)
-            self.grid.addWidget(self._virtual_top_spacer, grid_row, 0, 1, self.COLUMNS)
-            grid_row += 1
+        self.setUpdatesEnabled(False)
+        try:
+            self._clear_realized_virtual_widgets()
+            self._hide_empty_state()
+            self._virtual_render_range = (first_row, last_row)
 
-        for row_type, payload in rows[first_row:last_row]:
-            if row_type == "header":
-                source_id, source, total_count, visible_count, selected_count = payload
-                header = self._get_or_create_header(source_id, source.filename, total_count)
-                header.set_clip_counts(total_count, visible_count, selected_count)
-                header.set_expanded(self._group_expanded_state.get(source_id, True))
-                self.grid.addWidget(header, grid_row, 0, 1, self.COLUMNS)
-                header.setVisible(True)
+            grid_row = 0
+            top_height = first_row * row_height
+            if top_height:
+                self._virtual_top_spacer = self._make_virtual_spacer(top_height)
+                self.grid.addWidget(self._virtual_top_spacer, grid_row, 0, 1, self.COLUMNS)
                 grid_row += 1
-                continue
 
-            entries = payload
-            for col, (clip, source) in enumerate(entries):
-                thumb = self._create_thumbnail(clip, source)
-                thumb.set_selected(clip.id in self.selected_clips)
-                self.thumbnails.append(thumb)
-                self._thumbnail_by_id[clip.id] = thumb
-                self.grid.addWidget(thumb, grid_row, col, Qt.AlignTop | Qt.AlignLeft)
-                thumb.setVisible(True)
-            grid_row += 1
+            for row_type, payload in rows[first_row:last_row]:
+                if row_type == "header":
+                    source_id, source, total_count, visible_count, selected_count = payload
+                    header = self._get_or_create_header(source_id, source.filename, total_count)
+                    header.set_clip_counts(total_count, visible_count, selected_count)
+                    header.set_expanded(self._group_expanded_state.get(source_id, True))
+                    self.grid.addWidget(header, grid_row, 0, 1, self.COLUMNS)
+                    header.setVisible(True)
+                    grid_row += 1
+                    continue
 
-        bottom_height = max(0, (len(rows) - last_row) * row_height)
-        if bottom_height:
-            self._virtual_bottom_spacer = self._make_virtual_spacer(bottom_height)
-            self.grid.addWidget(self._virtual_bottom_spacer, grid_row, 0, 1, self.COLUMNS)
+                entries = payload
+                for col, (clip, source) in enumerate(entries):
+                    thumb = self._get_virtual_thumbnail(clip, source)
+                    thumb.set_selected(clip.id in self.selected_clips)
+                    self.thumbnails.append(thumb)
+                    self._thumbnail_by_id[clip.id] = thumb
+                    self.grid.addWidget(thumb, grid_row, col, Qt.AlignTop | Qt.AlignLeft)
+                    thumb.setVisible(True)
+                grid_row += 1
+
+            bottom_height = max(0, (len(rows) - last_row) * row_height)
+            if bottom_height:
+                self._virtual_bottom_spacer = self._make_virtual_spacer(bottom_height)
+                self.grid.addWidget(
+                    self._virtual_bottom_spacer,
+                    grid_row,
+                    0,
+                    1,
+                    self.COLUMNS,
+                )
+        finally:
+            self.setUpdatesEnabled(True)
 
     def _get_or_create_header(
         self, source_id: str, filename: str, clip_count: int

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -118,6 +118,30 @@ def _scaled_thumbnail_from_cache(path: Path, width: int, height: int) -> QPixmap
     return scaled
 
 
+def _sort_key_by_color(clip: Clip) -> float:
+    """Module-level color sort key for both virtual and non-virtual paths."""
+    return get_primary_hue(clip.dominant_colors) if clip.dominant_colors else 0.0
+
+
+def _sort_key_by_duration(clip: Clip, source: Source) -> float:
+    """Module-level duration sort key (seconds) for both browser paths."""
+    return clip.duration_seconds(source.fps)
+
+
+def _sort_key_by_timeline(clip: Clip) -> int:
+    """Module-level timeline sort key (start frame) for both browser paths."""
+    return clip.start_frame
+
+
+def clear_thumbnail_pixmap_cache() -> None:
+    """Flush the module-level scaled-thumbnail pixmap cache.
+
+    Should be called when a project is closed/reopened so stale pixmaps from
+    the previous project don't linger and waste memory.
+    """
+    _THUMBNAIL_PIXMAP_CACHE.clear()
+
+
 def get_latest_custom_query_results(custom_queries: list[dict] | None) -> dict[str, dict]:
     """Collapse append-only custom query history to the latest result per query."""
     latest_results: dict[str, dict] = {}
@@ -762,6 +786,7 @@ class ClipBrowser(QWidget):
     filters_changed = Signal()  # Emitted when any filter changes
     view_details_requested = Signal(object, object)  # Clip, Source - request to show clip details
     export_requested = Signal(object, object)  # Clip, Source - request to export a single clip
+    disabled_clips_changed = Signal(list)  # list[str] clip IDs whose disabled state was toggled
 
     _MIN_COLUMNS = 2
 
@@ -910,6 +935,7 @@ class ClipBrowser(QWidget):
         self._virtual_rows_dirty = True
         self._virtual_rows_columns = 0
         self._virtual_widget_cache: OrderedDict[str, ClipThumbnail] = OrderedDict()
+        self._rebuild_pending: bool = False
 
         # Shared filter state — all filter values live here. Proxy properties
         # on this class (e.g., `_current_filter`, `_gaze_filter`) read/write
@@ -1152,6 +1178,10 @@ class ClipBrowser(QWidget):
         """Return the number of live card widgets currently realized."""
         return len(self.thumbnails)
 
+    def is_clip_realized(self, clip_id: str) -> bool:
+        """Whether a clip currently has a live card widget realized in the grid."""
+        return clip_id in self._thumbnail_by_id
+
     def set_virtual_clips(self, clip_source_pairs: list[tuple[Clip, Source]]) -> None:
         """Load clips in data-backed mode and realize only visible widgets."""
         self.clear()
@@ -1174,22 +1204,40 @@ class ClipBrowser(QWidget):
         self._rebuild_grid()
 
     def _clear_realized_virtual_widgets(self) -> None:
-        """Remove currently realized virtual widgets from the grid."""
+        """Remove currently realized virtual widgets from the grid.
+
+        Reuses cached `ClipThumbnail` widgets via `_virtual_widget_cache`, and
+        also reuses `SourceGroupHeader` widgets registered in
+        `_source_headers`. Only headers whose `source_id` is no longer present
+        in the current virtual entries are torn down (handled below).
+        """
         while self.grid.count():
             item = self.grid.takeAt(0)
             widget = item.widget()
             if widget is None:
                 continue
             widget.setVisible(False)
-            if isinstance(widget, ClipThumbnail):
+            if isinstance(widget, (ClipThumbnail, SourceGroupHeader)):
                 continue
             if widget is not self.empty_label:
                 widget.deleteLater()
 
+        # Drop any header whose source_id is no longer represented in the
+        # virtual entries; reuse the rest on the next rebuild.
+        if self._source_headers:
+            current_source_ids = {source.id for _clip, source in self._virtual_entries}
+            stale_ids = [
+                sid for sid in self._source_headers
+                if sid not in current_source_ids
+            ]
+            for sid in stale_ids:
+                header = self._source_headers.pop(sid)
+                header.deleteLater()
+                self._group_expanded_state.pop(sid, None)
+
         self._empty_label_in_grid = False
         self.thumbnails = []
         self._thumbnail_by_id = {}
-        self._source_headers = {}
         self._virtual_top_spacer = None
         self._virtual_bottom_spacer = None
         self._virtual_render_range = None
@@ -1220,12 +1268,18 @@ class ClipBrowser(QWidget):
             self._virtual_widget_cache.move_to_end(clip.id)
             thumb.set_drag_enabled(self._drag_enabled)
 
-        while len(self._virtual_widget_cache) > VIRTUAL_WIDGET_CACHE_LIMIT:
-            evict_id, evict_thumb = self._virtual_widget_cache.popitem(last=False)
-            if evict_thumb.isVisible():
-                self._virtual_widget_cache[evict_id] = evict_thumb
-                break
-            evict_thumb.deleteLater()
+        # Walk oldest-to-newest and evict the first non-visible entry. If
+        # every cached widget is currently visible, accept that the cache is
+        # briefly over-limit rather than looping forever.
+        if len(self._virtual_widget_cache) > VIRTUAL_WIDGET_CACHE_LIMIT:
+            evict_target_id: str | None = None
+            for cached_id, cached_thumb in self._virtual_widget_cache.items():
+                if not cached_thumb.isVisible():
+                    evict_target_id = cached_id
+                    break
+            if evict_target_id is not None:
+                evict_thumb = self._virtual_widget_cache.pop(evict_target_id)
+                evict_thumb.deleteLater()
 
         return thumb
 
@@ -1239,7 +1293,14 @@ class ClipBrowser(QWidget):
             self._sync_custom_query_filter_options()
             self._incremental_filter_enable(clip)
             self._update_duration_range()
-            self._rebuild_grid()
+            # Per-clip thumbnail-ready signals can call this dozens of times in
+            # quick succession; coalesce into one rebuild via the existing
+            # _rebuild_pending guard inside _rebuild_grid.
+            self._invalidate_virtual_rows()
+            self._rebuild_grid(
+                invalidate_virtual_rows=False,
+                delay_ms=VIRTUAL_SCROLL_REBUILD_DELAY_MS,
+            )
             return
 
         if clip.id in self._thumbnail_by_id:
@@ -1495,7 +1556,13 @@ class ClipBrowser(QWidget):
             thumb.set_drag_enabled(enabled)
 
     def get_selected_clips(self) -> list[Clip]:
-        """Get list of selected clips."""
+        """Get list of selected clips.
+
+        Returns only currently-visible (non-filtered-out) selected clips so the
+        result is consistent regardless of whether the browser is operating in
+        virtual or non-virtual mode (the same project crossing the
+        VIRTUALIZATION_THRESHOLD must not return different selection sets).
+        """
         if not self.selected_clips:
             return []
         if self._virtual_mode:
@@ -1504,7 +1571,11 @@ class ClipBrowser(QWidget):
                 for clip, _source in self._ordered_filtered_entries()
                 if clip.id in self.selected_clips
             ]
-        return [t.clip for t in self.thumbnails if t.clip.id in self.selected_clips]
+        return [
+            t.clip
+            for t in self.thumbnails
+            if t.clip.id in self.selected_clips and self._matches_filter(t)
+        ]
 
     def set_selection(self, clip_ids: list[str]) -> None:
         """Set the selection to the specified clip IDs.
@@ -1861,6 +1932,18 @@ class ClipBrowser(QWidget):
                 (updated_by_id.get(existing_clip.id, existing_clip), source)
                 for existing_clip, source in self._virtual_entries
             ]
+            # Replace any stale Clip references in the cached display rows so
+            # subsequent renders (when preserve_layout=True keeps the cache)
+            # don't show pre-edit data.
+            if self._virtual_display_rows:
+                for row_index, (row_type, payload) in enumerate(self._virtual_display_rows):
+                    if row_type != "clips":
+                        continue
+                    refreshed = [
+                        (updated_by_id.get(clip.id, clip), source)
+                        for clip, source in payload
+                    ]
+                    self._virtual_display_rows[row_index] = (row_type, refreshed)
 
         for clip in clips:
             thumb = self._thumbnail_by_id.get(clip.id)
@@ -2015,20 +2098,14 @@ class ClipBrowser(QWidget):
         if self._virtual_mode:
             self._rebuild_grid()
             return
-        self._sort_within_groups(key=lambda t: t.clip.start_frame)
+        self._sort_within_groups(key=lambda t: _sort_key_by_timeline(t.clip))
 
     def _sort_by_color(self):
         """Sort clips by primary hue (HSV color wheel order) within each source group."""
         if self._virtual_mode:
             self._rebuild_grid()
             return
-
-        def get_hue(thumb: ClipThumbnail) -> float:
-            if thumb.clip.dominant_colors:
-                return get_primary_hue(thumb.clip.dominant_colors)
-            return 0.0
-
-        self._sort_within_groups(key=get_hue)
+        self._sort_within_groups(key=lambda t: _sort_key_by_color(t.clip))
 
     def _sort_by_duration(self):
         """Sort clips by duration (longest first) within each source group."""
@@ -2036,7 +2113,7 @@ class ClipBrowser(QWidget):
             self._rebuild_grid()
             return
         self._sort_within_groups(
-            key=lambda t: t.clip.duration_seconds(t.source.fps),
+            key=lambda t: _sort_key_by_duration(t.clip, t.source),
             reverse=True,
         )
 
@@ -2224,17 +2301,14 @@ class ClipBrowser(QWidget):
                     reverse=True,
                 )
             elif sort_option == "Color":
-                entries.sort(
-                    key=lambda pair: get_primary_hue(pair[0].dominant_colors)
-                    if pair[0].dominant_colors else 0.0
-                )
+                entries.sort(key=lambda pair: _sort_key_by_color(pair[0]))
             elif sort_option == "Duration":
                 entries.sort(
-                    key=lambda pair: pair[0].duration_seconds(pair[1].fps),
+                    key=lambda pair: _sort_key_by_duration(pair[0], pair[1]),
                     reverse=True,
                 )
             else:
-                entries.sort(key=lambda pair: pair[0].start_frame)
+                entries.sort(key=lambda pair: _sort_key_by_timeline(pair[0]))
 
         return grouped
 
@@ -3216,9 +3290,9 @@ class ClipBrowser(QWidget):
         from ui.commands.toggle_clip_disabled import ToggleClipDisabledCommand
         main_win = self.window()
         if hasattr(main_win, 'undo_stack'):
-            pending = set(getattr(main_win, "_preserve_clip_update_layout_ids", set()))
-            pending.update(clip_ids)
-            setattr(main_win, "_preserve_clip_update_layout_ids", pending)
+            # Notify listeners (e.g. MainWindow) that these IDs are toggling so the
+            # downstream `clips_updated` handler can preserve layout for them.
+            self.disabled_clips_changed.emit(list(clip_ids))
             cmd = ToggleClipDisabledCommand(main_win.project, clip_ids)
             main_win.undo_stack.push(cmd)
         else:

--- a/ui/clip_browser.py
+++ b/ui/clip_browser.py
@@ -1091,7 +1091,7 @@ class ClipBrowser(QWidget):
     def _on_scroll_changed(self, _value: int) -> None:
         """Refresh realized cards as the virtual browser scrolls."""
         if self._virtual_mode and not getattr(self, "_rebuild_pending", False):
-            if self._virtual_display_rows:
+            if self._virtual_display_rows and not self._virtual_rows_dirty:
                 first_row, last_row = self._current_virtual_render_range(
                     len(self._virtual_display_rows)
                 )
@@ -1531,6 +1531,35 @@ class ClipBrowser(QWidget):
             if thumb.isVisible() and not thumb.disabled
         })
 
+    def select_source(self, source_id: str, visible_only: bool = True) -> None:
+        """Select enabled clips from one source.
+
+        Args:
+            source_id: Source ID whose clips should become selected.
+            visible_only: When True, only clips matching active filters are selected.
+        """
+        if self._virtual_mode:
+            grouped = self._ordered_grouped_entries()
+            entries = grouped.get(source_id, [])
+            selected_ids = {
+                clip.id
+                for clip, source in entries
+                if source.id == source_id
+                and not clip.disabled
+                and (not visible_only or self._matches_entry(clip, source))
+            }
+        else:
+            selected_ids = {
+                thumb.clip.id
+                for thumb in self.thumbnails
+                if thumb.source.id == source_id
+                and not thumb.disabled
+                and (not visible_only or self._matches_filter(thumb))
+            }
+
+        self._set_selected_ids(selected_ids)
+        self._refresh_source_header_counts()
+
     def clear_selection(self) -> None:
         """Clear all selections."""
         self._set_selected_ids(set())
@@ -1563,6 +1592,53 @@ class ClipBrowser(QWidget):
                 if thumb.clip.id in self.selected_clips
             ]
         self.selection_changed.emit(selected_ids)
+
+    def _refresh_source_header_counts(self) -> None:
+        """Refresh visible source header counts without rebuilding the grid."""
+        if not self._source_headers:
+            return
+
+        if self._virtual_mode:
+            grouped = self._ordered_grouped_entries()
+            for source_id, header in self._source_headers.items():
+                entries = grouped.get(source_id, [])
+                total_count = len(entries)
+                visible_count = sum(
+                    1 for clip, source in entries if self._matches_entry(clip, source)
+                )
+                selected_count = sum(
+                    1 for clip, _source in entries if clip.id in self.selected_clips
+                )
+                header.set_clip_counts(total_count, visible_count, selected_count)
+            return
+
+        thumbs_by_source: dict[str, list[ClipThumbnail]] = {}
+        for thumb in self.thumbnails:
+            thumbs_by_source.setdefault(thumb.source.id, []).append(thumb)
+
+        for source_id, header in self._source_headers.items():
+            source_thumbs = thumbs_by_source.get(source_id, [])
+            total_count = len(source_thumbs)
+            visible_count = sum(1 for thumb in source_thumbs if self._matches_filter(thumb))
+            selected_count = sum(
+                1 for thumb in source_thumbs if thumb.clip.id in self.selected_clips
+            )
+            header.set_clip_counts(total_count, visible_count, selected_count)
+
+    def _selected_count_for_source(self, source_id: str) -> int:
+        """Return selected clip count for a source without depending on row cache."""
+        if self._virtual_mode:
+            return sum(
+                1
+                for clip, source in self._virtual_entries
+                if source.id == source_id and clip.id in self.selected_clips
+            )
+
+        return sum(
+            1
+            for thumb in self.thumbnails
+            if thumb.source.id == source_id and thumb.clip.id in self.selected_clips
+        )
 
     def _on_container_mouse_press(self, event) -> None:
         """Begin tracking an empty-space click or marquee drag."""
@@ -1721,12 +1797,18 @@ class ClipBrowser(QWidget):
         if thumb:
             thumb.set_custom_queries(custom_queries)
             selection_changed = self._sync_custom_query_filter_options()
-            self._rebuild_grid()
+            if selection_changed or self._clip_updates_require_rebuild():
+                self._rebuild_grid()
+            else:
+                self._refresh_source_header_counts()
             if selection_changed:
                 self.filters_changed.emit()
         elif self._virtual_mode and clip_id in self._source_lookup:
             selection_changed = self._sync_custom_query_filter_options()
-            self._rebuild_grid()
+            if selection_changed or self._clip_updates_require_rebuild():
+                self._rebuild_grid()
+            else:
+                self._refresh_source_header_counts()
             if selection_changed:
                 self.filters_changed.emit()
 
@@ -1742,10 +1824,16 @@ class ClipBrowser(QWidget):
         if thumb:
             thumb.set_gaze(category)
             self._update_filter_availability()
-            self._rebuild_grid()
+            if self._clip_updates_require_rebuild():
+                self._rebuild_grid()
+            else:
+                self._refresh_source_header_counts()
         elif self._virtual_mode and clip_id in self._source_lookup:
             self._update_filter_availability()
-            self._rebuild_grid()
+            if self._clip_updates_require_rebuild():
+                self._rebuild_grid()
+            else:
+                self._refresh_source_header_counts()
 
     def update_clip_thumbnail(self, clip_id: str, thumb_path: Path):
         """Update the thumbnail image for a specific clip (O(1) lookup)."""
@@ -1760,11 +1848,12 @@ class ClipBrowser(QWidget):
                 len(self._thumbnail_by_id),
             )
 
-    def update_clips(self, clips: list[Clip]):
+    def update_clips(self, clips: list[Clip], preserve_layout: bool = False):
         """Update thumbnails for the given clips (called when clips are edited).
 
         Args:
             clips: List of clips that were updated
+            preserve_layout: When True, refresh realized cards without rebuilding rows.
         """
         updated_by_id = {clip.id: clip for clip in clips}
         if self._virtual_mode and updated_by_id:
@@ -1785,9 +1874,23 @@ class ClipBrowser(QWidget):
                 thumb._update_style()  # Refresh disabled visual state
 
         selection_changed = self._sync_custom_query_filter_options()
-        self._rebuild_grid()
+        can_preserve_layout = (
+            preserve_layout and self._filter_state.enabled_filter is None
+        )
+        if can_preserve_layout or not self._clip_updates_require_rebuild():
+            self._refresh_source_header_counts()
+        else:
+            self._rebuild_grid()
         if selection_changed:
             self.filters_changed.emit()
+
+    def _clip_updates_require_rebuild(self) -> bool:
+        """Whether generic clip data updates can affect current layout/filtering."""
+        if self.has_active_filters():
+            return True
+        if hasattr(self, "sort_combo") and self.sort_combo.currentText() != "Timeline":
+            return True
+        return False
 
     def _available_custom_query_names(self) -> list[str]:
         """Return sorted custom query names present across all clips."""
@@ -2247,7 +2350,8 @@ class ClipBrowser(QWidget):
 
             for row_type, payload in rows[first_row:last_row]:
                 if row_type == "header":
-                    source_id, source, total_count, visible_count, selected_count = payload
+                    source_id, source, total_count, visible_count, _selected_count = payload
+                    selected_count = self._selected_count_for_source(source_id)
                     header = self._get_or_create_header(source_id, source.filename, total_count)
                     header.set_clip_counts(total_count, visible_count, selected_count)
                     header.set_expanded(self._group_expanded_state.get(source_id, True))
@@ -2286,6 +2390,7 @@ class ClipBrowser(QWidget):
         if source_id not in self._source_headers:
             header = SourceGroupHeader(source_id, filename, clip_count)
             header.toggled.connect(self._on_header_toggled)
+            header.select_requested.connect(self._on_header_select_requested)
             self._source_headers[source_id] = header
         return self._source_headers[source_id]
 
@@ -2293,6 +2398,10 @@ class ClipBrowser(QWidget):
         """Handle source group header toggle."""
         self._group_expanded_state[source_id] = is_expanded
         self._rebuild_grid()
+
+    def _on_header_select_requested(self, source_id: str):
+        """Handle request to select visible clips from a source group."""
+        self.select_source(source_id, visible_only=True)
 
     def expand_all_groups(self):
         """Expand all source groups."""
@@ -3107,6 +3216,9 @@ class ClipBrowser(QWidget):
         from ui.commands.toggle_clip_disabled import ToggleClipDisabledCommand
         main_win = self.window()
         if hasattr(main_win, 'undo_stack'):
+            pending = set(getattr(main_win, "_preserve_clip_update_layout_ids", set()))
+            pending.update(clip_ids)
+            setattr(main_win, "_preserve_clip_update_layout_ids", pending)
             cmd = ToggleClipDisabledCommand(main_win.project, clip_ids)
             main_win.undo_stack.push(cmd)
         else:
@@ -3122,8 +3234,10 @@ class ClipBrowser(QWidget):
         self.selected_clips.difference_update(becoming_disabled)
         for thumb in self.thumbnails:
             thumb.set_selected(thumb.clip.id in self.selected_clips)
-        if self._virtual_mode:
+        if self._filter_state.enabled_filter is not None:
             self._rebuild_grid()
+        else:
+            self._refresh_source_header_counts()
 
         if self.selected_clips != selection_before:
             self._emit_selection_changed()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -67,6 +67,7 @@ from core.project import (
     Project,
     ProjectMetadata,
     ProjectLoadError,
+    save_project,
 )
 from ui.project_adapter import ProjectSignalAdapter
 from ui.settings_dialog import SettingsDialog
@@ -74,7 +75,7 @@ from ui.tabs import CollectTab, CutTab, AnalyzeTab, FramesTab, SequenceTab, Rend
 from ui.theme import theme, Spacing
 from ui.chat_panel import ChatPanel
 from ui.chat_worker import ChatAgentWorker
-from ui.clip_browser import VIRTUALIZATION_THRESHOLD
+from ui.clip_browser import VIRTUALIZATION_THRESHOLD, clear_thumbnail_pixmap_cache
 from ui.clip_details_sidebar import ClipDetailsSidebar
 from ui.dialogs import IntentionImportDialog, AnalysisPickerDialog, URLImportDialog
 from ui.log_viewer import LogViewerWidget, get_in_app_log_bridge
@@ -277,19 +278,34 @@ class ThumbnailWorker(QThread):
 
 
 class SaveProjectWorker(QThread):
-    """Background worker for saving a project without blocking the UI."""
+    """Background worker for saving a project without blocking the UI.
+
+    Takes a *snapshot* of the project state at dispatch time (rather than the
+    live `Project`) so the main thread can keep mutating the project while a
+    save is in flight without corrupting the on-disk JSON.
+    """
 
     save_finished = Signal(bool, str, str)  # success, path, error
 
-    def __init__(self, project: Project, filepath: Path):
+    def __init__(self, snapshot: dict, filepath: Path):
         super().__init__()
-        self.project = project
+        self._snapshot = snapshot
         self.filepath = filepath
 
     def run(self):
         try:
             started = time.perf_counter()
-            success = self.project.save(self.filepath)
+            success = save_project(
+                filepath=self.filepath,
+                sources=self._snapshot["sources"],
+                clips=self._snapshot["clips"],
+                sequence=self._snapshot["sequence"],
+                ui_state=self._snapshot["ui_state"],
+                metadata=self._snapshot["metadata"],
+                frames=self._snapshot["frames"],
+                extra_data=self._snapshot["extra_data"],
+                audio_sources=self._snapshot["audio_sources"],
+            )
             elapsed = time.perf_counter() - started
             logger.info("Saved project to %s in %.2fs", self.filepath, elapsed)
             self.save_finished.emit(success, str(self.filepath), "")
@@ -894,6 +910,11 @@ class MainWindow(QMainWindow):
 
         # Plan execution state
         self._pending_plan_tool_call_id: Optional[str] = None
+
+        # Track clip IDs whose disabled state was just toggled so the next
+        # `clips_updated` notification can preserve the existing card layout
+        # (avoids visual reflow when only the disabled flag changed).
+        self._preserve_clip_update_layout_ids: set[str] = set()
 
         # GUI state tracking for agent context awareness
         self._gui_state = GUIState()
@@ -1673,6 +1694,7 @@ class MainWindow(QMainWindow):
         self.cut_tab.clip_browser.filters_changed.connect(self._on_cut_filters_changed)
         self.cut_tab.clip_browser.view_details_requested.connect(self.show_clip_details)
         self.cut_tab.clip_browser.export_requested.connect(self._on_clip_export_requested)
+        self.cut_tab.clip_browser.disabled_clips_changed.connect(self._on_disabled_clips_changed)
 
         # Analyze tab signals
         self.analyze_tab.quick_run_requested.connect(self._on_quick_run_from_tab)
@@ -1683,6 +1705,7 @@ class MainWindow(QMainWindow):
         self.analyze_tab.clip_browser.filters_changed.connect(self._on_analyze_filters_changed)
         self.analyze_tab.clip_browser.view_details_requested.connect(self.show_clip_details)
         self.analyze_tab.clip_browser.export_requested.connect(self._on_clip_export_requested)
+        self.analyze_tab.clip_browser.disabled_clips_changed.connect(self._on_disabled_clips_changed)
 
         # Sequence tab signals
         self.sequence_tab.playback_requested.connect(self._on_playback_requested)
@@ -1838,6 +1861,16 @@ class MainWindow(QMainWindow):
         logger.debug(f"Clip {clip.id} updated from sidebar")
 
     @Slot(list)
+    def _on_disabled_clips_changed(self, clip_ids: list):
+        """Record clip IDs whose disabled state is being toggled.
+
+        ClipBrowser emits this just before pushing the toggle command onto the
+        undo stack; the resulting `clips_updated` notification can then
+        preserve the existing layout for these IDs.
+        """
+        self._preserve_clip_update_layout_ids.update(clip_ids)
+
+    @Slot(list)
     def _on_clips_updated(self, clips: list):
         """Handle clips updated signal from project.
 
@@ -1848,14 +1881,10 @@ class MainWindow(QMainWindow):
             clips: List of updated clips
         """
         updated_ids = {clip.id for clip in clips}
-        preserve_ids = set(getattr(self, "_preserve_clip_update_layout_ids", set()))
+        preserve_ids = self._preserve_clip_update_layout_ids
         preserve_layout = bool(updated_ids and updated_ids.issubset(preserve_ids))
         if preserve_layout:
-            remaining = preserve_ids - updated_ids
-            if remaining:
-                self._preserve_clip_update_layout_ids = remaining
-            elif hasattr(self, "_preserve_clip_update_layout_ids"):
-                delattr(self, "_preserve_clip_update_layout_ids")
+            preserve_ids.difference_update(updated_ids)
 
         # Update clip browsers in both tabs
         if hasattr(self, 'cut_tab') and hasattr(self.cut_tab, 'clip_browser'):
@@ -4428,12 +4457,11 @@ class MainWindow(QMainWindow):
             self.collect_tab.update_source_has_analysis(source_id, True)
 
         # Analysis can update data-backed virtual browsers for clips whose
-        # card widgets are not currently realized. Refresh the affected clip
-        # data so every source group remains represented after the grid rebuilds.
-        if hasattr(self, 'cut_tab') and hasattr(self.cut_tab, 'clip_browser'):
-            self.cut_tab.clip_browser.update_clips(clips)
-        if hasattr(self, 'analyze_tab') and hasattr(self.analyze_tab, 'clip_browser'):
-            self.analyze_tab.clip_browser.update_clips(clips)
+        # card widgets are not currently realized. Notify the project once so
+        # the standard `clips_updated` observer path refreshes both browsers
+        # (and any other listeners) — this also marks the project dirty.
+        if clips and hasattr(self, "project") and hasattr(self.project, "update_clips"):
+            self.project.update_clips(clips)
 
         # Save project
         if self.project.path:
@@ -10019,7 +10047,10 @@ class MainWindow(QMainWindow):
 
         self.save_project_action.setEnabled(False)
         self.save_project_as_action.setEnabled(False)
-        self.save_worker = SaveProjectWorker(self.project, filepath)
+        # Snapshot project state at dispatch time so main-thread mutations
+        # while the worker runs cannot corrupt the on-disk file.
+        snapshot = self.project.snapshot_for_save()
+        self.save_worker = SaveProjectWorker(snapshot, filepath)
         self.save_worker.save_finished.connect(self._on_project_save_finished)
         self.save_worker.start()
 
@@ -10029,6 +10060,16 @@ class MainWindow(QMainWindow):
         self.save_project_action.setEnabled(True)
         self.save_project_as_action.setEnabled(True)
         self.save_worker = None
+        if success:
+            # The worker only writes the snapshot to disk; the live Project
+            # bookkeeping (path + dirty flag + project_saved notification)
+            # happens here on the main thread.
+            self.project.path = filepath
+            self.project.mark_clean()
+            try:
+                self.project._notify_observers("project_saved", filepath)
+            except Exception:
+                logger.exception("project_saved observer notification failed")
 
         if success:
             self._add_recent_project(filepath)
@@ -10333,6 +10374,10 @@ class MainWindow(QMainWindow):
 
         # Clear GUI state (for agent context)
         self._gui_state.clear()
+
+        # Flush the module-level thumbnail pixmap cache so stale thumbnails
+        # from the previous project don't linger in memory.
+        clear_thumbnail_pixmap_cache()
 
     def _refresh_ui_from_project(self):
         """Refresh all UI components after project load.

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1847,11 +1847,24 @@ class MainWindow(QMainWindow):
         Args:
             clips: List of updated clips
         """
+        updated_ids = {clip.id for clip in clips}
+        preserve_ids = set(getattr(self, "_preserve_clip_update_layout_ids", set()))
+        preserve_layout = bool(updated_ids and updated_ids.issubset(preserve_ids))
+        if preserve_layout:
+            remaining = preserve_ids - updated_ids
+            if remaining:
+                self._preserve_clip_update_layout_ids = remaining
+            elif hasattr(self, "_preserve_clip_update_layout_ids"):
+                delattr(self, "_preserve_clip_update_layout_ids")
+
         # Update clip browsers in both tabs
         if hasattr(self, 'cut_tab') and hasattr(self.cut_tab, 'clip_browser'):
-            self.cut_tab.clip_browser.update_clips(clips)
+            self.cut_tab.clip_browser.update_clips(clips, preserve_layout=preserve_layout)
         if hasattr(self, 'analyze_tab') and hasattr(self.analyze_tab, 'clip_browser'):
-            self.analyze_tab.clip_browser.update_clips(clips)
+            self.analyze_tab.clip_browser.update_clips(
+                clips,
+                preserve_layout=preserve_layout,
+            )
             self._auto_include_analyzed_clips(clips)
 
     def _auto_include_analyzed_clips(self, clips: list) -> None:

--- a/ui/tabs/analyze_tab.py
+++ b/ui/tabs/analyze_tab.py
@@ -408,7 +408,7 @@ class AnalyzeTab(BaseTab):
         for clip_id in pending_ids:
             if clip_id not in self._clip_ids:
                 continue
-            if clip_id in self.clip_browser._thumbnail_by_id:
+            if self.clip_browser.is_clip_realized(clip_id):
                 continue
             clip = self._clips_by_id.get(clip_id)
             source = self._sources_by_id.get(clip.source_id) if clip else None
@@ -419,23 +419,21 @@ class AnalyzeTab(BaseTab):
                 self._clip_ids.discard(clip_id)
 
         if clip_source_pairs:
+            clip_count = len(clip_source_pairs)
             self._add_pairs_to_browser(clip_source_pairs)
-            self._log_deferred_browser_population(len(clip_source_pairs))
-
-    def _log_deferred_browser_population(self, clip_count: int) -> None:
-        """Log deferred Analyze restore with virtual/realized counts."""
-        if not self.clip_browser.is_virtualized():
-            logger.info(f"Populated {clip_count} deferred Analyze clips")
-            return
-
-        QTimer.singleShot(
-            0,
-            lambda: logger.info(
-                "Virtualized Analyze browser for %s deferred clips; realized %s widgets",
-                clip_count,
-                self.clip_browser.get_realized_clip_count(),
-            ),
-        )
+            if self.clip_browser.is_virtualized():
+                # Defer one tick so realization counts reflect the rebuilt grid.
+                QTimer.singleShot(
+                    0,
+                    lambda count=clip_count: logger.info(
+                        "Virtualized Analyze browser for %s deferred clips; "
+                        "realized %s widgets",
+                        count,
+                        self.clip_browser.get_realized_clip_count(),
+                    ),
+                )
+            else:
+                logger.info(f"Populated {clip_count} deferred Analyze clips")
 
     def remove_clip(self, clip_id: str):
         """Remove a single clip from the analysis tab.
@@ -544,14 +542,14 @@ class AnalyzeTab(BaseTab):
     def update_clip_colors(self, clip_id: str, colors: list):
         """Update colors for a clip."""
         if clip_id in self._clip_ids:
-            if clip_id in self.clip_browser._thumbnail_by_id:
+            if self.clip_browser.is_clip_realized(clip_id):
                 self.clip_browser.update_clip_colors(clip_id, colors)
             self._refresh_quick_run_availability()
 
     def update_clip_shot_type(self, clip_id: str, shot_type: str):
         """Update shot type for a clip."""
         if clip_id in self._clip_ids:
-            if clip_id in self.clip_browser._thumbnail_by_id:
+            if self.clip_browser.is_clip_realized(clip_id):
                 self.clip_browser.update_clip_shot_type(clip_id, shot_type)
             self._refresh_quick_run_availability()
 
@@ -559,21 +557,21 @@ class AnalyzeTab(BaseTab):
         """Update thumbnail for a clip."""
         if (
             clip_id in self._clip_ids
-            and clip_id in self.clip_browser._thumbnail_by_id
+            and self.clip_browser.is_clip_realized(clip_id)
         ):
             self.clip_browser.update_clip_thumbnail(clip_id, thumb_path)
 
     def update_clip_transcript(self, clip_id: str, segments: list):
         """Update transcript for a clip."""
         if clip_id in self._clip_ids:
-            if clip_id in self.clip_browser._thumbnail_by_id:
+            if self.clip_browser.is_clip_realized(clip_id):
                 self.clip_browser.update_clip_transcript(clip_id, segments)
             self._refresh_quick_run_availability()
 
     def update_clip_extracted_text(self, clip_id: str, texts: list):
         """Update extracted text for a clip."""
         if clip_id in self._clip_ids:
-            if clip_id in self.clip_browser._thumbnail_by_id:
+            if self.clip_browser.is_clip_realized(clip_id):
                 self.clip_browser.update_clip_extracted_text(clip_id, texts)
             self._refresh_quick_run_availability()
 
@@ -581,7 +579,7 @@ class AnalyzeTab(BaseTab):
         """Update custom query results for a clip."""
         if (
             clip_id in self._clip_ids
-            and clip_id in self.clip_browser._thumbnail_by_id
+            and self.clip_browser.is_clip_realized(clip_id)
         ):
             self.clip_browser.update_clip_custom_queries(clip_id, custom_queries)
 
@@ -593,7 +591,7 @@ class AnalyzeTab(BaseTab):
             cinematography: CinematographyAnalysis object
         """
         if clip_id in self._clip_ids:
-            if clip_id in self.clip_browser._thumbnail_by_id:
+            if self.clip_browser.is_clip_realized(clip_id):
                 self.clip_browser.update_clip_cinematography(clip_id, cinematography)
             self._refresh_quick_run_availability()
 

--- a/ui/video_player.py
+++ b/ui/video_player.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import ctypes.util
 import ctypes
+import importlib
 import locale
 import logging
 import os
@@ -57,12 +58,60 @@ def _find_bundled_mpv_library() -> Optional[Path]:
     return None
 
 
-def _prepare_frozen_mpv_import() -> Optional[Path]:
-    """Make bundled libmpv discoverable before importing python-mpv."""
-    library_path = _find_bundled_mpv_library()
-    if library_path is None:
-        return None
+def _find_system_mpv_library() -> Optional[Path]:
+    """Return a system libmpv path without broadening DYLD_LIBRARY_PATH."""
+    env_path = os.environ.get("SCENE_RIPPER_LIBMPV_DYLIB", "").strip()
+    candidates: list[Path] = []
+    if env_path:
+        candidates.append(Path(env_path))
 
+    if sys.platform == "darwin":
+        candidates.extend(
+            [
+                Path("/opt/homebrew/lib/libmpv.dylib"),
+                Path("/opt/homebrew/opt/mpv/lib/libmpv.dylib"),
+                Path("/usr/local/lib/libmpv.dylib"),
+                Path("/usr/local/opt/mpv/lib/libmpv.dylib"),
+            ]
+        )
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    found = ctypes.util.find_library("mpv")
+    if found:
+        return Path(found)
+
+    return None
+
+
+def _find_mpv_library() -> Optional[Path]:
+    """Return the best known libmpv path without loading the library."""
+    return _find_bundled_mpv_library() or _find_system_mpv_library()
+
+
+def _patch_find_library_for_mpv(library_path: Path) -> None:
+    """Point python-mpv's ctypes lookup at one exact libmpv path."""
+    original_find_library = getattr(
+        ctypes.util.find_library,
+        "_scene_ripper_original_find_library",
+        ctypes.util.find_library,
+    )
+    known_names = {"mpv", "libmpv", "mpv-2.dll", "libmpv-2.dll", "mpv-1.dll"}
+
+    def _patched_find_library(name: str):
+        if name in known_names:
+            return str(library_path)
+        return original_find_library(name)
+
+    _patched_find_library._scene_ripper_original_find_library = original_find_library  # type: ignore[attr-defined]
+    _patched_find_library._scene_ripper_mpv_path = str(library_path)  # type: ignore[attr-defined]
+    ctypes.util.find_library = _patched_find_library
+
+
+def _prepare_mpv_import(library_path: Path) -> None:
+    """Make libmpv discoverable before importing python-mpv."""
     library_dir = str(library_path.parent)
     current_path = os.environ.get("PATH", "")
     path_parts = current_path.split(os.pathsep) if current_path else []
@@ -79,24 +128,34 @@ def _prepare_frozen_mpv_import() -> Optional[Path]:
             logger = logging.getLogger(__name__)
             logger.debug("Failed to register bundled mpv DLL directory", exc_info=True)
 
-    original_find_library = ctypes.util.find_library
-    known_names = {"mpv", "libmpv", "mpv-2.dll", "libmpv-2.dll", "mpv-1.dll"}
+    _patch_find_library_for_mpv(library_path)
 
-    def _patched_find_library(name: str):
-        if name in known_names:
-            return str(library_path)
-        return original_find_library(name)
 
-    ctypes.util.find_library = _patched_find_library
+def _prepare_frozen_mpv_import() -> Optional[Path]:
+    """Make bundled libmpv discoverable before importing python-mpv."""
+    library_path = _find_bundled_mpv_library()
+    if library_path is None:
+        return None
+
+    _prepare_mpv_import(library_path)
     return library_path
 
 
-_prepare_frozen_mpv_import()
+def _import_mpv():
+    """Import python-mpv only when playback actually initializes."""
+    global mpv
+    if mpv is not None:
+        return mpv
 
-try:
-    import mpv
-except OSError:
-    mpv = None  # libmpv not available (e.g. Windows CI without DLL)
+    library_path = _find_mpv_library()
+    if library_path is not None:
+        _prepare_mpv_import(library_path)
+
+    mpv = importlib.import_module("mpv")
+    return mpv
+
+
+mpv = None  # Loaded lazily to avoid libmpv/PyAV FFmpeg dylib collisions at startup.
 
 from core.constants import PLAYBACK_SPEEDS, DEFAULT_SPEED_INDEX
 from ui.theme import theme, TypeScale, Spacing, UISizes
@@ -523,13 +582,15 @@ class VideoPlayer(QWidget):
         """Set up MPV player instance with OpenGL render API."""
         if self._player_ready:
             return
-        if mpv is None:
+        try:
+            mpv_module = _import_mpv()
+        except (ImportError, OSError) as e:
             raise RuntimeError(
                 "libmpv is not available. Install mpv/libmpv for your platform."
-            )
+            ) from e
 
         # Create mpv with vo=libmpv — rendering is handled by MpvGLWidget
-        self._mpv = mpv.MPV(
+        self._mpv = mpv_module.MPV(
             vo='libmpv',
             keep_open='yes',
             idle='yes',

--- a/ui/widgets/source_group_header.py
+++ b/ui/widgets/source_group_header.py
@@ -1,6 +1,6 @@
 """Collapsible source group header for ClipBrowser."""
 
-from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel
+from PySide6.QtWidgets import QFrame, QHBoxLayout, QLabel, QToolButton
 from PySide6.QtCore import Signal, Qt
 from PySide6.QtGui import QKeyEvent
 
@@ -15,9 +15,11 @@ class SourceGroupHeader(QFrame):
 
     Signals:
         toggled: Emitted with (source_id, is_expanded) when header is clicked
+        select_requested: Emitted with source_id when the select button is clicked
     """
 
     toggled = Signal(str, bool)  # (source_id, is_expanded)
+    select_requested = Signal(str)  # source_id
 
     def __init__(
         self,
@@ -85,6 +87,14 @@ class SourceGroupHeader(QFrame):
         self._update_count_label()
         layout.addWidget(self.count_label)
 
+        self.select_button = QToolButton()
+        self.select_button.setText("Select")
+        self.select_button.setToolTip("Select visible clips from this source")
+        self.select_button.setAccessibleName(f"Select clips from {self._filename}")
+        self.select_button.setCursor(Qt.PointingHandCursor)
+        self.select_button.clicked.connect(self._on_select_clicked)
+        layout.addWidget(self.select_button)
+
     def _update_chevron(self):
         """Update chevron icon based on expanded state."""
         icon = "▼" if self._is_expanded else "▶"
@@ -94,16 +104,15 @@ class SourceGroupHeader(QFrame):
         """Update the clip count label text."""
         if self._visible_clip_count == self._total_clip_count:
             # No filter active - show total
-            count_text = f"({self._total_clip_count} clips)"
+            count_text = f"{self._total_clip_count} clips"
         else:
             # Filter active - show "X of Y"
-            count_text = f"({self._visible_clip_count} of {self._total_clip_count})"
+            count_text = f"{self._visible_clip_count} of {self._total_clip_count}"
 
-        # Add selection indicator if collapsed and has selections
-        if not self._is_expanded and self._selected_count > 0:
-            count_text = f"({self._total_clip_count} clips \u2022 {self._selected_count} selected)"
+        if self._selected_count > 0:
+            count_text = f"{count_text} \u2022 {self._selected_count} selected"
 
-        self.count_label.setText(count_text)
+        self.count_label.setText(f"({count_text})")
 
     def _update_style(self):
         """Update visual style based on state."""
@@ -125,6 +134,19 @@ class SourceGroupHeader(QFrame):
         self.count_label.setStyleSheet(
             f"font-size: 11px; color: {theme().text_muted};"
         )
+        self.select_button.setStyleSheet(f"""
+            QToolButton {{
+                color: {theme().text_primary};
+                background-color: {theme().background_secondary};
+                border: 1px solid {theme().border_secondary};
+                border-radius: 3px;
+                padding: 2px 8px;
+            }}
+            QToolButton:hover {{
+                background-color: {theme().card_hover};
+                border-color: {theme().border_focus};
+            }}
+        """)
 
     @property
     def is_expanded(self) -> bool:
@@ -144,6 +166,10 @@ class SourceGroupHeader(QFrame):
         self._update_chevron()
         self._update_count_label()
         self.toggled.emit(self.source_id, self._is_expanded)
+
+    def _on_select_clicked(self):
+        """Request selection of clips from this source."""
+        self.select_requested.emit(self.source_id)
 
     def set_clip_counts(
         self,


### PR DESCRIPTION
Addresses the actionable findings from a multi-agent code review of the past session's work plus the perf/virtualization commits.

## P1 (architectural)

- **Double `update_clips()` after analysis pipeline complete** — routed through `project.update_clips()` so `clips_updated` is the single source of truth and the source-group preservation invariant from `0000c17` still holds.
- **`_preserve_clip_update_layout_ids` cross-object setattr smell** — replaced with a `ClipBrowser.disabled_clips_changed` signal. MainWindow declares the attribute and owns its lifecycle.

## P2 (correctness, perf, maintainability)

- `get_selected_clips()` semantics now consistent across virtual/non-virtual modes (visible-only filtering in both).
- `SaveProjectWorker` takes a `Project.snapshot_for_save()` snapshot at dispatch time. New tests cover snapshot independence, success/failure signals, and concurrent-save isolation.
- `_clear_realized_virtual_widgets` reuses `SourceGroupHeader` widgets across rebuilds.
- `ClipBrowser.add_clip()` in virtual mode coalesces rebuilds via the existing `_rebuild_pending` flag instead of triggering one full rebuild per thumbnail-ready signal.
- New `ClipBrowser.is_clip_realized()` public method; 8 sites in `analyze_tab.py` no longer reach into the private `_thumbnail_by_id` dict.
- Sort-key helpers extracted to module level so virtual and non-virtual paths share definitions.
- `clear_thumbnail_pixmap_cache()` flushes stale pixmaps on project close.
- `export_bundle`'s `include_clips` parameter now documented in the agent-tools reference.

## P3

- `_get_virtual_thumbnail` LRU eviction walks oldest-to-newest, evicts the first non-visible entry.
- `update_clips` in virtual mode refreshes `_virtual_display_rows` Clip references.
- `_rebuild_pending` declared in `__init__` for static-analysis visibility.
- `_log_deferred_browser_population` inlined; wrapping method removed.

## Defense-in-depth

- New `tests/test_lazy_init_attrs.py` walks `core.__all__` and `ui.__all__` via `__getattr__` and asserts via clean-interpreter subprocess that resolving each name does not pull `mpv` or `PyAV` into `sys.modules`.
- New regression test in `test_transcription_runtime_imports.py`: `import core.transcription` must not load `faster_whisper` or `PyAV`. (`faster_whisper` 1.x imports `av` eagerly — the import boundary in `core.transcription` is what keeps the dylib collision blocked.)
- Updated the libmpv/pyav dylib-collision solution doc with the `faster_whisper` finding.

## Test plan

- [x] `pytest tests/ --ignore=tests/test_windows_compat.py` — 2271 passed (3 pre-existing failures in `test_sorting_card_grid.py::TestCategoryFiltering` confirmed pre-existing on `e290bac`)
- [x] `pytest tests/test_lazy_init_attrs.py` — 6 new tests pass in isolation and in full-suite runs (subprocess-based mpv/PyAV assertions immune to test-ordering pollution)
- [x] `pytest tests/test_save_project_worker.py` — 4 new tests pass
- [ ] Manual: open a 1500-clip project, run analysis, confirm Cut tab source groups remain visible
- [ ] Manual: toggle clips disabled across both Cut and Analyze tabs, confirm preserve-layout still applies
- [ ] Manual: save a project mid-analysis to confirm the snapshot save is consistent

## Findings deliberately deferred

- **Mixed row-height drift in virtual render range** — flagged P3; needed deeper refactor of `_current_virtual_render_range` to track per-row-type heights. The upcoming model/view rewrite (`docs/plans/2026-05-04-clip-browser-model-view-virtualization-plan.md`) will obsolete the current row-height arithmetic, so deferred to that work.
- **Prove-It pattern process note** — feedback for future commits; no code action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)