### PR TITLE
feat: Word Sequencer with forced-alignment-augmented transcription

### DIFF
--- a/core/analysis/alignment.py
+++ b/core/analysis/alignment.py
@@ -84,6 +84,69 @@ class AlignmentFFmpegError(AlignmentError):
 
 
 # ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def distribute_words_to_segments(
+    segments: "list[TranscriptSegment]",
+    words: "list[WordTimestamp]",
+) -> None:
+    """Assign a flat ``list[WordTimestamp]`` back onto transcript segments.
+
+    The forced-alignment worker emits one flat word list per clip (alignment
+    runs over the concatenated text). Callers need those words distributed
+    back onto the parent ``TranscriptSegment[]`` so the existing per-segment
+    word-data shape is preserved.
+
+    For each word: assign to the first segment whose
+    ``[start_time, end_time]`` contains the word's midpoint; if no segment
+    contains it, fall back to the segment whose nearest boundary is closest
+    to the midpoint. After distribution, *every* segment in ``segments``
+    has its ``.words`` attribute assigned (to a — possibly empty — list).
+    That empty-list-vs-None distinction is load-bearing: it lets the skip
+    predicate treat a re-aligned clip as fully aligned even when individual
+    segments end up wordless.
+
+    Args:
+        segments: The clip's transcript segments. Mutated in place — each
+            segment's ``.words`` is reassigned. Empty input → no-op.
+        words: Flat word list from alignment. Empty list is fine (every
+            segment ends up with ``.words = []``).
+    """
+    if not segments:
+        return
+
+    per_segment: list[list] = [[] for _ in segments]
+    n = len(segments)
+
+    # Both inputs are time-sorted in practice; the per-word linear scan is
+    # cheap enough that we keep the simple shape here (correctness over a
+    # micro-optimization).
+    for word in words:
+        midpoint = (float(word.start) + float(word.end)) / 2.0
+        chosen_idx: Optional[int] = None
+        for i, seg in enumerate(segments):
+            if seg.start_time <= midpoint <= seg.end_time:
+                chosen_idx = i
+                break
+        if chosen_idx is None:
+            chosen_idx = min(
+                range(n),
+                key=lambda i: min(
+                    abs(midpoint - segments[i].start_time),
+                    abs(midpoint - segments[i].end_time),
+                ),
+            )
+        per_segment[chosen_idx].append(word)
+
+    for seg, seg_words in zip(segments, per_segment):
+        # Always assign — even an empty list means "alignment ran for this
+        # segment", which is what the skip predicate checks.
+        seg.words = seg_words
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -178,7 +241,7 @@ def align_words(
     if not full_text:
         return []
 
-    wav_path = _extract_audio_to_wav(audio_path_obj)
+    wav_path = extract_audio_to_wav(audio_path_obj)
     try:
         raw_word_timings = _run_alignment_engine(
             wav_path=wav_path,
@@ -290,12 +353,30 @@ def _require_ffmpeg() -> str:
     return ffmpeg_path
 
 
-def _extract_audio_to_wav(source_path: Path) -> Path:
+def extract_audio_to_wav(
+    source_path: Path,
+    start_time: Optional[float] = None,
+    end_time: Optional[float] = None,
+) -> Path:
     """Extract source audio to a temporary 16 kHz mono PCM WAV.
 
     Mirrors the pattern in ``core.transcription.transcribe_clip``. The temp
     file is created here; the caller is responsible for cleanup via the
     ``try/finally`` around the alignment call.
+
+    Args:
+        source_path: Path to the source media (video or audio file).
+        start_time: Optional start time (seconds) for a sub-range extraction.
+            When provided alongside ``end_time``, ``-ss`` / ``-to`` are
+            passed to FFmpeg so only the named range is decoded. ``None``
+            extracts the whole file.
+        end_time: Optional end time (seconds) — see ``start_time``.
+
+    Returns:
+        Path to a newly-created temporary WAV file. The caller owns cleanup.
+
+    Raises:
+        AlignmentFFmpegError: FFmpeg is missing, failed, or produced no audio.
     """
     ffmpeg = _require_ffmpeg()
 
@@ -304,8 +385,12 @@ def _extract_audio_to_wav(source_path: Path) -> Path:
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
         tmp_path = Path(tmp.name)
 
-    cmd = [
-        ffmpeg, "-y",
+    cmd: list[str] = [ffmpeg, "-y"]
+    if start_time is not None:
+        cmd += ["-ss", str(float(start_time))]
+    if end_time is not None:
+        cmd += ["-to", str(float(end_time))]
+    cmd += [
         "-i", str(source_path),
         "-vn",
         "-acodec", "pcm_s16le",
@@ -442,5 +527,7 @@ __all__ = [
     "LanguageUnknownError",
     "UnsupportedLanguageError",
     "align_words",
+    "distribute_words_to_segments",
     "ensure_word_alignment_runtime_available",
+    "extract_audio_to_wav",
 ]

--- a/core/analysis/alignment.py
+++ b/core/analysis/alignment.py
@@ -1,0 +1,446 @@
+"""Word-level forced alignment via ``ctc-forced-aligner``.
+
+Given a clip's audio and the transcript segments produced for that clip, this
+module returns word-level timestamps (``WordTimestamp[]``) in the *same* frame
+of reference as the input segments (clip-relative seconds). Useful as a
+post-step on transcripts produced by either ``faster-whisper`` (already has
+word data — alignment refines accuracy) or ``lightning-whisper-mlx`` (no word
+data at all — alignment is the only path to words).
+
+Design notes:
+
+- **Pure module**: no Qt imports, no project model imports. Inputs are an audio
+  path plus pure-data ``TranscriptSegment`` objects; output is pure-data
+  ``WordTimestamp`` objects.
+- **Lazy heavy imports**: ``ctc_forced_aligner`` and ``torch`` are imported
+  inside function bodies so the module loads on a clean Python environment
+  (e.g. for unit tests that mock the engine). The model and its checkpoint(s)
+  install on demand through ``core.feature_registry.install_for_feature(
+  "word_alignment", ...)``.
+- **Per-clip audio strategy**: this module mirrors ``core/transcription.py``'s
+  ``transcribe_clip`` pattern — a small FFmpeg pass extracts the clip's audio
+  to a temporary WAV (16 kHz mono pcm_s16le) before alignment. Returned
+  timestamps are clip-relative seconds; no source-vs-clip offset translation
+  is needed downstream.
+- **Apple Silicon constraint**: forced CPU + fp32. MPS-backed ``wav2vec2``
+  alignment is unreliable in 2026; promising MPS would silently degrade
+  accuracy. Users on Apple Silicon pay the CPU latency cost; the worker layer
+  is responsible for surfacing this to the UI.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from core.binary_resolver import find_binary, get_subprocess_env, get_subprocess_kwargs
+
+if TYPE_CHECKING:
+    # Type-only import; the runtime import lives inside ``align_words``.
+    from core.transcription import TranscriptSegment, WordTimestamp
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class AlignmentError(Exception):
+    """Base exception for forced-alignment failures."""
+
+
+class LanguageUnknownError(AlignmentError):
+    """Raised when the transcript carries no language signal.
+
+    Only legacy transcripts produced before U1 should hit this. Re-running
+    transcription on the source repopulates ``TranscriptSegment.language``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Cannot align: transcript carries no language information. "
+            "Re-run transcription to populate the language field before aligning."
+        )
+
+
+class UnsupportedLanguageError(AlignmentError):
+    """Raised when the alignment model does not support the transcript's language."""
+
+    def __init__(self, language: str) -> None:
+        self.language = language
+        super().__init__(
+            f"Forced alignment does not support language '{language}'. "
+            "This source is unavailable for word-level sequencing."
+        )
+
+
+class AlignmentFFmpegError(AlignmentError):
+    """Raised when FFmpeg fails to extract the clip audio for alignment."""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+# Languages supported by the MMS-based ``ctc-forced-aligner`` model.
+#
+# Mirrors the ISO 639-1 / ISO 639-3 set covered by Meta's MMS-1B-ALL alignment
+# model (the default backend the library ships with). The runtime canonical
+# list lives inside ``ctc_forced_aligner`` (queried via
+# ``ctc_forced_aligner.alignment_utils.SUPPORTED_LANGUAGES`` when the package is
+# importable), but we keep a small, conservative subset here so the language
+# pre-check can run without importing the heavy module.
+#
+# This static set is treated as authoritative for the unit-test path; if the
+# real runtime can prove a language is also supported, ``_check_language_supported``
+# delegates to the runtime when available.
+_FALLBACK_SUPPORTED_ISO_639_1: frozenset[str] = frozenset(
+    {
+        # A small, high-confidence subset — used only when the runtime
+        # SUPPORTED_LANGUAGES lookup is unavailable.
+        "en", "fr", "de", "es", "it", "pt", "nl", "pl", "ru", "uk", "cs",
+        "sv", "no", "da", "fi", "tr", "el", "ro", "hu", "bg", "hr", "sk",
+        "sl", "lt", "lv", "et", "ar", "fa", "he", "hi", "bn", "ta", "te",
+        "ml", "kn", "mr", "gu", "pa", "ur", "ja", "ko", "zh", "vi", "th",
+        "id", "ms", "tl", "sw", "yo", "ig", "ha", "am",
+    }
+)
+
+
+def align_words(
+    audio_path: str,
+    transcript_segments: "list[TranscriptSegment]",
+) -> "list[WordTimestamp]":
+    """Produce word-level timestamps for a clip's audio.
+
+    Args:
+        audio_path: Path to the clip's source media (video or audio file). The
+            function extracts a 16 kHz mono WAV from this path via FFmpeg
+            before running the alignment model. ``WordTimestamp.start`` /
+            ``.end`` returned here are clip-relative seconds — the same frame
+            of reference as ``TranscriptSegment.start_time``.
+        transcript_segments: The transcript for the clip. Language is read off
+            ``transcript_segments[0].language``; passing legacy segments with
+            ``language is None`` raises ``LanguageUnknownError``.
+
+    Returns:
+        A list of ``WordTimestamp`` objects in chronological order. The list is
+        flat across the input segments — segment boundaries are not preserved
+        in the output (alignment operates on the concatenated text). Empty
+        input segments → empty result; the alignment model is not loaded and
+        no FFmpeg extraction is attempted.
+
+    Raises:
+        LanguageUnknownError: ``transcript_segments[0].language is None``.
+        UnsupportedLanguageError: language is not supported by the model.
+        AlignmentFFmpegError: FFmpeg failed to extract audio.
+        FileNotFoundError: audio path does not exist.
+        AlignmentError: any other alignment failure.
+    """
+    # Fast paths first: avoid loading the heavy model when there's nothing to do.
+    if not transcript_segments:
+        return []
+
+    # Use the local import so test code can monkeypatch the model entry points
+    # without dragging the heavy deps into ``sys.modules`` at module load.
+    from core.transcription import WordTimestamp  # local-import: avoid cycles at module load
+
+    language = transcript_segments[0].language
+    if language is None:
+        raise LanguageUnknownError()
+
+    # Validate the language up-front so users don't pay the FFmpeg + model-load
+    # cost before discovering the source can't be aligned.
+    _check_language_supported(language)
+
+    # Strip empty segments — alignment requires text. If every segment is
+    # empty, return [] (consistent with the empty-input fast path).
+    non_empty_segments = [
+        seg for seg in transcript_segments if (seg.text or "").strip()
+    ]
+    if not non_empty_segments:
+        return []
+
+    audio_path_obj = Path(audio_path)
+    if not audio_path_obj.exists():
+        raise FileNotFoundError(f"Audio path does not exist: {audio_path}")
+
+    # Build the concatenated transcript for the clip. The library expects a
+    # single text string per audio; segment boundaries are reconstructed via
+    # the returned word timings.
+    full_text = " ".join((seg.text or "").strip() for seg in non_empty_segments).strip()
+    if not full_text:
+        return []
+
+    wav_path = _extract_audio_to_wav(audio_path_obj)
+    try:
+        raw_word_timings = _run_alignment_engine(
+            wav_path=wav_path,
+            text=full_text,
+            language=language,
+        )
+    finally:
+        # Always clean up the temp WAV, even if alignment raises.
+        try:
+            wav_path.unlink(missing_ok=True)
+        except OSError as cleanup_exc:
+            logger.warning("Failed to remove temp alignment WAV %s: %s", wav_path, cleanup_exc)
+
+    return [
+        WordTimestamp(
+            start=float(entry["start"]),
+            end=float(entry["end"]),
+            text=str(entry["text"]),
+            probability=(
+                float(entry["score"]) if entry.get("score") is not None else None
+            ),
+        )
+        for entry in raw_word_timings
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Runtime gating (called from feature_registry._validate_feature_runtime)
+# ---------------------------------------------------------------------------
+
+
+def ensure_word_alignment_runtime_available():
+    """Validate that the forced-alignment runtime imports cleanly.
+
+    Called from ``core.feature_registry._validate_feature_runtime`` for the
+    ``word_alignment`` feature. Mirrors the shape of
+    ``ensure_audio_analysis_runtime_available`` and
+    ``ensure_faster_whisper_runtime_available``.
+    """
+    try:
+        import ctc_forced_aligner  # noqa: F401
+        import torch  # noqa: F401
+
+        return ctc_forced_aligner
+    except Exception as e:  # pragma: no cover - exercised via mock
+        raise RuntimeError(f"word alignment runtime is incomplete: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _check_language_supported(language: str) -> None:
+    """Raise ``UnsupportedLanguageError`` when the language can't be aligned.
+
+    Tries the runtime's authoritative ``SUPPORTED_LANGUAGES`` map first; falls
+    back to a conservative static list when the runtime isn't installed. This
+    lets the test path validate language gating without requiring the heavy
+    dependency.
+    """
+    code = (language or "").lower().strip()
+    if not code:
+        raise UnsupportedLanguageError(language)
+
+    try:
+        # Local import: heavy dep is optional at module load time.
+        from ctc_forced_aligner.alignment_utils import (
+            SUPPORTED_LANGUAGES,  # type: ignore[attr-defined]
+        )
+    except Exception:
+        # ctc-forced-aligner isn't installed (or its API changed). Use the
+        # static fallback so language gating still works in the test / pre-install
+        # path. The runtime will raise its own clear error later if the language
+        # is rejected by the real model.
+        if code not in _FALLBACK_SUPPORTED_ISO_639_1:
+            raise UnsupportedLanguageError(language)
+        return
+
+    # Runtime present: SUPPORTED_LANGUAGES is typically a dict whose keys cover
+    # both ISO 639-1 and ISO 639-3 codes. Accept either; library raises KeyError
+    # internally on unsupported codes, but we want to fail with our own
+    # exception type so callers can branch cleanly.
+    try:
+        if code in SUPPORTED_LANGUAGES:
+            return
+        # Some versions key by ISO 639-3 only; check the values too.
+        try:
+            if any(code == str(v).lower() for v in SUPPORTED_LANGUAGES.values()):
+                return
+        except Exception:
+            pass
+    except TypeError:
+        # SUPPORTED_LANGUAGES is not a mapping/iterable as expected. Fall
+        # through to the unsupported branch.
+        pass
+
+    raise UnsupportedLanguageError(language)
+
+
+def _require_ffmpeg() -> str:
+    """Return the resolved FFmpeg path or raise ``AlignmentFFmpegError``."""
+    ffmpeg_path = find_binary("ffmpeg")
+    if ffmpeg_path is None:
+        raise AlignmentFFmpegError(
+            "FFmpeg is required for forced alignment but was not found. "
+            "Install FFmpeg from Settings > Dependencies and try again."
+        )
+    return ffmpeg_path
+
+
+def _extract_audio_to_wav(source_path: Path) -> Path:
+    """Extract source audio to a temporary 16 kHz mono PCM WAV.
+
+    Mirrors the pattern in ``core.transcription.transcribe_clip``. The temp
+    file is created here; the caller is responsible for cleanup via the
+    ``try/finally`` around the alignment call.
+    """
+    ffmpeg = _require_ffmpeg()
+
+    # NamedTemporaryFile with ``delete=False`` because we need the path
+    # after the file handle closes. Cleanup happens in the caller's finally.
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    cmd = [
+        ffmpeg, "-y",
+        "-i", str(source_path),
+        "-vn",
+        "-acodec", "pcm_s16le",
+        "-ar", "16000",
+        "-ac", "1",
+        str(tmp_path),
+    ]
+
+    try:
+        subprocess.run(
+            cmd,
+            capture_output=True,
+            check=True,
+            env=get_subprocess_env(),
+            **get_subprocess_kwargs(),
+        )
+    except subprocess.CalledProcessError as exc:
+        # Clean up the empty/partial temp file before re-raising — we own it.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        stderr = exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""
+        raise AlignmentFFmpegError(
+            f"FFmpeg failed to extract audio from {source_path}: {stderr.strip() or exc}"
+        ) from exc
+    except FileNotFoundError as exc:
+        # FFmpeg vanished between resolution and exec — rare but possible.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise AlignmentFFmpegError(f"FFmpeg binary not found: {exc}") from exc
+
+    if tmp_path.stat().st_size == 0:
+        # Defensive: FFmpeg can succeed but produce no audio (e.g. video-only
+        # input). Treat the same as a failed extract.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise AlignmentFFmpegError(
+            f"FFmpeg produced an empty audio file for {source_path} "
+            "(source may have no audio stream)."
+        )
+
+    return tmp_path
+
+
+def _run_alignment_engine(
+    wav_path: Path,
+    text: str,
+    language: str,
+) -> list[dict]:
+    """Run ``ctc-forced-aligner`` against the extracted audio + text.
+
+    All heavy imports happen here so the module-level import of
+    ``core.analysis.alignment`` does not pay the ``torch`` / ``ctc_forced_aligner``
+    startup cost — and so unit tests can monkeypatch this function to bypass
+    the real engine entirely.
+
+    Returns:
+        A list of ``{"start": float, "end": float, "text": str, "score": float | None}``
+        dicts in chronological order. ``start`` / ``end`` are clip-relative
+        seconds. ``score`` is the per-word alignment score when the library
+        provides one; otherwise ``None``.
+    """
+    # Local imports so module-level load is cheap.
+    try:
+        import torch  # type: ignore[import-not-found]
+    except Exception as exc:
+        raise AlignmentError(
+            "PyTorch is required for forced alignment but is not installed. "
+            "Install the 'word_alignment' feature first."
+        ) from exc
+
+    try:
+        from ctc_forced_aligner import (  # type: ignore[import-not-found]
+            generate_emissions,
+            get_alignments,
+            get_spans,
+            load_alignment_model,
+            load_audio,
+            postprocess_results,
+            preprocess_text,
+        )
+    except Exception as exc:
+        raise AlignmentError(
+            "ctc-forced-aligner is not installed. "
+            "Install the 'word_alignment' feature first."
+        ) from exc
+
+    # CPU + fp32 — see module docstring. MPS wav2vec2 forced alignment is
+    # unreliable in 2026; do not promise it.
+    device = "cpu"
+    dtype = torch.float32
+
+    model, alignment_tokenizer = load_alignment_model(device=device, dtype=dtype)
+
+    audio_waveform = load_audio(str(wav_path), dtype=dtype, device=device)
+
+    emissions, stride = generate_emissions(model, audio_waveform)
+
+    # ``preprocess_text`` signature varies slightly across versions of the
+    # library; pass the parameters the public docs call out and rely on the
+    # library's defaults for the rest.
+    tokens_starred, text_starred = preprocess_text(
+        text,
+        romanize=True,
+        language=language,
+    )
+
+    segments, scores, blank_id = get_alignments(
+        emissions,
+        tokens_starred,
+        alignment_tokenizer,
+    )
+
+    spans = get_spans(tokens_starred, segments, blank_id)
+
+    word_timestamps = postprocess_results(
+        text_starred,
+        spans,
+        stride,
+        scores,
+    )
+
+    return word_timestamps
+
+
+__all__ = [
+    "AlignmentError",
+    "AlignmentFFmpegError",
+    "LanguageUnknownError",
+    "UnsupportedLanguageError",
+    "align_words",
+    "ensure_word_alignment_runtime_available",
+]

--- a/core/cost_estimates.py
+++ b/core/cost_estimates.py
@@ -92,13 +92,13 @@ METADATA_CHECKS: dict[str, callable] = {
     "cinematography": lambda clip: bool(clip.cinematography),
     "face_embeddings": lambda clip: bool(clip.face_embeddings),
     "gaze": lambda clip: clip.gaze_category is not None,
-    # Word-level alignment is satisfied when at least one segment has a
-    # ``words`` list. ``None`` segments mean alignment hasn't run yet;
-    # ``[]`` means alignment ran but produced no words and is still
-    # "complete" — but for cost-estimate purposes any populated list is
-    # the signal we care about.
+    # Word-level alignment is satisfied when at least one segment has had
+    # alignment run against it. ``None`` means alignment hasn't run yet;
+    # ``[]`` means alignment ran and produced no words (silence /
+    # instrumental) — both states are "complete" for the cost gate, so we
+    # check ``is not None`` rather than truthiness.
     "transcription_with_words": lambda clip: bool(
-        clip.transcript and any(seg.words for seg in clip.transcript)
+        clip.transcript and any(seg.words is not None for seg in clip.transcript)
     ),
 }
 

--- a/core/cost_estimates.py
+++ b/core/cost_estimates.py
@@ -37,6 +37,10 @@ TIME_PER_CLIP: dict[str, dict[str, float]] = {
     "cinematography": {"local": 3.0, "cloud": 1.0},  # local: mlx-vlm 7B; cloud: Gemini
     "face_embeddings": {"local": 2.0},  # ~2s per clip (30 frames x ~50ms each + overhead)
     "gaze": {"local": 1.5},
+    # Word-level alignment: CPU-only on Apple Silicon, ctc-forced-aligner pass
+    # over a clip's audio. Conservative — covers transcript-already-present
+    # case (faster-whisper retro-align) and pure-MLX case.
+    "transcription_with_words": {"local": 30.0},
 }
 
 # Per-clip dollar costs (cloud tiers only)
@@ -71,6 +75,7 @@ OPERATION_LABELS: dict[str, str] = {
     "cinematography": "Rich Analysis",
     "face_embeddings": "Detect Faces",
     "gaze": "Detect Gaze",
+    "transcription_with_words": "Word-level alignment",
 }
 
 # Map operation key to a function that checks if a clip has that metadata
@@ -87,6 +92,14 @@ METADATA_CHECKS: dict[str, callable] = {
     "cinematography": lambda clip: bool(clip.cinematography),
     "face_embeddings": lambda clip: bool(clip.face_embeddings),
     "gaze": lambda clip: clip.gaze_category is not None,
+    # Word-level alignment is satisfied when at least one segment has a
+    # ``words`` list. ``None`` segments mean alignment hasn't run yet;
+    # ``[]`` means alignment ran but produced no words and is still
+    # "complete" — but for cost-estimate purposes any populated list is
+    # the signal we care about.
+    "transcription_with_words": lambda clip: bool(
+        clip.transcript and any(seg.words for seg in clip.transcript)
+    ),
 }
 
 # Default parallelism by operation (used when no settings provided)

--- a/core/feature_registry.py
+++ b/core/feature_registry.py
@@ -49,6 +49,7 @@ _FULL_PACKAGE_REPAIR_FEATURES = {
     "shot_classify",
     "transcribe",
     "transcribe_mlx",
+    "word_alignment",
 }
 
 
@@ -111,6 +112,10 @@ def _validate_feature_runtime(name: str) -> None:
         from core.transcription import ensure_mlx_whisper_runtime_available
 
         ensure_mlx_whisper_runtime_available()
+    elif name == "word_alignment":
+        from core.analysis.alignment import ensure_word_alignment_runtime_available
+
+        ensure_word_alignment_runtime_available()
     elif name == "gaze_detect":
         from core.analysis.gaze import ensure_gaze_runtime_available
 
@@ -294,6 +299,13 @@ FEATURE_DEPS: dict[str, FeatureDeps] = {
         size_estimate_mb=450,
         repair_packages=["torch", "transformers", "tokenizers"],
         native_install=True,
+    ),
+    "word_alignment": FeatureDeps(
+        binaries=["ffmpeg"],
+        packages=["torch", "ctc_forced_aligner"],
+        size_estimate_mb=750,
+        repair_packages=["torch", "ctc_forced_aligner", "transformers", "tokenizers"],
+        native_install=True,  # torch has native extensions; must land in proper site-packages
     ),
 }
 

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -198,6 +198,41 @@ class ProviderConfig:
         return None
 
 
+class LLMEmptyResponseError(Exception):
+    """Raised when an LLM returns ``None`` or an empty response body.
+
+    Carries both the prompt that was sent and a human-readable hint so the
+    caller can surface a useful error to the user.
+
+    Per a recurring LLM gotcha, providers occasionally return ``None``
+    content without raising an exception — always validate before using
+    the response.
+    """
+
+    def __init__(self, prompt: str, hint: str) -> None:
+        self.prompt = prompt
+        self.hint = hint
+        super().__init__(f"{hint} (prompt: {prompt!r})")
+
+
+class OllamaUnreachableError(Exception):
+    """Raised when an Ollama HTTP call fails to connect or times out.
+
+    Includes a hint pointing the user at ``check_ollama_health()`` and
+    ``ollama serve``.
+    """
+
+    def __init__(self, message: str, original: Optional[Exception] = None) -> None:
+        self.original = original
+        full = (
+            f"{message} — start Ollama with 'ollama serve' or check "
+            f"check_ollama_health()."
+        )
+        if original is not None:
+            full += f" Original error: {original}"
+        super().__init__(full)
+
+
 async def check_ollama_health(api_base: str = "http://localhost:11434") -> tuple[bool, str]:
     """Check if Ollama is running and accessible.
 
@@ -592,6 +627,229 @@ def complete_with_local_fallback(
                 missing_api_key=missing_api_key,
             )
         ) from local_exc
+
+
+def complete_with_enum_constraint(
+    prompt: str,
+    vocabulary: list[str],
+    target_length: int,
+    *,
+    system_prompt: Optional[str] = None,
+    model: Optional[str] = None,
+    api_base: Optional[str] = None,
+    temperature: float = 0.7,
+    timeout: float = 120.0,
+    frequencies: Optional[dict[str, int]] = None,
+    think: bool = False,
+) -> list[str]:
+    """Run a vocabulary-constrained Ollama completion via JSON-schema enum.
+
+    Ollama supports decode-time vocabulary constraints via its ``format``
+    parameter when ``format`` carries a JSON Schema whose values include an
+    ``enum``. Note: Ollama has explicitly closed all GBNF PRs (issue
+    #6237, PR #1606); ``format``+enum is currently the only constrained-
+    decoding API exposed by Ollama. Mask construction is non-parallelized
+    in current Ollama builds — latency at large vocabulary sizes can be
+    high. The plan documents this as a deferred concern.
+
+    Implementation note — LiteLLM passthrough investigation:
+        LiteLLM 1.82.6's Ollama provider DOES forward ``response_format``
+        when supplied as ``{"type": "json_schema", "json_schema":
+        {"schema": <dict>}}`` (see ``litellm/llms/ollama/chat/transformation.py``
+        ``map_openai_params`` — it pops the schema out of ``response_format``
+        and writes it into Ollama's ``format`` field). So we COULD reach
+        Ollama through LiteLLM. We deliberately take a direct HTTP path
+        via ``httpx`` here instead: (a) it avoids LiteLLM's translation
+        layer for the most security-/correctness-sensitive call in this
+        module (the only one where a stripped/translated parameter would
+        silently corrupt output by removing the constraint), (b) it gives
+        us full control over the request timeout for this latency-prone
+        endpoint, and (c) it makes the failure modes (connection refused,
+        timeout, non-200) directly observable for ``OllamaUnreachableError``.
+
+    Args:
+        prompt: User-supplied generation prompt. Combined with ``system_prompt``
+            (or the default frequency-annotated vocabulary system prompt).
+        vocabulary: List of allowed words. Duplicates are deduplicated and
+            sorted before being passed to Ollama; the final order is also
+            used for deterministic schema generation.
+        target_length: Target ``words[]`` length used in the system prompt
+            so the model knows roughly how long an output to produce.
+            Ollama's enum constraint enforces vocabulary, not length.
+        system_prompt: Optional system message. If ``None``, a default
+            system prompt is constructed from ``vocabulary`` + (optional)
+            ``frequencies``.
+        model: Ollama model name (e.g. ``"qwen3:8b"``). Defaults to the
+            project's default local model from settings if available.
+        api_base: Ollama API base URL. Defaults to ``llm_api_base`` from
+            settings or ``http://localhost:11434``.
+        temperature: Sampling temperature for the underlying Ollama call.
+        timeout: Total HTTP timeout in seconds. Defaults to 120s because
+            enum-constrained decoding is slow at corpus scale.
+        frequencies: Optional ``{word: count}`` map used in the default
+            system prompt's frequency annotation.
+
+    Returns:
+        The parsed ``words`` array from Ollama's JSON response — a list of
+        strings drawn from ``vocabulary``.
+
+    Raises:
+        LLMEmptyResponseError: response body is ``None``/empty, JSON parse
+            fails, or the ``words`` field is missing/non-list/empty.
+        OllamaUnreachableError: HTTP connection refused, timed out, or
+            returned a non-2xx status.
+        ValueError: ``vocabulary`` is empty or ``target_length`` < 1.
+    """
+    import json
+
+    import httpx
+
+    if not vocabulary:
+        raise ValueError("complete_with_enum_constraint: vocabulary must be non-empty")
+    if target_length < 1:
+        raise ValueError(
+            f"complete_with_enum_constraint: target_length must be >= 1, got {target_length}"
+        )
+
+    # Deduplicate + sort for deterministic schema construction.
+    sorted_vocab = sorted(set(vocabulary))
+
+    if model is None or api_base is None:
+        try:
+            from core.settings import load_settings
+            _settings = load_settings()
+            if model is None:
+                model = getattr(_settings, "ollama_model", None) or "qwen3:8b"
+            if api_base is None:
+                api_base = _ollama_api_base(_settings)
+        except Exception:  # noqa: BLE001 — fall back to hard defaults
+            if model is None:
+                model = "qwen3:8b"
+            if api_base is None:
+                api_base = "http://localhost:11434"
+
+    model = _ollama_model_name(model)
+
+    if system_prompt is None:
+        if frequencies:
+            annotated = ", ".join(
+                f"{word} ({frequencies.get(word, 0)})" for word in sorted_vocab
+            )
+            vocab_section = f"Available vocabulary (frequency in parens): {annotated}."
+        else:
+            vocab_section = "Available vocabulary: " + ", ".join(sorted_vocab) + "."
+        system_prompt = (
+            "You compose short word sequences using ONLY the supplied "
+            "vocabulary. Aim for about "
+            f"{target_length} words. Respond with a single JSON object of the form "
+            "{\"words\": [...]} whose entries are drawn from the vocabulary. "
+            f"{vocab_section}"
+        )
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "words": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": sorted_vocab,
+                },
+            }
+        },
+        "required": ["words"],
+    }
+
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+        "stream": False,
+        "format": schema,
+        # Disable Ollama's "thinking" mode for thinking-capable models
+        # (qwen3 etc.). Thinking-mode tokens are extra eval cost that
+        # produces no observable output here — the JSON-schema-enum
+        # constraint is the only steering we need, and the model's
+        # chain-of-thought dramatically inflates latency at corpus scale.
+        # ``think`` is ignored by non-thinking models.
+        "think": bool(think),
+        "options": {"temperature": float(temperature)},
+    }
+
+    url = api_base.rstrip("/") + "/api/chat"
+
+    try:
+        # ``with`` block guarantees connection cleanup even on cancel /
+        # timeout / unhandled exception (subprocess-cleanup-on-exception
+        # learning, adapted to httpx).
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(url, json=payload)
+    except httpx.TimeoutException as exc:
+        raise OllamaUnreachableError(
+            f"Ollama call to {url} timed out after {timeout}s — "
+            "constrained decoding can be slow at corpus scale",
+            original=exc,
+        ) from exc
+    except httpx.ConnectError as exc:
+        raise OllamaUnreachableError(
+            f"Cannot connect to Ollama at {api_base}",
+            original=exc,
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise OllamaUnreachableError(
+            f"Ollama HTTP error talking to {url}",
+            original=exc,
+        ) from exc
+
+    if response.status_code != 200:
+        raise OllamaUnreachableError(
+            f"Ollama returned status {response.status_code} from {url}: "
+            f"{response.text[:200]}",
+        )
+
+    # Validate response shape per the LLM-empty-response gotcha.
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise LLMEmptyResponseError(
+            prompt=prompt,
+            hint=f"Ollama response was not valid JSON: {exc}",
+        ) from exc
+
+    content = (body or {}).get("message", {}).get("content")
+    if not content:
+        raise LLMEmptyResponseError(
+            prompt=prompt,
+            hint="Ollama returned no content; the model may have produced an "
+                 "empty response — retry the prompt or check model availability",
+        )
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise LLMEmptyResponseError(
+            prompt=prompt,
+            hint=f"Ollama JSON content failed to parse: {exc}",
+        ) from exc
+
+    if not isinstance(parsed, dict) or "words" not in parsed:
+        raise LLMEmptyResponseError(
+            prompt=prompt,
+            hint="Ollama response was missing the 'words' key",
+        )
+
+    words = parsed.get("words")
+    if not isinstance(words, list) or not words:
+        raise LLMEmptyResponseError(
+            prompt=prompt,
+            hint="Ollama returned an empty or non-list 'words' field",
+        )
+
+    # All entries should be strings; the enum constraint should have
+    # prevented anything else.
+    return [str(w) for w in words]
 
 
 def create_provider_config_from_settings() -> ProviderConfig:

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -263,6 +263,37 @@ async def check_ollama_health(api_base: str = "http://localhost:11434") -> tuple
         return False, f"Cannot connect to Ollama: {e}"
 
 
+def check_ollama_health_sync(api_base: str = "http://localhost:11434") -> tuple[bool, str]:
+    """Synchronous wrapper around :func:`check_ollama_health`.
+
+    Useful for sync entry points (Qt dialogs, CLI commands) that don't run
+    inside an event loop.
+
+    Behavior:
+        - When ``asyncio.run`` can be used (no running loop), the async
+          probe is awaited and its result returned verbatim.
+        - When a loop is already running (``asyncio.run`` raises
+          ``RuntimeError``), this returns ``(True, "")`` — the assumption is
+          that the caller is in an async test harness and a downstream
+          client call will surface a real error if Ollama is unreachable.
+          This branch is the *only* swallowed exception; every other
+          exception type propagates.
+
+    Args:
+        api_base: Ollama API base URL.
+
+    Returns:
+        ``(is_healthy, error_message)`` — same shape as the async helper.
+    """
+    import asyncio
+
+    try:
+        return asyncio.run(check_ollama_health(api_base))
+    except RuntimeError:
+        # Already inside an event loop — skip the probe.
+        return True, ""
+
+
 class LLMClient:
     """Unified LLM client supporting multiple providers via LiteLLM."""
 

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -289,9 +289,13 @@ def check_ollama_health_sync(api_base: str = "http://localhost:11434") -> tuple[
 
     try:
         return asyncio.run(check_ollama_health(api_base))
-    except RuntimeError:
-        # Already inside an event loop — skip the probe.
-        return True, ""
+    except RuntimeError as exc:
+        # Only swallow the "loop already running" case — any other RuntimeError
+        # (corrupted loop, error inside the coroutine) must propagate, otherwise
+        # the dialog gate silently believes Ollama is healthy.
+        if "loop" in str(exc).lower() and "running" in str(exc).lower():
+            return True, ""
+        raise
 
 
 class LLMClient:

--- a/core/package_manifest.json
+++ b/core/package_manifest.json
@@ -103,6 +103,12 @@
       "size_mb": 200,
       "depends_on": ["torch"],
       "features": ["stem_separation"]
+    },
+    "ctc_forced_aligner": {
+      "pip_specifier": "ctc-forced-aligner>=0.1.0,<1.0",
+      "size_mb": 400,
+      "depends_on": ["torch"],
+      "features": ["word_alignment"]
     }
   }
 }

--- a/core/remix/word_llm_composer.py
+++ b/core/remix/word_llm_composer.py
@@ -1,0 +1,123 @@
+"""LLM Word Composer remix wrapper.
+
+Thin shim over ``core/spine/words.compose_with_llm`` that materializes a
+prompt-driven LLM word ordering into ``SequenceClip[]``.
+
+This unit (U5) owns the registration of ``word_llm_composer`` in
+``ui/algorithm_config.py`` end-to-end. Frame-math semantics are shared
+with the preset-modes path (U4) via
+``core/remix/word_sequencer.instances_to_sequence_clips`` — there is
+intentionally only one implementation of the floor/ceil/handle/clamp
+conversion so the two paths cannot drift.
+
+LLM details (vocabulary constraint, repeat-policy semantics, OOV
+handling, system-prompt construction) live in
+``core/spine/words.compose_with_llm``; this wrapper only translates the
+Sequence-tab's ``[(Clip, Source)]`` input shape into the spine-level
+inventory call and then translates the resulting ``WordInstance[]`` into
+``SequenceClip[]``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from core.remix.word_sequencer import (
+    MissingWordDataError,  # re-export for callers / dialogs
+    instances_to_sequence_clips,
+    validate_word_data,
+)
+from core.spine.words import (
+    RepeatPolicy,
+    build_inventory,
+    compose_with_llm,
+)
+
+if TYPE_CHECKING:
+    from models.sequence import SequenceClip
+
+
+__all__ = [
+    "MissingWordDataError",  # re-exported so dialog code can import from one place
+    "generate_llm_word_sequence",
+]
+
+
+def generate_llm_word_sequence(
+    clips: list[tuple[Any, Any]],
+    prompt: str,
+    target_length: int,
+    repeat_policy: RepeatPolicy = "round-robin",
+    seed: Optional[int] = None,
+    handle_frames: int = 0,
+    *,
+    model: Optional[str] = None,
+    api_base: Optional[str] = None,
+    temperature: float = 0.7,
+    timeout: float = 120.0,
+    system_prompt: Optional[str] = None,
+    think: bool = False,
+    _compose_fn=None,
+) -> list["SequenceClip"]:
+    """Materialize a prompt-driven LLM word ordering into ``SequenceClip[]``.
+
+    Args:
+        clips: ``[(Clip, Source), ...]`` — same shape the Sequence-tab
+            dialog dispatch hands every other algorithm. The corpus is
+            built from these clips' aligned words.
+        prompt: User-supplied generation prompt.
+        target_length: Target number of words (used in the system prompt).
+        repeat_policy: How to choose among multiple corpus instances when
+            the LLM emits the same word more than once. See
+            ``core.spine.words.compose_with_llm`` for full semantics.
+        seed: Seed for ``repeat_policy="random"``.
+        handle_frames: Symmetric handle padding (frames). Default 0 — raw
+            cuts, per the brainstorm.
+        model: Ollama model name (defaults to project setting / qwen3:8b).
+        api_base: Ollama API base URL.
+        temperature: Sampling temperature for the underlying Ollama call.
+        timeout: Total HTTP timeout in seconds.
+        system_prompt: Override the default frequency-annotated system prompt.
+        _compose_fn: Test-only hook. Callable with the same signature as
+            ``core.spine.words.compose_with_llm`` returning ``WordInstance[]``.
+            When ``None``, the real spine composer is used.
+
+    Returns:
+        ``list[SequenceClip]`` ordered as the LLM emitted words, with
+        frame coords from the shared U4/U5 frame-math helper.
+
+    Raises:
+        MissingWordDataError: any selected clip has a segment with
+            ``words is None``. The dialog catches this and triggers
+            alignment.
+        ValueError: source has missing or non-positive ``fps``, empty
+            corpus, or the LLM emits an OOV word.
+        core.llm_client.LLMEmptyResponseError: LLM produced no content.
+        core.llm_client.OllamaUnreachableError: Ollama not reachable.
+    """
+    if not clips:
+        return []
+
+    # Validation must happen BEFORE the LLM call — the dialog catches
+    # MissingWordDataError and triggers alignment without burning an
+    # Ollama call on incomplete data.
+    validate_word_data(clips)
+
+    inventory = build_inventory(clips)
+
+    compose = compose_with_llm if _compose_fn is None else _compose_fn
+    instances = compose(
+        inventory,
+        prompt=prompt,
+        target_length=target_length,
+        repeat_policy=repeat_policy,
+        seed=seed,
+        model=model,
+        api_base=api_base,
+        temperature=temperature,
+        timeout=timeout,
+        system_prompt=system_prompt,
+        think=think,
+    )
+
+    return instances_to_sequence_clips(instances, clips, handle_frames)

--- a/core/remix/word_sequencer.py
+++ b/core/remix/word_sequencer.py
@@ -180,7 +180,7 @@ def instances_to_sequence_clips(
                 "convert word boundaries to frames"
             )
         fps = float(raw_fps)
-        if fps <= 0:
+        if not math.isfinite(fps) or fps <= 0:
             raise ValueError(
                 f"Source {getattr(source, 'id', '?')} has non-positive fps {fps!r}"
             )
@@ -191,7 +191,7 @@ def instances_to_sequence_clips(
 
         handle_seconds = handle_frames / fps
         in_seconds = max(0.0, float(inst.start) - handle_seconds)
-        out_seconds = min(clip_duration_seconds, float(inst.end) + handle_seconds)
+        out_seconds = max(0.0, min(clip_duration_seconds, float(inst.end) + handle_seconds))
 
         in_point = math.floor(in_seconds * fps)
         out_point = math.ceil(out_seconds * fps)

--- a/core/remix/word_sequencer.py
+++ b/core/remix/word_sequencer.py
@@ -27,8 +27,11 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, Any, Optional
 
+from typing import get_args as _get_typing_args
+
 from core.spine.words import (
     WordInstance,
+    WordMode,
     alphabetical,
     build_inventory,
     by_chosen_words,
@@ -75,16 +78,7 @@ class MissingWordDataError(Exception):
 # ---------------------------------------------------------------------------
 
 
-_MODES = {
-    "alphabetical",
-    "by_chosen_words",
-    "by_frequency",
-    "by_property",
-    "from_word_list",
-}
-
-
-def _apply_mode(inv, mode: str, mode_params: dict) -> list[WordInstance]:
+def _apply_mode(inv, mode: WordMode, mode_params: dict) -> list[WordInstance]:
     if mode == "alphabetical":
         return alphabetical(inv)
     if mode == "by_chosen_words":
@@ -104,7 +98,8 @@ def _apply_mode(inv, mode: str, mode_params: dict) -> list[WordInstance]:
             on_missing=mode_params.get("on_missing", "skip"),
         )
     raise ValueError(
-        f"Unknown word-sequencer mode {mode!r}; expected one of {sorted(_MODES)}"
+        "Unknown word-sequencer mode "
+        f"{mode!r}; expected one of {sorted(_get_typing_args(WordMode))}"
     )
 
 
@@ -227,7 +222,7 @@ def instances_to_sequence_clips(
 
 def generate_word_sequence(
     clips: list[tuple[Any, Any]],
-    mode: str,
+    mode: WordMode,
     mode_params: Optional[dict] = None,
     handle_frames: int = 0,
 ) -> list["SequenceClip"]:

--- a/core/remix/word_sequencer.py
+++ b/core/remix/word_sequencer.py
@@ -45,6 +45,8 @@ if TYPE_CHECKING:
 __all__ = [
     "MissingWordDataError",
     "generate_word_sequence",
+    "instances_to_sequence_clips",
+    "validate_word_data",
 ]
 
 
@@ -122,6 +124,102 @@ def _validate_word_data(clips: list[tuple[Any, Any]]) -> None:
         raise MissingWordDataError(missing)
 
 
+# Public alias so the LLM-composer wrapper can call into the same validation
+# logic without poking the underscore name.
+validate_word_data = _validate_word_data
+
+
+# ---------------------------------------------------------------------------
+# Frame-math helper (shared with the LLM composer)
+# ---------------------------------------------------------------------------
+
+
+def instances_to_sequence_clips(
+    instances,
+    clips: list[tuple[Any, Any]],
+    handle_frames: int = 0,
+) -> list["SequenceClip"]:
+    """Materialize a list of ``WordInstance`` into ``SequenceClip[]``.
+
+    This is the *single* implementation of the frame-math convention.
+    Both ``generate_word_sequence`` (preset modes — U4) and the LLM
+    composer (U5) call into it, so the two paths cannot drift on
+    floor/ceil/handle/clamp semantics.
+
+    Args:
+        instances: Ordered iterable of ``WordInstance`` objects.
+        clips: ``[(Clip, Source), ...]`` — same shape passed to the
+            sequencer entry points; used for fps lookup and clip-bound
+            clamping.
+        handle_frames: Symmetric handle padding (frames). Default 0.
+
+    Returns:
+        ``list[SequenceClip]`` with ``in_point``/``out_point`` set per the
+        floor / ceil / clamp convention. ``start_frame`` and
+        ``track_index`` are left at their defaults; the caller assembles
+        the timeline.
+
+    Raises:
+        ValueError: source has missing or non-positive ``fps``.
+    """
+    from models.sequence import SequenceClip
+
+    by_clip_id: dict[str, tuple[Any, Any]] = {
+        getattr(clip, "id", ""): (clip, source) for clip, source in clips
+    }
+
+    result: list[SequenceClip] = []
+    for inst in instances:
+        # Drop zero-duration words silently (rare ASR artifact).
+        if inst.end <= inst.start:
+            continue
+
+        clip, source = by_clip_id.get(inst.clip_id, (None, None))
+        if clip is None or source is None:
+            continue
+
+        raw_fps = getattr(source, "fps", None)
+        if raw_fps is None:
+            raise ValueError(
+                f"Source {getattr(source, 'id', '?')} has no fps; cannot "
+                "convert word boundaries to frames"
+            )
+        fps = float(raw_fps)
+        if fps <= 0:
+            raise ValueError(
+                f"Source {getattr(source, 'id', '?')} has non-positive fps {fps!r}"
+            )
+
+        start_frame = int(getattr(clip, "start_frame", 0))
+        end_frame = int(getattr(clip, "end_frame", start_frame))
+        clip_duration_seconds = max(0.0, (end_frame - start_frame) / fps)
+
+        handle_seconds = handle_frames / fps
+        in_seconds = max(0.0, float(inst.start) - handle_seconds)
+        out_seconds = min(clip_duration_seconds, float(inst.end) + handle_seconds)
+
+        in_point = math.floor(in_seconds * fps)
+        out_point = math.ceil(out_seconds * fps)
+
+        clip_length = end_frame - start_frame
+        in_point = max(0, min(in_point, clip_length))
+        out_point = max(0, min(out_point, clip_length))
+
+        if out_point <= in_point:
+            continue
+
+        result.append(
+            SequenceClip(
+                source_clip_id=getattr(clip, "id", ""),
+                source_id=getattr(clip, "source_id", ""),
+                in_point=in_point,
+                out_point=out_point,
+            )
+        )
+
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -156,10 +254,6 @@ def generate_word_sequence(
             ``words is None``.
         ValueError: ``mode`` is not recognized, or any source has missing fps.
     """
-    # Local import keeps the spine boundary check clean and avoids paying
-    # the import cost when the module is only being collected by pytest.
-    from models.sequence import SequenceClip
-
     if not clips:
         return []
 
@@ -169,68 +263,8 @@ def generate_word_sequence(
     # MissingWordDataError and triggers alignment.
     _validate_word_data(clips)
 
-    # Build a quick lookup by clip_id to source/clip pair for the frame math.
-    by_clip_id: dict[str, tuple[Any, Any]] = {
-        getattr(clip, "id", ""): (clip, source) for clip, source in clips
-    }
-
     inventory = build_inventory(clips)
     instances = _apply_mode(inventory, mode, mode_params)
 
-    result: list[SequenceClip] = []
-    for inst in instances:
-        # Drop zero-duration words silently (rare ASR artifact).
-        if inst.end <= inst.start:
-            continue
-
-        clip, source = by_clip_id.get(inst.clip_id, (None, None))
-        if clip is None or source is None:
-            # Defensive — should never happen since instances come from
-            # build_inventory(clips).
-            continue
-
-        # fps: explicitly convert Fraction → float per the FFmpeg
-        # fractional-duration learning.
-        raw_fps = getattr(source, "fps", None)
-        if raw_fps is None:
-            raise ValueError(
-                f"Source {getattr(source, 'id', '?')} has no fps; cannot "
-                "convert word boundaries to frames"
-            )
-        fps = float(raw_fps)
-        if fps <= 0:
-            raise ValueError(
-                f"Source {getattr(source, 'id', '?')} has non-positive fps {fps!r}"
-            )
-
-        start_frame = int(getattr(clip, "start_frame", 0))
-        end_frame = int(getattr(clip, "end_frame", start_frame))
-        clip_duration_seconds = max(0.0, (end_frame - start_frame) / fps)
-
-        handle_seconds = handle_frames / fps
-        in_seconds = max(0.0, float(inst.start) - handle_seconds)
-        out_seconds = min(clip_duration_seconds, float(inst.end) + handle_seconds)
-
-        in_point = math.floor(in_seconds * fps)
-        out_point = math.ceil(out_seconds * fps)
-
-        # Hard-clamp to clip bounds after the floor/ceil snap, in case
-        # float rounding pushed past the limits.
-        clip_length = end_frame - start_frame
-        in_point = max(0, min(in_point, clip_length))
-        out_point = max(0, min(out_point, clip_length))
-
-        # Defensive: skip slots that collapsed to zero frames.
-        if out_point <= in_point:
-            continue
-
-        result.append(
-            SequenceClip(
-                source_clip_id=getattr(clip, "id", ""),
-                source_id=getattr(clip, "source_id", ""),
-                in_point=in_point,
-                out_point=out_point,
-            )
-        )
-
-    return result
+    # Shared frame-math helper, also used by the LLM composer in U5.
+    return instances_to_sequence_clips(instances, clips, handle_frames)

--- a/core/remix/word_sequencer.py
+++ b/core/remix/word_sequencer.py
@@ -1,0 +1,236 @@
+"""Word Sequencer remix wrapper.
+
+Thin shim over ``core/spine/words.py`` that materializes word-instance
+sequences into ``SequenceClip`` entries with the documented frame-math
+convention.
+
+Frame conversion convention (committed in the plan):
+
+- ``fps = source.fps``; ``ValueError`` if missing (no silent default).
+- Handle padding pre-conversion in seconds:
+  ``in_seconds  = max(0.0, word.start - handle_frames / fps)``
+  ``out_seconds = min(clip_duration_seconds, word.end + handle_frames / fps)``
+- Integer-frame snap:
+  ``in_point  = floor(in_seconds * fps)``  (keep consonant onset)
+  ``out_point = ceil(out_seconds * fps)``  (keep consonant offset)
+- All intermediate math uses Python ``float`` after explicit conversion from
+  any ``Fraction`` (per the FFmpeg-fractional-duration learning).
+- Zero-duration words (``word.start == word.end``) are dropped silently.
+
+The wrapper is a pure function — no Qt, no project mutation. Callers
+(``ui/dialogs/word_sequencer_dialog.py``) wrap the returned list in a
+``Sequence`` / ``Track`` and assign via ``project.sequence = ...``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any, Optional
+
+from core.spine.words import (
+    WordInstance,
+    alphabetical,
+    build_inventory,
+    by_chosen_words,
+    by_frequency,
+    by_property,
+    from_word_list,
+)
+
+if TYPE_CHECKING:
+    from models.clip import Clip, Source
+    from models.sequence import SequenceClip
+
+
+__all__ = [
+    "MissingWordDataError",
+    "generate_word_sequence",
+]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class MissingWordDataError(Exception):
+    """Raised when any selected clip has segments lacking word-level data.
+
+    ``clip_ids`` lists the offending clip ids. The dialog (U6) catches this
+    and triggers alignment.
+    """
+
+    def __init__(self, clip_ids: list[str]) -> None:
+        self.clip_ids = list(clip_ids)
+        super().__init__(
+            "The following clip(s) are missing word-level alignment data: "
+            + ", ".join(self.clip_ids)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mode dispatch
+# ---------------------------------------------------------------------------
+
+
+_MODES = {
+    "alphabetical",
+    "by_chosen_words",
+    "by_frequency",
+    "by_property",
+    "from_word_list",
+}
+
+
+def _apply_mode(inv, mode: str, mode_params: dict) -> list[WordInstance]:
+    if mode == "alphabetical":
+        return alphabetical(inv)
+    if mode == "by_chosen_words":
+        return by_chosen_words(inv, include=mode_params.get("include", []))
+    if mode == "by_frequency":
+        return by_frequency(inv, order=mode_params.get("order", "descending"))
+    if mode == "by_property":
+        return by_property(
+            inv,
+            key=mode_params.get("key", "length"),
+            order=mode_params.get("order", "ascending"),
+        )
+    if mode == "from_word_list":
+        return from_word_list(
+            inv,
+            sequence=mode_params.get("sequence", []),
+            on_missing=mode_params.get("on_missing", "skip"),
+        )
+    raise ValueError(
+        f"Unknown word-sequencer mode {mode!r}; expected one of {sorted(_MODES)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_word_data(clips: list[tuple[Any, Any]]) -> None:
+    """Raise ``MissingWordDataError`` if any selected clip has unaligned segments."""
+    missing: list[str] = []
+    for clip, _source in clips:
+        transcript = getattr(clip, "transcript", None) or []
+        if any(getattr(seg, "words", None) is None for seg in transcript):
+            missing.append(getattr(clip, "id", ""))
+    if missing:
+        raise MissingWordDataError(missing)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_word_sequence(
+    clips: list[tuple[Any, Any]],
+    mode: str,
+    mode_params: Optional[dict] = None,
+    handle_frames: int = 0,
+) -> list["SequenceClip"]:
+    """Materialize a word-instance ordering into ``SequenceClip[]``.
+
+    Args:
+        clips: List of ``(Clip, Source)`` tuples — the same shape the
+            Sequence-tab dialog dispatch passes every other algorithm.
+        mode: One of ``alphabetical`` / ``by_chosen_words`` / ``by_frequency``
+            / ``by_property`` / ``from_word_list``.
+        mode_params: Mode-specific keyword arguments (e.g. ``{"order":
+            "descending"}`` for ``by_frequency``).
+        handle_frames: Symmetric handle padding in frames (default 0 — raw
+            cuts). Clamped to clip bounds.
+
+    Returns:
+        A list of ``SequenceClip`` objects with ``in_point`` / ``out_point``
+        set to the word-aligned frame boundaries. ``start_frame`` /
+        ``track_index`` are left at their defaults — the caller assembles the
+        timeline.
+
+    Raises:
+        MissingWordDataError: any selected clip has a segment with
+            ``words is None``.
+        ValueError: ``mode`` is not recognized, or any source has missing fps.
+    """
+    # Local import keeps the spine boundary check clean and avoids paying
+    # the import cost when the module is only being collected by pytest.
+    from models.sequence import SequenceClip
+
+    if not clips:
+        return []
+
+    mode_params = mode_params or {}
+
+    # Validation must happen BEFORE any frame math — the dialog catches
+    # MissingWordDataError and triggers alignment.
+    _validate_word_data(clips)
+
+    # Build a quick lookup by clip_id to source/clip pair for the frame math.
+    by_clip_id: dict[str, tuple[Any, Any]] = {
+        getattr(clip, "id", ""): (clip, source) for clip, source in clips
+    }
+
+    inventory = build_inventory(clips)
+    instances = _apply_mode(inventory, mode, mode_params)
+
+    result: list[SequenceClip] = []
+    for inst in instances:
+        # Drop zero-duration words silently (rare ASR artifact).
+        if inst.end <= inst.start:
+            continue
+
+        clip, source = by_clip_id.get(inst.clip_id, (None, None))
+        if clip is None or source is None:
+            # Defensive — should never happen since instances come from
+            # build_inventory(clips).
+            continue
+
+        # fps: explicitly convert Fraction → float per the FFmpeg
+        # fractional-duration learning.
+        raw_fps = getattr(source, "fps", None)
+        if raw_fps is None:
+            raise ValueError(
+                f"Source {getattr(source, 'id', '?')} has no fps; cannot "
+                "convert word boundaries to frames"
+            )
+        fps = float(raw_fps)
+        if fps <= 0:
+            raise ValueError(
+                f"Source {getattr(source, 'id', '?')} has non-positive fps {fps!r}"
+            )
+
+        start_frame = int(getattr(clip, "start_frame", 0))
+        end_frame = int(getattr(clip, "end_frame", start_frame))
+        clip_duration_seconds = max(0.0, (end_frame - start_frame) / fps)
+
+        handle_seconds = handle_frames / fps
+        in_seconds = max(0.0, float(inst.start) - handle_seconds)
+        out_seconds = min(clip_duration_seconds, float(inst.end) + handle_seconds)
+
+        in_point = math.floor(in_seconds * fps)
+        out_point = math.ceil(out_seconds * fps)
+
+        # Hard-clamp to clip bounds after the floor/ceil snap, in case
+        # float rounding pushed past the limits.
+        clip_length = end_frame - start_frame
+        in_point = max(0, min(in_point, clip_length))
+        out_point = max(0, min(out_point, clip_length))
+
+        # Defensive: skip slots that collapsed to zero frames.
+        if out_point <= in_point:
+            continue
+
+        result.append(
+            SequenceClip(
+                source_clip_id=getattr(clip, "id", ""),
+                source_id=getattr(clip, "source_id", ""),
+                in_point=in_point,
+                out_point=out_point,
+            )
+        )
+
+    return result

--- a/core/spine/words.py
+++ b/core/spine/words.py
@@ -1,0 +1,316 @@
+"""Word inventory + preset ordering modes for the Word Sequencer.
+
+This is the GUI-agnostic shared layer (spine boundary) used by both the
+chat/agent tools and ``scene_ripper_mcp`` (future). It holds **no** Qt /
+mpv / av / faster_whisper / paddleocr / mlx_vlm imports at module top
+level — see ``tests/test_spine_imports.py`` for the enforcement test.
+
+Data model
+----------
+
+- ``WordInstance`` — a single occurrence of a word inside a specific clip,
+  carrying clip-relative ``start`` / ``end`` (seconds) and back-references to
+  the source / clip / transcript indices.
+
+- ``WordInventory`` — frozen container with two pre-built indices: ``by_word``
+  (normalized word → instances) and ``by_clip`` (clip id → instances).
+
+Modes
+-----
+
+Five preset ordering functions take a ``WordInventory`` and return an
+ordered ``list[WordInstance]``:
+
+- ``alphabetical`` — lexical order over ``by_word`` keys.
+- ``by_chosen_words(include=[...])`` — subset filter that emits *every*
+  instance of each listed word, grouped by include-list order.
+- ``by_frequency(order="descending"|"ascending")`` — frequency sort.
+- ``by_property(key="length"|"duration"|"log_frequency", order=...)`` —
+  property-based sort.
+- ``from_word_list(sequence=[...])`` — literal materialization (one slot per
+  list entry, repeats allowed).
+
+Word normalization
+------------------
+
+Lowercase + strip surrounding ASCII punctuation. Contractions stay whole
+(``"don't"`` is one word — faster-whisper's tokenizer already commits to
+that). Original (un-normalized) ``text`` is preserved on each
+``WordInstance`` so callers can render it verbatim.
+"""
+
+from __future__ import annotations
+
+import math
+import string
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, Optional
+
+if TYPE_CHECKING:
+    # Project models — type-only imports keep the spine module loadable
+    # without triggering downstream imports we don't need at runtime.
+    from core.transcription import TranscriptSegment
+    from models.clip import Clip, Source
+
+
+__all__ = [
+    "MissingWordsError",
+    "WordInstance",
+    "WordInventory",
+    "alphabetical",
+    "build_inventory",
+    "by_chosen_words",
+    "by_frequency",
+    "by_property",
+    "from_word_list",
+    "normalize_word",
+]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class MissingWordsError(Exception):
+    """Raised by ``from_word_list(on_missing="raise")`` when entries are absent.
+
+    ``missing`` holds the list of words (normalized form) that could not be
+    found in the inventory, in input order.
+    """
+
+    def __init__(self, missing: list[str]) -> None:
+        self.missing = list(missing)
+        super().__init__(
+            "Word(s) not found in corpus: " + ", ".join(repr(w) for w in self.missing)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WordInstance:
+    """A single occurrence of a word within a specific transcript segment.
+
+    ``start`` and ``end`` are clip-relative seconds — the same frame of
+    reference as ``TranscriptSegment.start_time`` set by per-clip
+    transcription / alignment.
+    """
+
+    source_id: str
+    clip_id: str
+    segment_index: int  # index into clip.transcript
+    word_index: int  # index into clip.transcript[segment_index].words
+    start: float  # clip-relative seconds
+    end: float  # clip-relative seconds
+    text: str  # original (un-normalized) word text
+
+
+@dataclass(frozen=True)
+class WordInventory:
+    """Two pre-built indices over the selected clips' words.
+
+    - ``by_word`` is keyed by normalized word string.
+    - ``by_clip`` is keyed by ``Clip.id``.
+
+    Both indices share the same underlying ``WordInstance`` objects.
+    """
+
+    by_word: dict[str, list[WordInstance]]
+    by_clip: dict[str, list[WordInstance]]
+
+
+# ---------------------------------------------------------------------------
+# Normalization helper
+# ---------------------------------------------------------------------------
+
+
+def normalize_word(word: str) -> str:
+    """Normalize a single word for indexing.
+
+    Lowercase + strip surrounding ASCII punctuation. Internal punctuation
+    (apostrophes inside contractions, hyphens inside hyphenated words) is
+    preserved.
+    """
+    return word.strip().strip(string.punctuation).lower()
+
+
+# ---------------------------------------------------------------------------
+# build_inventory
+# ---------------------------------------------------------------------------
+
+
+def build_inventory(clips: list[tuple["Clip", "Source"]]) -> WordInventory:
+    """Build a ``WordInventory`` from a list of ``(Clip, Source)`` tuples.
+
+    Empty / missing transcripts are silently skipped. Words with empty
+    normalized text (e.g. a token that was nothing but punctuation) are
+    also dropped.
+    """
+    by_word: dict[str, list[WordInstance]] = {}
+    by_clip: dict[str, list[WordInstance]] = {}
+
+    for clip, _source in clips:
+        clip_id = getattr(clip, "id", "")
+        source_id = getattr(clip, "source_id", "")
+        transcript = getattr(clip, "transcript", None)
+        if not transcript:
+            # No transcript at all → don't materialize a by_clip entry.
+            # ``by_clip.get(clip_id, [])`` returns ``[]`` for callers anyway.
+            continue
+
+        # Ensure the clip appears in by_clip even when every segment has
+        # ``words = []`` (alignment ran but produced no words). Tests rely
+        # on the distinction between "clip not visited" and "clip visited
+        # but empty".
+        clip_bucket = by_clip.setdefault(clip_id, [])
+
+        for seg_idx, segment in enumerate(transcript):
+            words = getattr(segment, "words", None) or []
+            for word_idx, word in enumerate(words):
+                text = getattr(word, "text", "")
+                normalized = normalize_word(text)
+                if not normalized:
+                    continue
+                instance = WordInstance(
+                    source_id=source_id,
+                    clip_id=clip_id,
+                    segment_index=seg_idx,
+                    word_index=word_idx,
+                    start=float(getattr(word, "start", 0.0)),
+                    end=float(getattr(word, "end", 0.0)),
+                    text=text,
+                )
+                by_word.setdefault(normalized, []).append(instance)
+                clip_bucket.append(instance)
+
+    return WordInventory(by_word=by_word, by_clip=by_clip)
+
+
+# ---------------------------------------------------------------------------
+# Mode functions
+# ---------------------------------------------------------------------------
+
+
+def alphabetical(inv: WordInventory) -> list[WordInstance]:
+    """Lexical order over ``inv.by_word`` keys; encounter order within each word."""
+    result: list[WordInstance] = []
+    for word_key in sorted(inv.by_word.keys()):
+        result.extend(inv.by_word[word_key])
+    return result
+
+
+def by_chosen_words(inv: WordInventory, include: list[str]) -> list[WordInstance]:
+    """Emit every instance of each listed word, grouped by include-list order.
+
+    Case-insensitive (comparison on normalized form). Unknown words are
+    silently dropped — the dialog can preview which entries matched.
+    """
+    result: list[WordInstance] = []
+    for raw in include:
+        key = normalize_word(raw)
+        if not key:
+            continue
+        result.extend(inv.by_word.get(key, []))
+    return result
+
+
+def by_frequency(
+    inv: WordInventory,
+    order: Literal["descending", "ascending"] = "descending",
+) -> list[WordInstance]:
+    """Order every instance by the frequency of its parent word.
+
+    Default emits most-frequent first. Within a frequency tier, words sort
+    alphabetically to keep the output deterministic.
+    """
+    if order not in ("descending", "ascending"):
+        raise ValueError(f"order must be 'descending' or 'ascending', got {order!r}")
+
+    keys = sorted(
+        inv.by_word.keys(),
+        key=lambda k: (-len(inv.by_word[k]), k) if order == "descending"
+        else (len(inv.by_word[k]), k),
+    )
+    result: list[WordInstance] = []
+    for key in keys:
+        result.extend(inv.by_word[key])
+    return result
+
+
+def by_property(
+    inv: WordInventory,
+    key: Literal["length", "duration", "log_frequency"],
+    order: Literal["descending", "ascending"] = "ascending",
+) -> list[WordInstance]:
+    """Order every instance by a word-derived metric.
+
+    - ``length`` — number of characters in the normalized word.
+    - ``duration`` — ``end - start`` of the individual instance.
+    - ``log_frequency`` — log of the parent word's corpus frequency.
+
+    Default is ascending (shortest / quickest / rarest first). Ties break
+    alphabetically on the normalized form to keep output deterministic.
+    """
+    if key not in ("length", "duration", "log_frequency"):
+        raise ValueError(
+            f"key must be 'length', 'duration', or 'log_frequency', got {key!r}"
+        )
+    if order not in ("descending", "ascending"):
+        raise ValueError(f"order must be 'descending' or 'ascending', got {order!r}")
+
+    # Build (instance, normalized_key, metric) tuples and sort.
+    rows: list[tuple[WordInstance, str, float]] = []
+    for word_key, instances in inv.by_word.items():
+        freq = len(instances)
+        log_freq = math.log(freq) if freq > 0 else 0.0
+        for inst in instances:
+            if key == "length":
+                metric = float(len(word_key))
+            elif key == "duration":
+                metric = float(inst.end - inst.start)
+            else:  # log_frequency
+                metric = log_freq
+            rows.append((inst, word_key, metric))
+
+    reverse = (order == "descending")
+    rows.sort(key=lambda r: (r[2], r[1]), reverse=reverse)
+    return [r[0] for r in rows]
+
+
+def from_word_list(
+    inv: WordInventory,
+    sequence: list[str],
+    on_missing: Literal["skip", "raise"] = "skip",
+) -> list[WordInstance]:
+    """Literal materialization — one slot per ``sequence`` entry, repeats allowed.
+
+    For each slot we return the *first* matching instance in the inventory.
+    Higher layers (the LLM-composer's ``repeat_policy``) can rotate among
+    multiple instances if they want different picks per slot.
+
+    Unknown words: ``on_missing="skip"`` drops them silently; ``on_missing="raise"``
+    raises ``MissingWordsError`` listing every missing entry.
+    """
+    if on_missing not in ("skip", "raise"):
+        raise ValueError(
+            f"on_missing must be 'skip' or 'raise', got {on_missing!r}"
+        )
+
+    missing: list[str] = []
+    result: list[WordInstance] = []
+    for raw in sequence:
+        key = normalize_word(raw)
+        instances = inv.by_word.get(key) if key else None
+        if not instances:
+            missing.append(key or raw)
+            continue
+        result.append(instances[0])
+
+    if missing and on_missing == "raise":
+        raise MissingWordsError(missing)
+
+    return result

--- a/core/spine/words.py
+++ b/core/spine/words.py
@@ -42,6 +42,7 @@ that). Original (un-normalized) ``text`` is preserved on each
 from __future__ import annotations
 
 import math
+import secrets
 import string
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Optional
@@ -62,9 +63,13 @@ __all__ = [
     "by_chosen_words",
     "by_frequency",
     "by_property",
+    "compose_with_llm",
     "from_word_list",
     "normalize_word",
 ]
+
+
+RepeatPolicy = Literal["round-robin", "random", "first", "longest", "shortest"]
 
 
 # ---------------------------------------------------------------------------
@@ -279,6 +284,212 @@ def by_property(
     reverse = (order == "descending")
     rows.sort(key=lambda r: (r[2], r[1]), reverse=reverse)
     return [r[0] for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Repeat-policy instance picker
+# ---------------------------------------------------------------------------
+
+
+def _pick_instance(
+    candidates: list[WordInstance],
+    *,
+    policy: RepeatPolicy,
+    counter: int,
+    rng,
+) -> WordInstance:
+    """Pick a ``WordInstance`` from ``candidates`` under a repeat policy.
+
+    ``counter`` is the per-word emission count (0-based) and is only used
+    by ``round-robin``. ``rng`` is a ``random.Random``-shaped object and
+    is only used by ``random``.
+    """
+    if not candidates:
+        # Caller should have filtered this out; defensive raise.
+        raise ValueError("_pick_instance called with empty candidate list")
+
+    if policy == "round-robin":
+        return candidates[counter % len(candidates)]
+    if policy == "random":
+        return rng.choice(candidates)
+    if policy == "first":
+        return candidates[0]
+
+    # ``longest`` / ``shortest`` sort the candidates by duration and use
+    # ``(clip_id, segment_index, word_index)`` as the tiebreak. Sorting (vs
+    # min/max with a complex key) keeps the tiebreak direction explicit:
+    # ties always resolve to the earliest (clip_id, segment_index,
+    # word_index) regardless of whether we're picking the longest or
+    # shortest duration.
+    sorted_by_dur = sorted(
+        candidates,
+        key=lambda inst: (
+            inst.end - inst.start,
+            inst.clip_id,
+            inst.segment_index,
+            inst.word_index,
+        ),
+    )
+    if policy == "shortest":
+        return sorted_by_dur[0]
+    if policy == "longest":
+        # Last entry is longest duration; among ties at max duration, the
+        # earliest (clip_id, segment_index, word_index) wins because we
+        # sort ascending and tie-broken ascending — so we walk back from
+        # the end to the first one whose duration matches the max.
+        target = sorted_by_dur[-1].end - sorted_by_dur[-1].start
+        for inst in sorted_by_dur:
+            if (inst.end - inst.start) == target:
+                return inst
+        return sorted_by_dur[-1]  # pragma: no cover — unreachable
+    raise ValueError(
+        f"policy must be one of round-robin/random/first/longest/shortest, "
+        f"got {policy!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# LLM-composed mode
+# ---------------------------------------------------------------------------
+
+
+def compose_with_llm(
+    inv: WordInventory,
+    prompt: str,
+    target_length: int,
+    repeat_policy: RepeatPolicy = "round-robin",
+    seed: Optional[int] = None,
+    *,
+    model: Optional[str] = None,
+    api_base: Optional[str] = None,
+    temperature: float = 0.7,
+    timeout: float = 120.0,
+    system_prompt: Optional[str] = None,
+    think: bool = False,
+    _completion_fn=None,
+) -> list[WordInstance]:
+    """Compose an ordered ``list[WordInstance]`` from a user prompt via Ollama.
+
+    The corpus vocabulary (``inv.by_word`` keys) is fed to Ollama as a
+    JSON-schema enum so the model can only emit corpus words. The
+    resulting words are mapped back to ``WordInstance`` objects under the
+    chosen ``repeat_policy``.
+
+    Args:
+        inv: ``WordInventory`` built from selected clips.
+        prompt: User-supplied generation prompt.
+        target_length: Target output length (used in the system prompt).
+        repeat_policy: How to choose among multiple corpus instances when
+            the LLM emits the same word more than once.
+
+            - ``"round-robin"`` (default): cycle through instances in
+              inventory order. State is per ``compose_with_llm`` call.
+            - ``"random"``: seeded ``random.choice``. Same ``seed`` →
+              identical output.
+            - ``"first"``: always the first instance in inventory order.
+            - ``"longest"`` / ``"shortest"``: by ``end - start``; ties
+              broken deterministically by ``(clip_id, segment_index,
+              word_index)``.
+        seed: Seed for ``repeat_policy="random"``. ``None`` → cryptographic
+            random seed (output non-deterministic; documented).
+        model: Ollama model name (defaults to project setting / qwen3:8b).
+        api_base: Ollama API base URL.
+        temperature: Sampling temperature for the underlying Ollama call.
+        timeout: Total HTTP timeout in seconds.
+        system_prompt: Override the default frequency-annotated system prompt.
+        _completion_fn: Test-only hook. Callable with the same signature as
+            ``core.llm_client.complete_with_enum_constraint`` returning a
+            list of words. When ``None``, the real client is used.
+
+    Returns:
+        Ordered list of ``WordInstance`` objects, one per LLM-emitted word.
+
+    Raises:
+        ValueError: empty vocabulary, ``target_length`` < 1, unknown
+            ``repeat_policy``.
+        core.llm_client.LLMEmptyResponseError: LLM produced no content.
+        core.llm_client.OllamaUnreachableError: Ollama not reachable.
+        ValueError: LLM somehow emits an OOV word (the ``format`` + enum
+            constraint should prevent this; raise loudly so the bug
+            surfaces rather than silently dropping the slot).
+    """
+    import random
+
+    if not inv.by_word:
+        raise ValueError("compose_with_llm: inventory is empty (no words to draw from)")
+    if target_length < 1:
+        raise ValueError(
+            f"compose_with_llm: target_length must be >= 1, got {target_length}"
+        )
+    if repeat_policy not in (
+        "round-robin", "random", "first", "longest", "shortest"
+    ):
+        raise ValueError(
+            "repeat_policy must be one of round-robin/random/first/longest/"
+            f"shortest, got {repeat_policy!r}"
+        )
+
+    vocabulary = sorted(inv.by_word.keys())
+    frequencies = {k: len(v) for k, v in inv.by_word.items()}
+
+    # Run the LLM. Lazy import keeps the spine module importable when
+    # llm_client's deps aren't available.
+    if _completion_fn is None:
+        from core.llm_client import complete_with_enum_constraint
+        _completion_fn = complete_with_enum_constraint
+
+    words = _completion_fn(
+        prompt=prompt,
+        vocabulary=vocabulary,
+        target_length=target_length,
+        system_prompt=system_prompt,
+        model=model,
+        api_base=api_base,
+        temperature=temperature,
+        timeout=timeout,
+        frequencies=frequencies,
+        think=think,
+    )
+
+    # Seeded RNG for the random policy.
+    if repeat_policy == "random":
+        if seed is None:
+            # Document: when ``seed is None`` we use a cryptographic seed
+            # so runs are not deterministic. Tests can pass an explicit
+            # seed for reproducibility.
+            seed = int.from_bytes(secrets.token_bytes(8), "big", signed=False)
+        rng = random.Random(seed)
+    else:
+        rng = random.Random(0)  # unused; kept non-None for the picker
+
+    # Round-robin counter is per-word.
+    counters: dict[str, int] = {}
+
+    result: list[WordInstance] = []
+    for raw in words:
+        key = normalize_word(raw)
+        candidates = inv.by_word.get(key)
+        if not candidates:
+            # The enum constraint should prevent OOV emission. If we see
+            # one anyway, fail loudly — silently dropping would hide the
+            # bug. Covers the AE4 negative case.
+            raise ValueError(
+                f"LLM emitted out-of-vocabulary word {raw!r} (normalized: "
+                f"{key!r}); the format+enum constraint should have prevented "
+                "this. Check Ollama / LiteLLM constrained-decoding support."
+            )
+
+        counter = counters.get(key, 0)
+        instance = _pick_instance(
+            candidates,
+            policy=repeat_policy,
+            counter=counter,
+            rng=rng,
+        )
+        counters[key] = counter + 1
+        result.append(instance)
+
+    return result
 
 
 def from_word_list(

--- a/core/spine/words.py
+++ b/core/spine/words.py
@@ -56,8 +56,10 @@ if TYPE_CHECKING:
 
 __all__ = [
     "MissingWordsError",
+    "RepeatPolicy",
     "WordInstance",
     "WordInventory",
+    "WordMode",
     "alphabetical",
     "build_inventory",
     "by_chosen_words",
@@ -66,6 +68,17 @@ __all__ = [
     "compose_with_llm",
     "from_word_list",
     "normalize_word",
+]
+
+
+# Public mode-name Literal — the single source of truth shared by the spine
+# functions and the ``core.remix.word_sequencer`` dispatch.
+WordMode = Literal[
+    "alphabetical",
+    "by_chosen_words",
+    "by_frequency",
+    "by_property",
+    "from_word_list",
 ]
 
 

--- a/core/transcription.py
+++ b/core/transcription.py
@@ -254,6 +254,47 @@ def _resolve_backend(backend: str = "auto") -> str:
 
 
 @dataclass
+class WordTimestamp:
+    """A single word with start/end timestamps from forced alignment or word-level ASR.
+
+    Times are in the same frame of reference as the parent ``TranscriptSegment``
+    (clip-relative seconds when produced from per-clip transcription/alignment).
+
+    ``probability`` is optional because different backends surface different
+    confidence metrics: ``faster-whisper`` reports a per-word probability,
+    while forced aligners (e.g. ``ctc-forced-aligner``) emit a different
+    signal that may or may not be normalized into this field.
+    """
+
+    start: float  # clip-relative seconds
+    end: float
+    text: str
+    probability: Optional[float] = None
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary for JSON export."""
+        data: dict = {
+            "start": self.start,
+            "end": self.end,
+            "text": self.text,
+        }
+        if self.probability is not None:
+            data["probability"] = self.probability
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "WordTimestamp":
+        """Deserialize from dictionary."""
+        probability = data.get("probability")
+        return cls(
+            start=data.get("start", 0.0),
+            end=data.get("end", 0.0),
+            text=data.get("text", ""),
+            probability=probability if probability is None else float(probability),
+        )
+
+
+@dataclass
 class TranscriptSegment:
     """A segment of transcribed speech."""
 
@@ -261,24 +302,59 @@ class TranscriptSegment:
     end_time: float
     text: str
     confidence: float = 0.0
+    # Word-level timestamps. ``None`` means "no word data surfaced yet" (legacy
+    # transcripts, or MLX transcripts before forced alignment runs). ``[]`` means
+    # "alignment ran and produced no words" (silence / instrumental). The two
+    # states are deliberately distinct and must not be conflated.
+    words: Optional[list[WordTimestamp]] = None
+    # ISO 639-1 detected language for this segment (e.g. ``"en"``). Populated
+    # from ``faster-whisper``'s ``info.language`` or MLX's ``result["language"]``.
+    # ``None`` only for transcripts produced before U1 (legacy project files).
+    language: Optional[str] = None
 
     def to_dict(self) -> dict:
         """Serialize to dictionary for JSON export."""
-        return {
+        data: dict = {
             "start_time": self.start_time,
             "end_time": self.end_time,
             "text": self.text,
             "confidence": self.confidence,
         }
+        # Only emit the new keys when they carry information so old project
+        # files stay byte-comparable after a round trip through code that
+        # didn't populate them.
+        if self.words is not None:
+            data["words"] = [w.to_dict() for w in self.words]
+        if self.language is not None:
+            data["language"] = self.language
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> "TranscriptSegment":
-        """Deserialize from dictionary."""
+        """Deserialize from dictionary.
+
+        Back-compat: legacy segments lacking ``words`` and ``language`` keys
+        deserialize with ``words=None`` and ``language=None``. The distinction
+        between ``words=None`` (no data surfaced) and ``words=[]`` (alignment
+        ran, found nothing) is preserved.
+        """
+        if "words" in data:
+            raw_words = data["words"]
+            words: Optional[list[WordTimestamp]] = (
+                [WordTimestamp.from_dict(w) for w in raw_words]
+                if raw_words is not None
+                else None
+            )
+        else:
+            words = None
+
         return cls(
             start_time=data.get("start_time", 0.0),
             end_time=data.get("end_time", 0.0),
             text=data.get("text", ""),
             confidence=data.get("confidence", 0.0),
+            words=words,
+            language=data.get("language"),
         )
 
 
@@ -426,6 +502,33 @@ def transcribe_video(
     return _transcribe_video_faster_whisper(video_path, model_name, language, progress_callback)
 
 
+def _build_word_timestamps(raw_words) -> Optional[list[WordTimestamp]]:
+    """Convert faster-whisper's per-segment .words iterable to WordTimestamp objects.
+
+    Returns ``None`` when the upstream segment did not surface word data
+    (defensive — ``word_timestamps=True`` should always populate this, but
+    callers should not crash when it's missing). Returns ``[]`` when the
+    segment surfaced an explicit empty list.
+    """
+    if raw_words is None:
+        return None
+    result: list[WordTimestamp] = []
+    for w in raw_words:
+        text = getattr(w, "word", None)
+        if text is None:
+            text = getattr(w, "text", "")
+        probability = getattr(w, "probability", None)
+        result.append(
+            WordTimestamp(
+                start=float(getattr(w, "start", 0.0)),
+                end=float(getattr(w, "end", 0.0)),
+                text=str(text).strip(),
+                probability=float(probability) if probability is not None else None,
+            )
+        )
+    return result
+
+
 def _transcribe_video_faster_whisper(
     video_path: Path,
     model_name: str,
@@ -449,6 +552,8 @@ def _transcribe_video_faster_whisper(
     if progress_callback:
         progress_callback(0.5, "Processing segments...")
 
+    detected_language = getattr(info, "language", None)
+
     results = []
     for segment in segments:
         results.append(
@@ -457,6 +562,8 @@ def _transcribe_video_faster_whisper(
                 end_time=segment.end,
                 text=segment.text.strip(),
                 confidence=segment.avg_logprob,
+                words=_build_word_timestamps(getattr(segment, "words", None)),
+                language=detected_language,
             )
         )
 
@@ -600,6 +707,8 @@ def transcribe_clip(
             vad_filter=True,
         )
 
+        detected_language = getattr(info, "language", None)
+
         results = []
         for segment in segments:
             results.append(
@@ -608,6 +717,8 @@ def transcribe_clip(
                     end_time=segment.end,
                     text=segment.text.strip(),
                     confidence=segment.avg_logprob,
+                    words=_build_word_timestamps(getattr(segment, "words", None)),
+                    language=detected_language,
                 )
             )
 
@@ -633,10 +744,14 @@ def _parse_mlx_result(result: dict) -> list[TranscriptSegment]:
             standard Whisper HOP_LENGTH=160, SAMPLE_RATE=16000).
 
     Returns:
-        List of TranscriptSegment objects
+        List of TranscriptSegment objects. ``language`` is populated from
+        ``result["language"]`` (previously discarded); ``words`` is left as
+        ``None`` — U2's forced-alignment pass fills it in.
     """
     # Whisper mel frames → seconds: frames / (SAMPLE_RATE / HOP_LENGTH)
     _FRAMES_PER_SECOND = 100.0  # 16000 / 160
+
+    detected_language = result.get("language")
 
     segments_out = []
     for seg in result.get("segments", []):
@@ -648,6 +763,8 @@ def _parse_mlx_result(result: dict) -> list[TranscriptSegment]:
                     end_time=seg.get("end", 0.0),
                     text=seg.get("text", "").strip(),
                     confidence=0.0,
+                    words=None,
+                    language=detected_language,
                 )
             )
         elif isinstance(seg, (list, tuple)) and len(seg) >= 3:
@@ -658,6 +775,8 @@ def _parse_mlx_result(result: dict) -> list[TranscriptSegment]:
                     end_time=float(seg[1]) / _FRAMES_PER_SECOND,
                     text=str(seg[2]).strip(),
                     confidence=0.0,
+                    words=None,
+                    language=detected_language,
                 )
             )
         else:

--- a/docs/brainstorms/word-sequencer-requirements.md
+++ b/docs/brainstorms/word-sequencer-requirements.md
@@ -1,0 +1,165 @@
+---
+date: 2026-05-11
+topic: word-sequencer
+---
+
+# Word Sequencer
+
+## Summary
+
+A new sequencer that cuts user-selected source video(s) into word-level fragments using forced-alignment-augmented transcription and resequences those fragments under five ordering rules — alphabetical (Lenka Clayton-style), chosen-words supercut, statistical (frequency / length / other), user-curated word lists, and LLM-composed sentences with strict vocabulary constraint. Joins are raw hard cuts.
+
+---
+
+## Problem Frame
+
+Scene Ripper's sequencers today operate at the *clip* level — they reorder scene-detected clips. There is a class of editorial work, exemplified by Lenka Clayton's *Qaeda Quality Question Quickly Quickly Quiet* (presidential speeches rearranged alphabetically by word), that operates at the *word* level: cuts happen mid-sentence, sometimes mid-breath, and the unit of meaning becomes the spoken word rather than the shot. There is no current path through the app to produce work of this kind without manual word-by-word cutting in an external NLE.
+
+The pain is twofold. First, the unit of cut is wrong — extracting a single word from a clip is a per-cut manual operation in tools like Premiere or DaVinci, and a 5-minute speech yields hundreds of cuts. Second, even with timestamps from existing transcription, cross-attention-derived word timestamps (which is what `faster-whisper` and `lightning-whisper-mlx` produce by default) drift by 50–150ms and routinely slice consonants and clip plosives, making spliced output unintelligible or aesthetically broken for any composition more deliberate than abstract collage.
+
+The work this brainstorm scopes is the smallest path to making word-as-cut-unit a first-class capability in Scene Ripper, accurate enough that LLM-composed sentence-collage output (the most ambitious of the proposed modes) produces recognizable speech rather than noise.
+
+---
+
+## Pipeline
+
+```
+Source video
+    │
+    ▼
+Transcribe (faster-whisper / lightning-whisper-mlx)  ← existing
+    │
+    ▼
+Forced alignment post-step (wav2vec2-style)          ← NEW, opt-in
+    │
+    ▼
+Structured per-word timestamps on the transcript     ← schema upgrade
+    │
+    ├──► Word Sequencer (preset modes) ───────────────┐
+    │      alphabetical / chosen-words / frequency /  │
+    │      by-property / user-curated list            │
+    │                                                 ├──► SequenceClip[]
+    └──► LLM-Composed Word Sequencer                  │      with tight in/out
+            LLM (strict-decode) → word list ──────────┘      at word boundaries
+                                                              │
+                                                              ▼
+                                                        Existing render
+                                                        (no changes)
+```
+
+---
+
+## Actors
+
+- A1. **Filmmaker / artist (primary user)**: selects source(s), runs transcription with alignment, runs the word sequencer in one of the supported modes, reviews the resulting sequence in the timeline, renders.
+- A2. **LLM (strict-decode capable)**: in LLM-composed mode, receives a prompt and the corpus vocabulary, emits text constrained to that vocabulary.
+
+---
+
+## Key Flows
+
+- F1. **Run an alphabetical word film**
+  - **Trigger:** User picks one or more sources and chooses "Word Sequencer → Alphabetical".
+  - **Actors:** A1
+  - **Steps:** (1) User selects sources; (2) if any selected source lacks word-aligned transcription, app offers to run alignment; (3) sequencer builds word inventory, sorts alphabetically, materializes `SequenceClip[]`; (4) sequence appears in Sequence tab.
+  - **Outcome:** A timeline whose clips are individual spoken words in alphabetical order from the selected corpus.
+  - **Covered by:** R6, R7, R8, R9
+
+- F2. **Compose a sentence-collage with an LLM**
+  - **Trigger:** User picks one or more sources and chooses "Word Sequencer → LLM-Composed", provides a topic/seed prompt.
+  - **Actors:** A1, A2
+  - **Steps:** (1) User provides prompt; (2) algorithm builds vocabulary from corpus; (3) LLM generates constrained to that vocabulary; (4) each generated word is mapped to a corpus instance via the configured selection policy; (5) `SequenceClip[]` is materialized.
+  - **Outcome:** A timeline whose clips, played in order, produce the LLM-composed sentence in the speaker's actual voice using only words the speaker actually said.
+  - **Covered by:** R10, R11, R12, R13
+
+---
+
+## Requirements
+
+**Word-timestamping foundation**
+- R1. The transcription pipeline gains an optional forced-alignment post-step that produces word-level start/end timestamps with substantially better accuracy than cross-attention-derived timestamps (target: ~20–30ms typical error).
+- R2. Forced alignment is opt-in per transcription run; existing transcripts and existing features that consume them remain unaffected when alignment is not run.
+- R3. Existing transcripts can be retro-aligned without re-running the transcription engine itself.
+- R4. Per-word timestamp data is stored as structured data on the existing transcript field of the source or clip; no new top-level entity is introduced.
+- R5. Forced alignment is language-aware. If the source's language is not supported by the available alignment model, the feature surfaces a clear message and the source is unavailable to the Word Sequencer (existing transcription continues to work).
+
+**Sequencer — preset ordering modes**
+- R6. A new sequencer ("Word Sequencer") operates on one or more user-selected sources and produces a `SequenceClip[]` whose entries reference word-level slices of those sources.
+- R7. The preset-ordering algorithm supports five modes selectable from its config dialog: alphabetical, chosen-words (user supplies a list of words to include and the order they should play), by-frequency (most-frequent → least-frequent or reverse), by-property (word length, word duration, or other word-derived metric), and user-curated ordered list (user types or pastes an exact word sequence to materialize).
+- R8. The sequencer outputs `SequenceClip` entries with in/out points set to the aligned word boundaries; joins are raw hard cuts with no audio crossfade, video smoothing, or held frames.
+- R9. If a selected source has no aligned word data, the sequencer surfaces the missing alignment and offers to run alignment before producing the sequence.
+
+**Sequencer — LLM-composed mode**
+- R10. A separate algorithm ("LLM Word Composer" or similar) accepts a user-provided prompt or topic seed and produces a sentence/paragraph whose every word is drawn from the corpus's word inventory.
+- R11. The vocabulary constraint is enforced at decode time via grammar-constrained decoding (or equivalent strict-decoding mechanism), not as a post-generation filter or substitution pass.
+- R12. The generated word sequence is materialized into a `SequenceClip[]` by mapping each word to an instance in the corpus inventory.
+- R13. When a generated word has multiple instances in the corpus, the algorithm uses a configurable selection policy (default: round-robin so repeated words use different physical instances; alternatives: random with seed, fixed-first, longest/shortest duration).
+
+**Integration**
+- R14. The sequencer integrates with the existing Sequence tab and follows the existing algorithm config-dialog pattern in `ui/dialogs/`.
+- R15. The output is consumable by the existing render pipeline without changes to that pipeline.
+- R16. New heavy ML dependencies (the alignment model, optionally a local LLM runtime) are installed on demand through the existing `core/feature_registry.py` pattern, not bundled with the base install.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R5.** Given a French-language source and an alignment model that supports only English, when the user runs the Word Sequencer on it, the app surfaces "alignment model does not support French; source unavailable for word-level sequencing", and existing transcription of that source continues to work for other features.
+- AE2. **Covers R9.** Given a selected source that has a transcript but no word-level alignment, when the user runs the Word Sequencer on it, the app offers "this source has no word-level alignment; run alignment now?" rather than failing or producing inaccurate output.
+- AE3. **Covers R13.** Given a corpus containing 12 instances of the word "the" and an LLM-composed sentence that uses "the" four times, when the sequence is materialized with the default round-robin policy, the four "the" `SequenceClip` entries reference four different source instances (in inventory order), not the same instance four times.
+- AE4. **Covers R11.** Given an LLM-composed mode run where the corpus does not contain the word "however", when the LLM generation completes, no `SequenceClip` references "however" — and the LLM never emitted "however" in the first place (i.e., constraint was enforced at decode, not patched after).
+
+---
+
+## Success Criteria
+
+- A user can take a single 3–5 minute speech source, run transcription + alignment + the Word Sequencer in alphabetical mode, and produce a renderable timeline of every spoken word in alphabetical order on the first attempt, with most word boundaries intelligibly clean (no audible plosive-clipping or consonant-loss at the splices).
+- A user can run the LLM-composed mode against the same corpus with a one-line prompt (e.g., "compose a sentence about silence") and produce a ~10–30-word sentence-collage timeline that is recognizably intelligible speech in the source speaker's voice, using only words the speaker actually said.
+- A downstream planning agent reading this doc can identify which existing modules are touched (transcription pipeline modules, `core/remix/` for sequencers, `ui/dialogs/` for config UI, `core/feature_registry.py` for dependency gating) without needing to invent product behavior or scope.
+
+---
+
+## Scope Boundaries
+
+**Rejected for this product** (not planned):
+- Sub-word / phoneme-level cuts.
+- Audio crossfades, freeze-frames, or any join smoothing at word boundaries.
+- Project-wide or arbitrary-clip corpus selection (corpus is always one or more chosen sources).
+- Replacing the existing transcription stack with a single WhisperX-style canonical pipeline (Approach C rejected — surgical addition of alignment is preferred to engine replacement).
+- "Say it like this" / prosody- or emotion-aware variant picking (e.g., "use only angry-sounding instances of this word").
+- Cloud-LLM-first strict-decode mode (cloud APIs that don't expose grammar-constrained decoding are not part of the primary path; see Key Decisions).
+
+**Deferred future enhancements** (documented; not built in v1):
+- **Speaker diarization** — would enable single-speaker corpora and per-speaker word grouping (e.g., "alphabetical of only the interviewer's words"). Could be added later as an optional analysis pass via `pyannote.audio` or by extracting WhisperX's diarization component. Not required for v1; flagged here so the v1 design does not accidentally preclude it.
+
+---
+
+## Key Decisions
+
+- **Foundation = forced alignment as a post-step (Approach B), not WhisperX replacement (Approach C) and not "ship on cross-attention" (Approach A).** Rationale: Approach B surgically fixes accuracy without disturbing the working `faster-whisper` / `lightning-whisper-mlx` transcription path (preserving the Apple Silicon fast path). Approach A's ~50–150ms drift fails the LLM-composed mode's intelligibility bar; rebuilding on Approach B later would require re-doing the splicing-assumptions work.
+- **LLM mode uses strict-at-decode-time constraint, not filter-time substitution.** Rationale: guarantees every emitted word is splicable from the corpus, aligns with the artistic premise (the speaker only ever says words they said), and avoids the substitution mode's drift away from corpus discipline.
+- **Word-timestamp data lives on the existing transcript field; no new entity.** Rationale: minimal schema disruption; existing serialization/migration paths absorb the change naturally; word data is intrinsically transcript-shaped.
+- **Preset-ordering modes and LLM-composed mode ship as two separate algorithms in `core/remix/`, not one mode-flagged algorithm.** Rationale: the input shapes are fundamentally different (presets read inventory; LLM consumes a topic prompt and requires an LLM runtime), and config dialogs would be confusingly overloaded if combined.
+- **Local LLMs (Ollama / llama.cpp) are the primary path for LLM-composed mode.** Rationale: grammar-constrained decoding is not exposed by the major cloud LLM APIs (OpenAI / Anthropic / Gemini); cloud-hosted-inference providers like Together AI and Fireworks AI do support it via API and remain a viable future fallback, but local is the cleanest primary path (offline-capable, no rate limits, no per-query cost during aesthetic iteration).
+
+---
+
+## Dependencies / Assumptions
+
+- A wav2vec2-style alignment model (~360MB–1GB) must be downloadable at first-run and is language-specific; multi-language workflows may require multiple model downloads or per-source language gating.
+- A local LLM runtime with grammar-constrained-decoding support (e.g., `llama.cpp` directly or via a wrapper like Ollama) is assumed available for the LLM-composed mode; UI affordance for that mode is gated on detection of a compatible local LLM through `core/feature_registry.py`.
+- Existing transcription engines produce per-segment or per-word coarse timestamps that the forced-alignment step can use as initial anchors, so alignment doesn't have to align from scratch.
+- The existing `SequenceClip` model fields (`source_id`, `in_point`, `out_point`) are sufficient to express word-level slices; no schema change to that model is anticipated.
+- The render pipeline already correctly handles very short `SequenceClip` durations (sub-second), which it does today for frame-level extraction; word-level slices fall in the same range.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1, R3][Needs research] Which forced-alignment library / model gives the best cross-platform consistency (MPS on Apple Silicon, CUDA on Linux/Windows, CPU fallback) and integrates most cleanly with the existing transcription pipeline? Candidates include `huggingface transformers` wav2vec2 variants, extracting the alignment subset from WhisperX, `ctc-segmentation`, and `aeneas`. Trade-offs span accuracy, install footprint, language coverage, and runtime.
+- [Affects R10–R13][Technical] Which local LLM stack is the right primary target given the existing LiteLLM abstraction? Ollama exposes JSON-schema constraint but limited GBNF; `llama.cpp` directly supports full GBNF; `Outlines` provides grammar-based decoding on top of `transformers`. Integration shape (subprocess, HTTP server, in-process) is a planning decision.
+- [Affects R8][Needs research] How many frames of "handle" should be included before/after each aligned word boundary to avoid clipping plosives even when alignment is accurate to ~20–30ms? A small empirical study (1, 2, 3 frames) on representative speech sources would resolve this; exposing it as a per-run parameter is a reasonable fallback.
+- [Affects R12][Technical] In LLM-composed mode, how is the "vocabulary" presented to the model — as a flat list, as a frequency-weighted list, with part-of-speech tags, with sample sentences? Affects output fluency; pure planning question.
+- [Affects R7][User decision, deferred to planning] For "by-property" mode, what is the default property and what is the user-selectable set (word length / word duration / log frequency / something else)? Defer to planning, ship with a sensible default.

--- a/docs/plans/2026-05-11-001-feat-word-sequencer-plan.md
+++ b/docs/plans/2026-05-11-001-feat-word-sequencer-plan.md
@@ -1,0 +1,602 @@
+---
+title: "feat: Word Sequencer with forced-alignment-augmented transcription"
+type: feat
+status: active
+date: 2026-05-11
+origin: docs/brainstorms/word-sequencer-requirements.md
+---
+
+# feat: Word Sequencer with forced-alignment-augmented transcription
+
+## Summary
+
+This plan delivers the Word Sequencer feature by surfacing `faster-whisper`'s already-computed word timestamps (currently discarded in `core/transcription.py`), adding `ctc-forced-aligner` as an opt-in accuracy upgrade and as the required path for MLX-transcribed sources, building a word-inventory and two new sequencer algorithms in `core/spine/` + `core/remix/`, and wiring the LLM-composed mode through Ollama's existing JSON-schema-enum constraint via `core/llm_client.py` — keeping new dependencies minimal and the LLM stack inside the existing client abstraction.
+
+---
+
+## Problem Frame
+
+See origin: `docs/brainstorms/word-sequencer-requirements.md`. Plan-specific framing: the foundation lift is smaller than the brainstorm assumed because `faster-whisper` already computes word timestamps that the current pipeline throws away (`core/transcription.py:446`, `core/transcription.py:599`). Reclaiming that data covers most non-MLX sources at minimal cost; forced alignment becomes a targeted upgrade rather than the only path.
+
+---
+
+## Requirements
+
+**Word-timestamping foundation**
+- R1. Transcription pipeline gains an optional forced-alignment post-step producing word-level start/end timestamps at ~20–30ms typical error.
+- R2. Forced alignment is opt-in per transcription run; existing transcripts and downstream features remain unaffected when alignment is not run.
+- R3. Existing transcripts can be retro-aligned without re-running the transcription engine.
+- R4. Per-word timestamp data is stored as structured data on the existing transcript field; no new top-level entity is introduced.
+- R5. Forced alignment is language-aware; if the source's language is not supported, the feature surfaces a clear message and the source is unavailable to the Word Sequencer.
+
+**Sequencer — preset ordering modes**
+- R6. A new sequencer operates on user-selected source(s) and produces `SequenceClip[]` whose entries reference word-level slices.
+- R7. Five preset modes selectable from the config dialog: **alphabetical** (every word in the corpus in lexical order); **chosen-words** (subset filter — keep only instances of words on the user-supplied include list; output is grouped by include-list order, all instances of word A then all instances of word B, etc., with no repeats from the user list); **by-frequency** (every word ordered most-frequent → least-frequent, or reverse); **by-property** (word length, word duration, or other word-derived metric); **user-curated ordered list** (user supplies an exact word sequence — including repeats — that the algorithm materializes literally, e.g., `["the", "the", "the", "sky"]`). chosen-words and user-curated differ in two ways: (1) chosen-words plays *every* instance of the listed words, user-curated plays *one slot per list entry*; (2) chosen-words is grouped by include-list word, user-curated is verbatim.
+- R8. Output `SequenceClip` entries have in/out points set to aligned word boundaries; joins are raw hard cuts (no crossfade, no smoothing, no held frames).
+- R9. If a selected source has no aligned word data, the sequencer surfaces the missing alignment and offers to run alignment before producing the sequence.
+
+**Sequencer — LLM-composed mode**
+- R10. A separate algorithm accepts a user-provided prompt and produces a sentence/paragraph whose every word is drawn from the corpus inventory.
+- R11. Vocabulary constraint is enforced at decode time via Ollama's JSON-schema-enum mechanism (Tier 1); GBNF (Tier 2) is deferred.
+- R12. Generated word sequence is materialized into `SequenceClip[]` by mapping each word to a corpus instance.
+- R13. When a generated word has multiple corpus instances, the algorithm uses a configurable selection policy (default: round-robin).
+
+**Integration**
+- R14. The sequencer integrates with the existing Sequence tab and follows the existing algorithm config-dialog pattern.
+- R15. Output is consumable by the existing render pipeline without changes.
+- R16. New heavy ML deps install on demand through `core/feature_registry.py`.
+
+**Origin actors:** A1 (filmmaker/artist), A2 (LLM)
+**Origin flows:** F1 (alphabetical word film), F2 (LLM-composed sentence-collage)
+**Origin acceptance examples:** AE1 (covers R5, unsupported language), AE2 (covers R9, missing alignment), AE3 (covers R13, round-robin instance selection), AE4 (covers R11, no OOV emission)
+
+---
+
+## Scope Boundaries
+
+- Sub-word / phoneme-level cuts.
+- Audio crossfades, freeze-frames, or join smoothing.
+- Project-wide / arbitrary-clip corpus selection (corpus is always one or more chosen sources).
+- Replacing the existing transcription stack with WhisperX or any single canonical pipeline.
+- "Say it like this" / prosody-aware variant picking.
+- Cloud-LLM strict-decode path (major cloud APIs don't expose decode-time grammar).
+- Render pipeline changes (per R15).
+
+### Deferred to Follow-Up Work
+
+- **Tier 2 grammar-constrained decoding via `llama-cpp-python` GBNF.** Deferred to a follow-up plan, gated on validation that Tier 1 (Ollama JSON-schema enum) is too slow at production corpus scales (see Open Questions). New `feature_registry` entry name reserved (`constrained_decoding_grammar`) but not implemented.
+- **Speaker diarization.** Deferred at brainstorm tier; would enable single-speaker corpora and per-speaker word grouping. Plan-time decision: do not preclude it — `Source` and `Clip` already have IDs that future diarization can attach per-segment.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `core/transcription.py:446, 599` — `faster-whisper` is already called with `word_timestamps=True`; the per-word `.words` list is currently unused.
+- `core/transcription.py:257` — `TranscriptSegment` dataclass lives here (NOT in `models/clip.py`, which only TYPE_CHECKING-imports it). Current fields: `start_time / end_time / text / confidence`. Round-trip via `to_dict` (line 268) / `from_dict` (line 275). `models/clip.py:261` references it via forward declaration on `Clip.transcript: Optional[list["TranscriptSegment"]]`.
+- `core/remix/staccato.py` — canonical sequencer-algorithm pattern: pure function, no Qt imports, input is `list[(Clip, Source)]`, output is algorithm-specific data that the dialog converts to `SequenceClip[]`.
+- `ui/dialogs/staccato_dialog.py` — canonical algorithm-dialog pattern: modal `QDialog`, owns its `CancellableWorker`, calls `check_feature_ready` + `install_for_feature` inside the worker, builds final `Sequence` and assigns via `project.sequence = ...`.
+- `ui/algorithm_config.py` — algorithm registration with keys `label`, `description`, `required_analysis`, `is_dialog`, `categories`, `allow_duplicates`.
+- `ui/workers/transcription_worker.py` — analysis-worker reference: `ThreadPoolExecutor` but forces serial when backend is `mlx-whisper` (not thread-safe). Pre-loads model with progress reporting. Same constraints apply to forced alignment.
+- `core/feature_registry.py:172` (`FEATURE_DEPS`), `:203` (`transcribe_mlx` reference entry), `:72-123` (`_validate_feature_runtime`) — pattern for new heavy-dep features. Must mirror in `core/dependency_manager.py`.
+- `core/llm_client.py` — `ProviderType.LOCAL` exists, default model `qwen3:8b`, `check_ollama_health()` at line 201, `complete_with_local_fallback()` at line 495. JSON-mode supported; no grammar/logit-bias passthrough today.
+- `core/spine/` + `tests/test_spine_imports.py` — boundary test forbids top-level imports of PySide6, mpv, av, faster_whisper, paddleocr, mlx_vlm in spine modules. Heavy imports must be inside function bodies.
+- `core/project.py:620+` — `project.sequences`, `project.sequence` getter/setter; sequence-builders assign via `project.sequence = new_seq`, observers fire automatically.
+- `.claude/rules/sequencer-algorithms.md` — sequencer-algorithm registry rules.
+- `.claude/rules/ui-consistency.md` — UI sizing (32px min heights, 140px label width, wrap forms in `QScrollArea`).
+
+### Institutional Learnings
+
+- `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md` — new workers need the guard-flag-plus-`Qt.UniqueConnection` pattern; reset the guard at click-start so re-runs work.
+- `docs/solutions/ui-bugs/cut-tab-clips-hidden-after-thumbnail-failure.md` — sub-second FFmpeg cuts fail with fractional/rational timestamps. Normalize all word boundaries to finite decimal seconds before constructing FFmpeg args.
+- `docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md` — route everything through the single canonical `Sequence`; no parallel widget-local copies.
+- `docs/solutions/logic-errors/circular-import-config-consolidation.md` — registering the new algorithm in both `ui/algorithm_config.py` and `ui/widgets/sorting_card_grid.py` (if separate `ALGORITHMS` registry exists) requires extraction to a neutral module first.
+- `docs/solutions/security-issues/ffmpeg-path-escaping-20260124.md` — LLM-composed sentence stems could produce shell metacharacters; use the existing FFmpeg escape helper.
+- `docs/solutions/runtime-errors/macos-libmpv-pyav-ffmpeg-dylib-collision-20260504.md` — keep `torch`/`transformers` lazy-imported inside function bodies in spine modules; top-level heavy imports break the spine boundary test and risk macOS dyld collisions.
+- `docs/solutions/reliability-issues/subprocess-cleanup-on-exception.md` — Ollama / FFmpeg subprocesses must wrap iteration in `try/finally` with explicit kill + wait; sequence cancellation with hundreds of words otherwise orphans processes.
+
+### External References
+
+- `ctc-forced-aligner` (MahmoudAshraf97) — chosen forced-alignment library; cleaner standalone API than WhisperX, multilingual via Meta MMS, CPU/CUDA support. CPU-only on Apple Silicon (MPS wav2vec2 is unreliable in 2026; force fp32).
+- Ollama `format` parameter — JSON-schema-enum mode enforces token-level constraints; Ollama has explicitly closed all arbitrary-GBNF PRs (issue #6237, PR #1606), so `format`+enum is the only constrained-decoding API through Ollama. Non-parallelized masking → validate latency empirically at corpus scale.
+- LiteLLM has no `grammar` passthrough parameter but does forward `response_format`. May need to bypass LiteLLM and call Ollama's `/api/generate` directly for the `format` parameter — verify during U5.
+
+---
+
+## Key Technical Decisions
+
+- **Surface faster-whisper's discarded word data as the cheap default; layer `ctc-forced-aligner` as opt-in upgrade and as required path for MLX-transcribed sources.** Rationale: `core/transcription.py` already computes the data; reclaiming it covers non-MLX sources at zero compute cost. Forced alignment becomes a quality knob, not a hard prerequisite.
+- **`ctc-forced-aligner` (over WhisperX, torchaudio, Outlines, aeneas).** Rationale: purpose-built for the "I have a transcript; align it" path, healthier maintenance than torchaudio's deprecating forced-alignment APIs, cleaner Python integration than WhisperX (no Whisper-engine coupling).
+- **Strict-decode via Ollama `format`+JSON-schema-enum for v1; `llama-cpp-python` GBNF deferred.** Rationale: zero new dependencies, works through the existing `core/llm_client.py` Ollama provider. Tier 2 is the documented escape hatch if Tier 1 perf is unacceptable at corpus scales.
+- **CPU-only alignment on Apple Silicon; force fp32.** Rationale: PyTorch MPS support for wav2vec2 forced-alignment is flaky in 2026. Promising MPS would mislead users; CPU on M-series is acceptable for typical short-corpus runs.
+- **Spine layout: alignment runtime in `core/analysis/alignment.py`; inventory + ordering + composer plumbing in `core/spine/words.py`; thin algorithm wrappers in `core/remix/`.** Rationale: keeps `core/spine/words.py` reusable from the MCP server (and future agent tools) without GUI or heavy-ML coupling; `core/analysis/alignment.py` can do top-level heavy imports because it's not spine-boundary-restricted; `core/remix/` wrappers match `staccato.py` shape so the algorithm registry treats this like any other sequencer.
+- **Schema upgrade: extend `TranscriptSegment` with optional `words: list[WordTimestamp]`; no new top-level entity (per R4).** Rationale: backward-compatible serialization; word data is intrinsically transcript-shaped.
+- **Register both algorithms with `is_dialog=True`.** Rationale: a known footgun (CLAUDE.md "sequence overwrite by generic handlers") affects dialog sequencers when the generic non-dialog handler also runs.
+- **Default handle-frame count = 0** (truly raw cuts, per brainstorm), exposed as a dialog parameter for user experimentation.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Which forced-alignment library?** → `ctc-forced-aligner`.
+- **Which local LLM stack for strict-decode?** → Ollama with `format`+JSON-schema-enum (Tier 1); `llama-cpp-python` GBNF deferred.
+- **Default by-property mode?** → Word length, ascending. User-selectable: length / duration / log-frequency, with ascending/descending companion select.
+- **Vocabulary presentation to LLM?** → Flat list with frequency annotations in the system prompt.
+- **Default handle-frame count?** → 0 (raw); exposed as dialog spinner.
+- **Where does the alignment runtime live?** → `core/analysis/alignment.py` (not spine — can import heavy deps at module level).
+- **Where does `WordTimestamp` live?** → Colocated with `TranscriptSegment` in `core/transcription.py:257`. `models/clip.py` only TYPE_CHECKING-imports it, so a new dataclass added there would create a circular import. (Closes a feasibility finding.)
+- **How is the source-language signal captured for MLX clips?** → `_parse_mlx_result` already reads `result["language"]` and discards it; U1 captures it into `TranscriptSegment.language`. Same field receives the faster-whisper detected language from the previously-discarded `info` object. (Closes a feasibility finding.)
+- **Alignment audio strategy: per-clip extracted WAV vs full-source audio?** → Per-clip, matching `transcribe_clip`'s existing pattern at `core/transcription.py:560–578`. `WordTimestamp.start/end` are clip-relative seconds — same frame of reference as `TranscriptSegment.start_time`. (Closes a feasibility finding.)
+- **Word-boundary-to-frame conversion convention?** → Floor on `in_point`, ceil on `out_point` (keeps the consonant onset and offset audible); all intermediate math in `float` after explicit `Fraction` conversion; handle-frame padding clamped to clip bounds. See U4 Approach. (Closes a feasibility finding.)
+- **Clip-boundary attribution for words straddling a Clip?** → Not reachable: alignment runs per-clip, so every word is intrinsically attributed to its parent clip. (Closes a feasibility finding.)
+- **How are repeated mode entries handled (`by_frequency(reverse=False)` ambiguity)?** → Renamed to `order: Literal["descending", "ascending"]` to eliminate boolean ambiguity. (Closes a coherence finding.)
+- **Algorithm registration ownership across U4/U5/U6?** → U4 owns `word_sequencer` registration; U5 owns `word_llm_composer` registration; U6 does not modify `ui/algorithm_config.py` at all. (Closes a coherence finding.)
+- **`METADATA_CHECKS` updates?** → U4 adds `transcription_with_words` to `core/cost_estimates.py`'s METADATA_CHECKS, OPERATION_LABELS, TIME_PER_CLIP, COST_PER_CLIP so the cost-confirmation gate surfaces the new dependency. `local_llm` is *not* in `required_analysis` — Ollama health is a runtime check, not per-clip metadata. (Closes a feasibility finding.)
+- **Dialog UX conventions (source picker shape, conditional field visibility, error display, missing-alignment behavior, empty-corpus state, Ollama-absent state)?** → All specified in U6 "Shared dialog conventions". (Closes the design-lens findings.)
+- **`chosen-words` vs `user-curated ordered list` semantic distinction?** → chosen-words is a subset filter that emits every instance of each listed word grouped by include-list order; user-curated is a verbatim materialization of an exact word sequence with one slot per entry, repeats allowed. R7 carries the full definition; U4 implements as two distinct functions (`by_chosen_words` vs `from_word_list`). (Closes a coherence finding.)
+- **U4's dependency on U3?** → U4 has a data-shape dependency on U1 (uses the new `WordTimestamp` and `language` fields) but only a runtime-data dependency on U3 (the worker that populates words). `core/spine/words.py` does not import the U3 worker, and U4 can be implemented + tested against mocked `Clip.transcript[*].words`. (Closes a coherence finding.)
+- **Retroactive alignment skip granularity?** → Per-clip (re-align if any `TranscriptSegment.words is None`). See U3 Approach. (Closes a feasibility finding.)
+- **`ui/algorithm_config.py` neutral module?** → Verified during planning to already exist. Both `ui/tabs/sequence_tab.py` and `ui/widgets/sorting_card_grid.py` consume from it. No pre-extraction work needed.
+
+### Deferred to Implementation
+
+- **[Affects U5][Needs validation] Ollama enum-constraint latency at corpus scale.** With ~5000-item enums, masking is non-parallelized in current Ollama builds; if generation latency is unacceptable for typical artistic corpora (single 5-minute speech → ~500 unique words; multiple sources → 2000–5000 unique words), Tier 2 (`llama-cpp-python` GBNF) becomes a follow-up plan. Measure during U5 implementation; document findings. **Go/no-go threshold for v1 ship:** for a 1000-word corpus and a 20-word target, full-sentence generation should complete under ~30s on `qwen3:8b` on representative hardware. Slower than that → flag for Tier 2.
+- **[Affects U5][Technical] Does LiteLLM strip Ollama's `format` parameter?** If LiteLLM doesn't forward `format` to Ollama, call `/api/generate` directly (still through `core/llm_client.py` as an Ollama-specific helper). Verify by inspecting LiteLLM's Ollama provider during U5; fall back to direct HTTP if needed.
+- **[Affects U4][Needs research-at-impl-time] Word normalization** (case, punctuation, contractions). Start with lowercase + strip surrounding ASCII punctuation, contractions intact (`"don't"` is one word); revisit if grouping behavior is surprising.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```
+Source video
+    │
+    ▼
+Transcribe (existing: faster-whisper / lightning-whisper-mlx)
+    │
+    ├─ faster-whisper path ─► capture .words AND info.language    ◄── U1
+    └─ mlx-whisper path ────► capture result["language"]; words=None
+    │
+    ▼
+TranscriptSegment.words (Optional)
+TranscriptSegment.language (Optional)                             ◄── U1 schema
+    │
+    ▼
+(optional for faster-whisper / required for MLX)
+Forced alignment post-step                                        ◄── U2, U3
+   ctc-forced-aligner: per-clip extracted WAV
+   → list[WordTimestamp], clip-relative seconds
+   language read from segments[0].language
+    │
+    ▼
+Word inventory build                                              ◄── U4
+   build_inventory(clips: list[(Clip, Source)]) -> WordInventory
+   { by_word: {normalized: [WordInstance]},
+     by_clip: {clip_id: [WordInstance]} }
+    │
+    ├──► Preset modes                                             ◄── U4
+    │       alphabetical / by_chosen_words / by_frequency /
+    │       by_property / from_word_list
+    │       │
+    │       ▼
+    │     list[WordInstance]  ───►  SequenceClip[]
+    │                                 (floor(start*fps)/ceil(end*fps) frames,
+    │                                  clip-relative, handle padding clamped)
+    │
+    └──► LLM-composed mode                                        ◄── U5
+            Ollama format=JSON-schema-enum(corpus)
+            → {"words": [...]}
+            │
+            ▼
+          map each emitted word → WordInstance via repeat-policy
+            │
+            ▼
+          SequenceClip[]
+    │
+    ▼
+project.sequence = Sequence(tracks=[Track(clips=SequenceClip[])])
+    │
+    ▼
+existing render pipeline (unchanged — R15)
+```
+
+---
+
+## Implementation Units
+
+### U1. TranscriptSegment word-data schema, language capture, and surface faster-whisper's existing word timestamps
+
+**Goal:** Extend `TranscriptSegment` (which lives in `core/transcription.py:257`) with optional `words` and `language` fields, round-trip them through serialization, capture the per-word data already returned by `faster-whisper`, and capture the detected source language from both backends so forced alignment in U2 has a reliable signal.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `core/transcription.py` (add `WordTimestamp` dataclass colocated with `TranscriptSegment` at line 257; add `words: Optional[list[WordTimestamp]]` and `language: Optional[str]` fields to `TranscriptSegment`; update `to_dict` line 268 and `from_dict` line 275; at line 445 and 599 capture `.words` from `faster-whisper` segments into `WordTimestamp` objects; capture `info.language` from `faster-whisper`'s `info` object — currently discarded — and `result["language"]` from `_parse_mlx_result` at line 626)
+- Modify: `models/clip.py` (no field changes; existing TYPE_CHECKING import at line 15 picks up the new `TranscriptSegment` shape automatically; verify the `from_dict` path at line 493–508 forwards the new fields through `TranscriptSegment.from_dict` unchanged)
+- Test: `tests/test_transcription.py` (TranscriptSegment serialization round-trip with words + language; faster-whisper word_timestamps population; MLX language capture)
+
+**Approach:**
+- New `@dataclass WordTimestamp(start: float, end: float, text: str, probability: Optional[float] = None)` colocated with `TranscriptSegment` in `core/transcription.py`. Keep `probability` optional because forced alignment surfaces a different confidence metric than `faster-whisper`.
+- `TranscriptSegment.words: Optional[list[WordTimestamp]]` — `None` means "no word data surfaced yet for this segment" (MLX case before alignment, or pre-feature project files). Empty list `[]` means "we tried alignment and produced no words" (rare — silence/instrumental). The two are deliberately not conflated.
+- `TranscriptSegment.language: Optional[str]` — ISO 639-1 code (e.g., `"en"`, `"fr"`). `None` only when neither backend produced one (older project files). faster-whisper's `info.language` and MLX's `result["language"]` populate it. Single value per segment because both backends produce one language per call; per-segment storage means future per-segment diarization can override without schema change.
+- `from_dict` accepts the absence of either field (back-compat with old project files).
+- In `core/transcription.py:445` (faster-whisper `transcribe_video`) and `:599` (faster-whisper `transcribe_clip`), the loop building `TranscriptSegment` objects also constructs a `WordTimestamp` per word from segment `.words` and stores `info.language` (returned by faster-whisper's `transcribe()` alongside segments) into every segment from that call.
+- In `_parse_mlx_result` at `:626`, read `result["language"]` (currently unused) and write it onto every emitted `TranscriptSegment`. The MLX backend still leaves `words = None` — alignment fills that in U2.
+
+**Execution note:** Test the serialization round-trip first — old-format files must still load.
+
+**Patterns to follow:**
+- Existing `TranscriptSegment` shape and `to_dict` / `from_dict` style.
+
+**Test scenarios:**
+- Happy path: A `TranscriptSegment` constructed with a list of `WordTimestamp` and `language="en"` round-trips through `to_dict` → `from_dict` identically.
+- Happy path: An old-format dict (no `words` and no `language` keys) deserializes to a `TranscriptSegment` with `words = None` and `language = None`.
+- Happy path: After `transcribe_video()` with the faster-whisper backend on an English source, every `TranscriptSegment` has a non-empty `words` list AND `language = "en"`.
+- Happy path: After `transcribe_video()` with the MLX backend on a French source, every `TranscriptSegment` has `words = None` AND `language = "fr"` (language was previously discarded; this is the fix).
+- Edge case: A `Clip` with `transcript = None` continues to serialize/deserialize correctly (no regression on clips without transcripts).
+- Edge case: `words = []` (empty list — alignment ran but produced no words) is preserved across round-trip and distinguished from `words = None`.
+
+**Verification:**
+- Loading an existing project from disk works unchanged.
+- `tests/test_spine_imports.py` continues to pass (schema change adds dataclass fields only; no new heavy imports).
+- After `transcribe_video()` runs on a fresh MLX-backend source, that source is now ready for U2 alignment without the user supplying a language argument (the segment carries it).
+
+---
+
+### U2. Forced-alignment runtime module
+
+**Goal:** Implement `align_words(audio_path, transcript_segments, language) -> list[WordTimestamp]` using `ctc-forced-aligner`. Register the heavy dep through `core/feature_registry.py`.
+
+**Requirements:** R1, R3, R5
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `core/analysis/alignment.py`
+- Modify: `core/feature_registry.py` (add `word_alignment` entry to `FEATURE_DEPS`; add `ensure_word_alignment_runtime_available()` branch in `_validate_feature_runtime`)
+- Modify: `core/dependency_manager.py` (mirror the new feature entry)
+- Test: `tests/test_alignment.py`
+
+**Approach:**
+- Pure module — no Qt, no project imports. Inputs are paths and pure-data segments; output is pure-data words.
+- Public API: `align_words(audio_path: str, transcript_segments: list[TranscriptSegment]) -> list[WordTimestamp]`. **Language is read off `transcript_segments[0].language`** (which U1 populates from both backends). When `language is None` (only true for legacy project files predating U1), raise `LanguageUnknownError` with the hint to re-transcribe; do not silently default to English. On a language the alignment model doesn't support, raise `UnsupportedLanguageError(language=...)`.
+- **Audio strategy: per-clip extracted WAV, matching the existing `transcribe_clip` pattern at `core/transcription.py:560–578`.** Per-clip extraction means `WordTimestamp.start` / `WordTimestamp.end` are **clip-relative seconds** (the same frame of reference as `TranscriptSegment.start_time`), which preserves the existing transcript-time contract and avoids a source-vs-clip offset translation later. Trade-off: one FFmpeg pass per clip vs one per source. Accepted because (a) it mirrors existing transcription behavior, (b) per-clip cancellation is naturally granular, and (c) clip-boundary attribution becomes trivial (every word belongs to the clip whose audio produced it).
+- `ctc-forced-aligner` and `torch` imports go inside the function body (avoids paying their startup cost when this module is loaded but not used; also keeps the module importable without the heavy deps for unit tests that mock the engine).
+- Force fp32 on Apple Silicon; do not attempt MPS — MPS wav2vec2 is unreliable in 2026.
+- Model download via `feature_registry.install_for_feature("word_alignment", progress_cb)` on first use.
+
+**Patterns to follow:**
+- `core/analysis/audio.py` — analysis module with lazy heavy-dep imports, clean public API.
+- `core/feature_registry.py:203` (`transcribe_mlx`) — native-install gating pattern.
+
+**Test scenarios:**
+- Happy path: align a known short clip-audio + transcript with the model mocked → returns a list of `WordTimestamp` whose count matches the transcript word count. Timestamps are clip-relative seconds (start of clip = 0.0).
+- Happy path: word boundaries returned are within `[0, clip_duration]` (no times beyond clip audio length).
+- Happy path: language is read from `segments[0].language` (`"en"`) and passed to the alignment model.
+- Edge case: empty transcript → returns empty list (no model load attempted, no FFmpeg extract).
+- Edge case: very short clip audio (< 1 s) does not crash.
+- Error path: `segments[0].language is None` raises `LanguageUnknownError` (legacy transcript pre-U1).
+- Error path: unsupported language (e.g., a language outside the MMS multilingual coverage) raises `UnsupportedLanguageError` with the language name. *Covers AE1.*
+- Error path: missing model triggers `install_for_feature` (mock the install path).
+- Integration: per-clip audio is extracted by FFmpeg, alignment runs, FFmpeg temp WAV is cleaned up afterward (no leftover temp files).
+
+**Verification:**
+- Module imports successfully on a clean Python env without `ctc-forced-aligner` installed (lazy-import contract holds).
+- `core/feature_registry.py` correctly detects the `word_alignment` feature as missing/installed.
+
+---
+
+### U3. ForcedAlignmentWorker and project-level wiring
+
+**Goal:** A new `CancellableWorker` subclass that runs alignment over a list of sources, surfaces progress, populates `TranscriptSegment.words` through the project, and is safe to cancel mid-run.
+
+**Requirements:** R1, R2, R3, R5, R9
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Create: `ui/workers/forced_alignment_worker.py`
+- Modify: `ui/tabs/analyze_tab.py` (add "Run word-level alignment" affordance — or wherever transcription is run today; locate the existing transcription trigger and add the alignment action adjacent to it)
+- Test: `tests/test_forced_alignment_worker.py`
+
+**Approach:**
+- Inherits `CancellableWorker` (`ui/workers/base.py`).
+- Signals: `progress(int, int)`, `clip_aligned(str, list)` (`clip_id`, `WordTimestamp` list as data), `alignment_completed()`, inherited `error(str)`.
+- Serial per-clip (alignment is CPU-bound on Mac; not thread-safe per `core/analysis/alignment.py`).
+- Pre-load the alignment model with progress reporting before the work loop (pattern from `ui/workers/transcription_worker.py:162-174`).
+- Calls `core.feature_registry.check_feature_ready("word_alignment")` and `install_for_feature("word_alignment", ...)` inside the worker before starting.
+- **Skip predicate (per-clip granularity):** for each clip, run alignment when *any* `TranscriptSegment.words is None`. When all segments already have `words` (even empty lists), skip the clip entirely — its alignment is fresh. This is per-clip not per-segment because alignment-per-clip is the FFmpeg-extract granularity from U2; reusing a model-loaded process to re-align only some segments of the same clip is more complex than it's worth. Edge case: if a prior cancellation interrupted *between segments of the same clip*, the clip has a mix of populated and `None` segments — current rule re-aligns the whole clip, which is correct (idempotent re-alignment produces the same word boundaries).
+- After each clip alignment, the worker emits `clip_aligned(clip_id, words)` and the main thread writes the words back through the project (use the existing pattern for project mutation — never mutate models directly from the worker).
+- Uses `Qt.UniqueConnection` on the `finished` signal handler and a guard flag pattern to prevent duplicate signal delivery on re-runs (per `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`).
+- On a worker rerun, reset the guard flag at click-start so re-runs work.
+
+**Execution note:** Write a failing test for the cancel-mid-run signal contract first.
+
+**Patterns to follow:**
+- `ui/workers/transcription_worker.py` (model preload + per-item processing + serial-execution constraint).
+- Guard-flag-plus-`Qt.UniqueConnection` from the QThread-destroyed-duplicate-signal-delivery learning.
+
+**Test scenarios:**
+- Happy path: Worker processes 3 clips → emits `clip_aligned` three times, then `alignment_completed` once.
+- Happy path: `progress(i, total)` emits incrementally across the run.
+- Edge case: Empty clip list → emits `alignment_completed` immediately without any `clip_aligned`.
+- Error path: `worker.cancel()` called mid-run → no further `clip_aligned` signals; `finished` still fires exactly once; cleanup runs.
+- Error path: alignment raises inside the worker → `error(message)` emits; `alignment_completed` does not fire; the worker is clean for reuse on next run.
+- Integration: After a successful run, the affected `TranscriptSegment.words` is populated on the project (project observer fires).
+- Integration: Re-running on already-aligned sources is a no-op (no model re-load if the data is fresh).
+
+**Verification:**
+- Cancelling a 100-clip alignment partway through leaves the partial results persisted (no all-or-nothing semantics — partial progress is real progress).
+- `Qt.UniqueConnection` is in place on the finished handler; double-clicking "Run alignment" doesn't double-fire downstream effects.
+
+---
+
+### U4. Word inventory + preset-modes algorithm + algorithm registration
+
+**Goal:** Build `core/spine/words.py` (inventory + ordering modes), the thin remix wrapper `core/remix/word_sequencer.py` that materializes mode output into `SequenceClip[]`, and register the algorithm canonically (this unit *owns* the `word_sequencer` registration end-to-end — U6 does not re-touch it).
+
+**Requirements:** R6, R7, R8, R9, R14
+
+**Dependencies:** U1 (data-shape dependency). U3 is a runtime-data prerequisite (clips must be aligned before the algorithm produces useful output) but **not** a code dependency — `core/spine/words.py` does not import the U3 worker, and U4 can be implemented and tested before U3 lands by mocking `Clip.transcript[*].words`.
+
+**Files:**
+- Create: `core/spine/words.py`
+- Create: `core/remix/word_sequencer.py`
+- Modify: `ui/algorithm_config.py` — register `word_sequencer` with `label="Word Sequencer"`, `is_dialog=True`, `required_analysis=["transcription_with_words"]`, `categories=["word", "experimental"]`, `allow_duplicates=False`. **This is the authoritative registration; no later unit modifies this entry.**
+- Modify: `core/cost_estimates.py` — add the `transcription_with_words` entries: a `METADATA_CHECKS["transcription_with_words"]` lambda (`lambda clip: bool(clip.transcript and any(seg.words for seg in clip.transcript))`), an `OPERATION_LABELS["transcription_with_words"]` label (e.g., `"Word-level alignment"`), and conservative `TIME_PER_CLIP` / `COST_PER_CLIP` rows so the cost-confirmation gate surfaces this dependency. Without these entries the gate silently skips the new algorithm.
+- Test: `tests/test_spine_words.py`
+- Test: `tests/test_word_sequencer.py`
+- Test: `tests/test_cost_estimates.py` (or wherever cost-estimate tests live — add a case proving the new key is recognized)
+
+**Approach:**
+
+*Input contract — clips, not sources.* The Sequence tab's dispatch (`ui/tabs/sequence_tab.py:1426` for the staccato pattern) hands the dialog `list[(Clip, Source)]`. The word sequencer accepts the same shape; **the corpus is the *selected clips' words*, not "every word in the source"**. This is the simpler product semantics: "make a word film from these clips I selected" rather than "make a word film from every source that happens to have at least one clip selected". The dialog deduplicates `Source` instances internally for the alignment-gating step.
+
+*`core/spine/words.py`:*
+  - `@dataclass WordInstance(source_id: str, clip_id: str, segment_index: int, word_index: int, start: float, end: float, text: str)`. `start` / `end` are **clip-relative seconds** (the same frame of reference as `TranscriptSegment.start_time` set by U2's per-clip alignment).
+  - `@dataclass(frozen=True) WordInventory(by_word: dict[str, list[WordInstance]], by_clip: dict[str, list[WordInstance]])` — both indices are populated at build time so callers can iterate either way without re-walking the data.
+  - `build_inventory(clips: list[tuple[Clip, Source]]) -> WordInventory`. Word normalization: lowercase + strip surrounding ASCII punctuation; preserve original `text` on the instance. Contractions stay as-is (`"don't"` is one word, not `"do"` + `"n't"`) — `faster-whisper`'s tokenizer already commits to that.
+  - Mode functions:
+    - `alphabetical(inv) -> list[WordInstance]` — lexical order over `inv.by_word.keys()`, then encounter order within each word.
+    - `by_chosen_words(inv, include: list[str]) -> list[WordInstance]` — emits every instance of each listed word, **grouped by include-list order**. Unknown words in `include` are silently dropped (no error — the dialog can preview which were dropped). This is "play every 'never', then every 'always', then every 'silence'."
+    - `by_frequency(inv, order: Literal["descending", "ascending"] = "descending") -> list[WordInstance]` — named keyword (not `reverse=` bool) to remove ambiguity about what `False` means. Default emits most-frequent first.
+    - `by_property(inv, key: Literal["length", "duration", "log_frequency"], order: Literal["descending", "ascending"] = "ascending") -> list[WordInstance]` — default emits shortest first when `key="length"`.
+    - `from_word_list(inv, sequence: list[str], on_missing: Literal["skip", "raise"] = "skip") -> list[WordInstance]` — literal materialization of `sequence`, one slot per entry, repeats allowed (e.g., `["the","the","the","sky"]` produces 4 slots). Instance picked per the higher-layer repeat policy (round-robin / random / etc.).
+  - No top-level imports of PySide6, mpv, av, faster_whisper, paddleocr, mlx_vlm — verify against `tests/test_spine_imports.py`.
+
+*`core/remix/word_sequencer.py`:*
+  - `generate_word_sequence(clips, mode, mode_params, handle_frames=0) -> list[SequenceClip]`.
+  - **Frame conversion convention (committed):**
+    - Source fps is the source of truth. Read from `Source.fps`; if missing, raise rather than guess.
+    - `WordTimestamp.start_clip_relative_seconds` → `clip_relative_in_seconds = max(0.0, start - (handle_frames / fps))`.
+    - `WordTimestamp.end_clip_relative_seconds` → `clip_relative_out_seconds = min(clip_duration_seconds, end + (handle_frames / fps))`.
+    - Convert to integer frames: `in_point = floor(clip_relative_in_seconds * fps)` (keep the consonant onset audible).
+    - `out_point = ceil(clip_relative_out_seconds * fps)` (keep the consonant offset audible).
+    - All intermediate math uses Python `float` after explicit conversion from any `Fraction` (per the FFmpeg-fractional-duration learning).
+    - `SequenceClip.source_clip_id` is the parent `Clip.id`; `SequenceClip.source_id` is `Clip.source_id`.
+    - Clip-boundary attribution is implicit because alignment runs per-clip in U2: every `WordInstance` already belongs to exactly one clip. No straddling case.
+  - Validates all selected clips have aligned word data (`all(seg.words is not None for seg in clip.transcript or [])`); raises `MissingWordDataError(clip_ids=[...])` if any are missing. The dialog catches this and triggers alignment.
+
+**Patterns to follow:**
+- `core/remix/staccato.py` (pure function, no Qt, returns algorithm-shaped data).
+- Spine module boundary discipline.
+
+**Test scenarios:**
+- Happy path: Inventory built from 2 clips spanning 1 source with known segment+word data shows correct grouping by normalized word and correct `by_clip` index.
+- Happy path: `alphabetical` returns word instances in lexical order over `by_word` keys.
+- Happy path: `by_frequency(order="descending")` returns most-frequent word first; `order="ascending"` reverses it.
+- Happy path: `by_property(key="length")` defaults to ascending (shortest first); explicit `order="descending"` reverses.
+- Happy path: `by_chosen_words(["never", "always"])` returns every instance of "never" (grouped together), then every instance of "always" — preserving include-list order.
+- Happy path: `from_word_list(["the", "the", "the", "sky"])` returns exactly 4 instance slots in that order.
+- Edge case: Empty `clips` list → empty inventory → empty result list; no crash.
+- Edge case: `by_chosen_words(["xyz"])` where "xyz" is not in corpus → empty result (silent drop is the default; no exception).
+- Edge case: `from_word_list(..., on_missing="raise")` with missing words raises `MissingWordsError` listing the absentees.
+- Edge case: Word boundary at clip start (`start = 0.0`) with `handle_frames=2` — `in_point` clamps to 0 (not negative).
+- Edge case: Word boundary at clip end with `handle_frames=2` — `out_point` clamps to `clip_duration * fps` (not past the end).
+- Edge case: Source with `fps` missing raises with a clear message (no silent default).
+- Edge case: Word with `start == end` (zero-duration word — rare ASR artifact) is dropped, not materialized as a 0-frame `SequenceClip`.
+- Error path: `generate_word_sequence` called on a `Clip` with any `TranscriptSegment.words = None` raises `MissingWordDataError(clip_ids=[...])`. *Covers AE2 (the dialog catches this and triggers alignment).*
+- Integration: `tests/test_spine_imports.py` passes (no spine boundary violation).
+- Integration: `core/cost_estimates.py` recognizes the `transcription_with_words` key (test in `tests/test_cost_estimates.py` confirms the cost gate surfaces it).
+
+**Verification:**
+- Running the full pipeline on a 30-second test source produces a valid `SequenceClip[]` whose timing maps to expected frame boundaries.
+- Spine boundary test continues to pass.
+
+---
+
+### U5. LLM-composed mode algorithm + algorithm registration
+
+**Goal:** Add the LLM word composer to `core/spine/words.py` and the remix wrapper `core/remix/word_llm_composer.py`. Use Ollama's `format`+JSON-schema-enum for strict vocabulary constraint. Register the algorithm canonically (this unit *owns* the `word_llm_composer` registration — U6 does not re-touch it).
+
+**Requirements:** R10, R11, R12, R13, R14
+
+**Dependencies:** U4
+
+**Files:**
+- Modify: `core/spine/words.py` (add `compose_with_llm(inventory, prompt, target_length, repeat_policy, seed=None) -> list[WordInstance]`)
+- Modify: `core/llm_client.py` (add `complete_with_enum_constraint(prompt, vocabulary, ...)` helper; may need to bypass LiteLLM and call Ollama's `/api/generate` directly with `format` payload if LiteLLM strips the parameter)
+- Create: `core/remix/word_llm_composer.py`
+- Modify: `ui/algorithm_config.py` — register `word_llm_composer` with `label="LLM Word Composer"`, `is_dialog=True`, `required_analysis=["transcription_with_words"]`, `categories=["word", "experimental", "llm"]`, `allow_duplicates=False`. **This is the authoritative registration; no later unit modifies this entry.** Note: `local_llm` does NOT belong in `required_analysis` — that key drives `METADATA_CHECKS` (per-clip data dependencies), not runtime-service availability. Ollama availability is checked at dialog open and inside the worker via `check_ollama_health()` (see U6 Dialog UX Conventions for the disabled-algorithm-entry UX when Ollama is absent).
+- Test: `tests/test_word_llm_composer.py`
+- Test: `tests/test_llm_client_constrained.py`
+
+**Approach:**
+- Schema for the constrained call: `{"type": "object", "properties": {"words": {"type": "array", "items": {"type": "string", "enum": [...vocabulary]}}}, "required": ["words"]}`.
+- Validate response: non-`None`, non-empty `words` list. Per a recurring LLM gotcha, never trust the LLM not to return `None` content.
+- Repeat-policy implementation: `"round-robin"` (default — cycle through instances per word), `"random"` (seeded for determinism), `"first"` (always use the first instance), `"longest"` / `"shortest"` (by `WordInstance.end - start`).
+- System prompt includes frequency annotations of the vocabulary so the model has usage hints (e.g., `"the (42), a (38), and (28), ..."`).
+- On Ollama unavailable: surface a clear error with a "check Ollama health" hint (reuse `check_ollama_health()` from `core/llm_client.py:201`).
+- Subprocess discipline: any subprocess spawned to talk to Ollama or to wrap a fallback path must use `try/finally` with explicit kill+wait (per the subprocess-cleanup-on-exception learning).
+- **Implementation-time measurement:** record decode latency for a ~5000-item enum on `qwen3:8b`. If unacceptable (e.g., >30s for a 20-word sentence), flag for Tier 2 follow-up and document findings inline.
+
+**Execution note:** Stub LLM responses in unit tests; an integration test against a real local Ollama runs only when `SCENE_RIPPER_OLLAMA_INTEGRATION=1` is set in the env.
+
+**Patterns to follow:**
+- `core/llm_client.py` — existing Ollama provider patterns, `check_ollama_health()`, `complete_with_local_fallback()`.
+- JSON-mode usage in `core/analysis/cinematography.py:565` and `:698`.
+
+**Test scenarios:**
+- Happy path: Stubbed LLM returns `{"words": ["i", "have", "always", "loved", "silence"]}` → 5 `SequenceClip` entries, each from a corpus instance.
+- Happy path: With 12 instances of "the" in the corpus and an LLM output using "the" 4 times under `round-robin`, the 4 emitted `SequenceClip`s reference 4 different source instances (in inventory order). *Covers AE3.*
+- Happy path: With `repeat_policy="random"` and a fixed seed, two runs produce identical SequenceClip sequences.
+- Edge case: LLM emits a single-word response → 1 SequenceClip.
+- Edge case: Corpus has only one instance of a word that the LLM emits 3 times → round-robin reuses the single instance three times; behavior is documented and tested.
+- Error path: LLM returns `None` content → raises `LLMEmptyResponseError` with a clear message (do not silently produce an empty sequence).
+- Error path: Ollama unreachable → raises with the Ollama health-check hint.
+- Error path: LLM somehow emits an OOV word (should not happen if `format`+enum is enforced) → fail loudly so the bug surfaces, not silently drop. *Covers AE4 (when the constraint works correctly, no OOV emission occurs).*
+- Integration: Real Ollama integration test (gated by env var) confirms `format` parameter survives the transport and the enum is enforced.
+
+**Verification:**
+- A test sentence runs end-to-end against a stubbed LLM and produces a renderable `SequenceClip[]`.
+- Real-Ollama integration test confirms decode latency is recorded; the test asserts a soft-upper-bound (warning, not failure) so future regressions are visible.
+
+---
+
+### U6. Dialogs and end-to-end smoke
+
+**Goal:** Two QDialog subclasses (preset modes + LLM composer); wire them into `ui/tabs/sequence_tab.py`'s algorithm-dispatch ladder; end-to-end smoke test from Sequence tab through render. Algorithm registration in `ui/algorithm_config.py` is *not* in this unit — U4 and U5 each register their own entry authoritatively.
+
+**Requirements:** R6, R7, R8, R9, R12, R14, R15, R16
+
+**Dependencies:** U4, U5
+
+**Files:**
+- Create: `ui/dialogs/word_sequencer_dialog.py`
+- Create: `ui/dialogs/word_llm_composer_dialog.py`
+- Modify: `ui/tabs/sequence_tab.py` — add two branches to the hand-maintained algorithm-dispatch if-ladder around `sequence_tab.py:778-807` (the `_show_<algorithm>_dialog` pattern), instantiating each new dialog with `(clips=clips, project=self.project, parent=self)` per the staccato pattern at `sequence_tab.py:1426`.
+- Modify (only if needed): `ui/widgets/sorting_card_grid.py` — should pick up the new algorithms automatically if it reads from `ui/algorithm_config.py`. Verify during U6.
+- Test: `tests/test_word_sequencer_dialog.py`
+- Test: `tests/test_word_llm_composer_dialog.py`
+
+**Approach:**
+
+*Shared dialog conventions* (apply to both Word Sequencer and LLM Composer):
+
+- **Source picker.** `QListWidget` with checkboxes; one row per `Source` represented in the user's selected clips (deduplicate by `Source.id`). Each row shows source filename, total duration, and an alignment-status badge: `✓ aligned`, `… needs alignment`, or `⚠ unsupported language`. Default state: every row checked. The user can uncheck rows to exclude sources without leaving the dialog. Pre-selection mirrors the Sequence tab's current selection.
+- **Disabled rows** (unsupported-language sources). The row is checkable=False with greyed-out text and a tooltip carrying the AE1 message ("alignment model does not support \<language\>; source unavailable for word-level sequencing"). The user can still proceed with the remaining sources; the Accept button stays enabled as long as at least one checked row is available.
+- **Conditional field visibility.** Mode-specific controls are wrapped in `QWidget` containers that toggle `.setVisible()` on mode change. When hidden, **user-entered values are preserved** (the widget keeps its state in memory). The dialog's `QScrollArea` recomputes layout on visibility change so the dialog height stays sane.
+- **Missing-alignment behavior.** When the user accepts and any selected source lacks word data, the dialog **auto-runs alignment** (no extra confirmation modal) and shows an inline progress indicator (a `QProgressBar` below the form, replacing the action buttons until completion). The user can cancel via a button that swaps in during alignment; cancellation aborts the worker per U3's contract and the dialog returns to its pre-Accept state. The "always prompt vs auto-run" question is **resolved: auto-run**, with the cancel button as the escape valve.
+- **LLM Composer generation state.** When the user accepts the LLM Composer, the dialog enters a generating state with the same in-dialog `QProgressBar` pattern. The prompt input becomes read-only during generation; the Accept button is replaced by a Cancel button that interrupts the in-flight LLM call (subprocess kill per the cleanup-on-exception learning). Empty / `None` responses surface as an inline error label without dismissing the dialog.
+- **Error display.** A single `QLabel` with the project's error style (red text, leading icon) sits below the action button row. It's hidden when empty and `.setText()` populates it for any user-surfaced error: `MissingWordDataError` ("source X has no word data — alignment ran but produced no segments — try re-transcribing"), Ollama-unreachable, `LLMEmptyResponseError`, install-feature failures. Inline label, not `QMessageBox` popup — the user keeps the dialog state visible.
+- **Empty corpus.** When every checked source's clips combined produce zero words (silence, instrumental-only, all words filtered out by chosen-words), the Accept button is disabled and the inline error label reads "no words in selected sources — adjust your selection or include list".
+- **Ollama-absent state (LLM Composer only).** Detected at dialog construction via `check_ollama_health()`. When Ollama is unreachable, the dialog opens with a single inline message ("Local LLM not detected — install or start Ollama, then re-open this dialog") and a "Open feature install" button that invokes `install_for_feature("ollama_runtime", ...)`. The Accept button is disabled until Ollama is healthy. The algorithm-picker entry in the Sequence tab is *not* greyed out in v1 — the Ollama check happens at dialog open, not at picker render, because we'd otherwise need to poll Ollama health on every Sequence tab refresh.
+
+*Per-dialog parameters:*
+
+- **Word Sequencer dialog parameters:**
+  - Source picker (shared convention above).
+  - Mode select — `QComboBox` with 5 entries: Alphabetical, Chosen Words, By Frequency, By Property, User-Curated Ordered List.
+  - **Chosen-words input** (visible when mode = Chosen Words): multi-line `QPlainTextEdit`, one word per line (also accept comma- or whitespace-separated; normalize on parse). Below it: a read-only label showing "in corpus: N / M" as the user types, so they see which entries match. Case-insensitive matching.
+  - **Property select** (visible when mode = By Property): `QComboBox` with `length` / `duration` / `log_frequency`; companion `QComboBox` for `ascending` / `descending` (default ascending).
+  - **User-curated word list** (visible when mode = User-Curated Ordered List): multi-line `QPlainTextEdit`, same parser as chosen-words but order- and repetition-preserving. Below it: "N slots; M unrecognized" preview.
+  - Handle-frame count: `QSpinBox`, default 0, range 0–10.
+- **LLM Composer dialog parameters:**
+  - Source picker (shared convention above).
+  - Prompt input: multi-line `QPlainTextEdit`; placeholder "e.g., 'compose a sentence about silence'".
+  - Target length: `QSpinBox`, default 20 (words), range 1–200.
+  - Repeat policy select: `QComboBox` with round-robin / random with seed / first / longest / shortest. Default round-robin.
+  - Seed: `QSpinBox`, visible only when repeat policy = random; default 0; range 0–2^31.
+
+*Dialog mechanics* (both):
+  - Modal `QDialog` subclass following `ui/dialogs/staccato_dialog.py`.
+  - Owns workers internally (the `ForcedAlignmentWorker` from U3 when alignment is needed; a lightweight `LLMComposerWorker` for the LLM generation step that calls into spine for the actual sequencing).
+  - Calls `check_feature_ready("word_alignment")` / `install_for_feature` inside the worker, not in dialog code (per the staccato pattern).
+  - On accept: builds a complete `Sequence` and assigns via `project.sequence = ...` (no parallel widget-local copies; per `docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md`).
+  - UI sizing follows `.claude/rules/ui-consistency.md` (`UISizes`, 32px min heights, 140px label width). Forms wrapped in `QScrollArea`.
+
+*Analyze tab affordance* (for U3 follow-through visible in U6 wiring):
+  - Add a `QPushButton "Run Word-Level Alignment"` to `ui/tabs/analyze_tab.py`, placed in the existing transcription button row, immediately after the "Transcribe" button.
+  - Disabled when no clips have a transcript (`Clip.transcript is None` for all selected). Enabled otherwise.
+  - On click: dispatches the `ForcedAlignmentWorker` over selected clips and shows progress in the tab's existing analysis-progress widget (same widget the transcription button uses).
+
+**Execution note:** End-to-end integration test the dialog → worker → spine → SequenceClip → render path with a tiny seeded source.
+
+**Patterns to follow:**
+- `ui/dialogs/staccato_dialog.py` (best reference — has a worker, feature-registry preflight, post-accept Sequence assignment).
+- `.claude/rules/ui-consistency.md`.
+
+**Test scenarios:**
+- Happy path: Opening the Word Sequencer dialog with aligned clips selected shows the source picker with all rows checked and `✓ aligned` badges; selecting "alphabetical" and accepting produces a timeline. *Covers F1.*
+- Happy path: Opening the LLM Composer with aligned clips, entering a prompt, and accepting produces a timeline. *Covers F2.*
+- Happy path: Mixed faster-whisper (word data present) + MLX (word data absent) source picker shows `✓ aligned` and `… needs alignment` badges respectively; accepting auto-runs alignment on the MLX sources only (inline progress, no extra modal).
+- Happy path: Switching between modes preserves the user-entered chosen-words text and the user-curated text independently (each retains its value when hidden).
+- Edge case: Unsupported-language source appears in the picker with row disabled, `⚠ unsupported language` badge, tooltip carrying the AE1 message; Accept stays enabled because other sources are checked and valid. *Covers AE1.*
+- Edge case: All checked sources are unsupported-language → Accept disabled, inline error label explains why.
+- Edge case: Word Sequencer with chosen-words mode and an include list whose entries are all absent from the corpus → Accept disabled, error label reads "0 of N include-list words found in corpus".
+- Edge case: Empty corpus (zero words in selected clips) → Accept disabled, error label "no words in selected sources".
+- Edge case: Cancelling alignment mid-run via the in-dialog cancel button → worker.cancel() fires; dialog returns to pre-Accept state with partial alignment results persisted in the project; no orphan worker.
+- Edge case: Cancelling LLM generation mid-run → in-flight Ollama call is interrupted (subprocess kill per cleanup learning); dialog returns to pre-Accept state.
+- Edge case: LLM Composer opened with Ollama down → dialog opens with installer-prompt and disabled Accept; clicking "Open feature install" invokes the feature_registry flow.
+- Edge case: LLM returns `None` content → inline error label shows the empty-response message; dialog stays open so the user can retry or adjust the prompt.
+- Edge case: A source with `fps = None` → dialog shows the source as disabled with tooltip "source missing fps metadata"; surfaces at picker render so the user sees it before Accept.
+- Integration: Full path clips → dialog → alignment → sequencer → `SequenceClip[]` → render produces a playable mp4 from a 30-second seeded source.
+- Integration: Existing algorithm dialogs (Staccato, etc.) continue to work unchanged — regression check.
+- Integration: Sub-second `SequenceClip` durations are FFmpeg-safe (timestamps normalized to finite decimal seconds per the fractional-duration learning); spot-check that the rendered output contains all expected words.
+- Integration: Analyze tab's "Run Word-Level Alignment" button is disabled when selected clips have no transcripts, enabled otherwise; clicking it dispatches the same `ForcedAlignmentWorker` and shows progress in the tab's existing analysis-progress widget.
+
+**Verification:**
+- End-to-end smoke from a 30-second source with 50 words produces a 50-cut alphabetical timeline that renders to a playable mp4.
+- The two new algorithms appear in the Sequence tab algorithm picker.
+- Existing algorithms still work (no regression).
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The new `ForcedAlignmentWorker` integrates with project observers; the new `complete_with_enum_constraint` helper on `LLMClient` is a new public method that chat tools / agent flows should *not* hit accidentally (the word composer is a pure algorithm, not a chat tool). The new dialogs add two entries to `ui/algorithm_config.py` and corresponding wiring in `ui/tabs/sequence_tab.py`.
+- **Error propagation:** Alignment errors propagate via `worker.error(str)`. LLM errors propagate via algorithm-level exceptions caught in the dialog and surfaced as user messages. `MissingWordDataError` and `UnsupportedLanguageError` are caught by the dialogs and routed to user-visible prompts (offer to align, disable the source).
+- **State lifecycle risks:** Alignment is per-clip and partial results persist. Mid-run cancellation leaves the already-aligned clips with `words` populated and the rest at `None`. Re-running picks up from where it left off (no extra work for already-aligned clips).
+- **API surface parity:** `core/spine/words.py` is shaped so `scene_ripper_mcp/tools/` could add `align_words` and `word_sequence` MCP tools in a follow-up without changes to the spine code. Not implemented in this plan.
+- **Integration coverage:** Spine boundary test (`tests/test_spine_imports.py`) must continue to pass — `core/spine/words.py` lazy-imports any heavy ML dependencies.
+- **Unchanged invariants:**
+  - Render pipeline is not touched (per R15).
+  - `SequenceClip` model is not changed. (R4 governs *word-timestamp storage location* — "no new top-level entity"; the fact that `SequenceClip` is unchanged is a separate plan-level observation reinforcing the brainstorm's "no render pipeline changes" guarantee, not a direct R4 consequence.)
+  - `Source` and `Clip` schemas are unchanged. (The schema change is on `TranscriptSegment`, which is referenced from `Clip.transcript` but not part of the `Clip` dataclass itself.)
+  - Existing transcripts without word data continue to work for current features (per R2).
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Ollama `format`+enum decode latency is unacceptable at corpus scale (~5000+ enum items, non-parallel masking) | Measure in U5; if unacceptable, Tier 2 (`llama-cpp-python` GBNF) is a documented follow-up plan. Tier 1 unblocks shipping for typical short-corpus runs. |
+| LiteLLM strips Ollama's `format` parameter when forwarding | Verify in U5; if stripped, bypass LiteLLM for the constrained-decode call and hit Ollama's `/api/generate` directly through `core/llm_client.py`. |
+| Forced alignment is CPU-only on Apple Silicon and slow for long sources | Worker reports per-clip progress; cancellation is safe; partial results persist. UI sets expectations clearly. |
+| Word-boundary splices still clip plosives at ~20–30ms accuracy | Handle-frame parameter is the user-facing escape valve (default 0 per brainstorm; spinner exposed). |
+| Sub-second `SequenceClip` durations break FFmpeg with fractional-second args | Normalize all timestamps to finite decimal seconds before constructing FFmpeg args (per existing learning). Covered by U4 approach and U6 integration test. |
+| Worker replaced before previous run finished → crash | Guard-flag + `Qt.UniqueConnection` pattern in U3 (per existing learning). |
+| Dialog "sequence overwrite by generic handlers" footgun | Register both algorithms with `is_dialog=True` and audit `ui/tabs/sequence_tab.py` for any non-dialog fallback path that might clobber the sequence post-accept. |
+| LLM returns `None` content → silent empty sequence | Explicit validation in U5; raise `LLMEmptyResponseError`. |
+| Subprocess orphan on cancellation (Ollama HTTP, FFmpeg extracts) | `try/finally` with explicit kill+wait (per existing learning); apply in U5 and any U6 render paths that spawn subprocesses. |
+| Algorithm registry circular import (historical) | Verified mitigated — `ui/algorithm_config.py` is already the neutral module; no extraction needed. |
+| MLX-transcribed corpora silently mis-align as English when source is non-English | U1 captures `result["language"]` from MLX (currently discarded) into `TranscriptSegment.language`; U2 reads `segments[0].language` and raises `LanguageUnknownError` rather than silently defaulting to "en". |
+| `core/cost_estimates.py` silently skips the new algorithm because `transcription_with_words` isn't in `METADATA_CHECKS` | U4 adds the entry (lambda + label + time + cost rows); test in `tests/test_cost_estimates.py` asserts the key is recognized. |
+| `WordTimestamp` accidentally added to `models/clip.py` causes circular import | U1 colocates `WordTimestamp` with `TranscriptSegment` in `core/transcription.py`; `models/clip.py` continues to TYPE_CHECKING-import only. |
+| Algorithm registration written from multiple units causes drift | U4 and U5 each own one entry end-to-end; U6 does not modify `ui/algorithm_config.py`. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `docs/user-guide/` with a new page describing the Word Sequencer (alignment opt-in, the five preset modes, the LLM-composed mode). Use the existing `/sync-feature-docs` or `/sync-sequencer-docs` skill to keep `docs/user-guide/sequencers.md` in step.
+- Update `.claude/rules/sequencer-algorithms.md` to include the two new algorithms.
+- The new feature-registry entries (`word_alignment`; reserved `constrained_decoding_grammar`) need to be documented in any developer-facing notes about adding ML features.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/word-sequencer-requirements.md](docs/brainstorms/word-sequencer-requirements.md)
+- Related code: `core/transcription.py:257` (`TranscriptSegment`), `core/transcription.py:445`/`:599` (word_timestamps call sites), `core/transcription.py:626` (`_parse_mlx_result`), `core/remix/staccato.py`, `ui/dialogs/staccato_dialog.py`, `core/llm_client.py:201` (`check_ollama_health`), `core/feature_registry.py:172`/`:203`, `core/cost_estimates.py:77` (`METADATA_CHECKS`), `ui/workers/transcription_worker.py`, `ui/tabs/sequence_tab.py:1426` (dialog dispatch pattern)
+- Related rules: `.claude/rules/sequencer-algorithms.md`, `.claude/rules/ui-consistency.md`
+- Related learnings: `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`, `docs/solutions/ui-bugs/cut-tab-clips-hidden-after-thumbnail-failure.md`, `docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md`, `docs/solutions/logic-errors/circular-import-config-consolidation.md`, `docs/solutions/security-issues/ffmpeg-path-escaping-20260124.md`, `docs/solutions/runtime-errors/macos-libmpv-pyav-ffmpeg-dylib-collision-20260504.md`, `docs/solutions/reliability-issues/subprocess-cleanup-on-exception.md`
+- External: `ctc-forced-aligner` (MahmoudAshraf97/ctc-forced-aligner on GitHub); Ollama `format` documentation; LiteLLM Input Params docs

--- a/docs/plans/2026-05-11-001-feat-word-sequencer-plan.md
+++ b/docs/plans/2026-05-11-001-feat-word-sequencer-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Word Sequencer with forced-alignment-augmented transcription"
 type: feat
-status: active
+status: completed
 date: 2026-05-11
 origin: docs/brainstorms/word-sequencer-requirements.md
 ---

--- a/tests/test_algorithm_config.py
+++ b/tests/test_algorithm_config.py
@@ -5,7 +5,8 @@ from ui.algorithm_config import ALGORITHM_CONFIG, CATEGORY_ORDER
 
 def test_category_order_has_expected_entries():
     # "Word" and "Experimental" were added in U4 of the word-sequencer plan
-    # so the new ``word_sequencer`` algorithm has somewhere to live.
+    # so the new ``word_sequencer`` algorithm has somewhere to live; "LLM"
+    # was added in U5 for the ``word_llm_composer`` algorithm.
     assert CATEGORY_ORDER == [
         "All",
         "Arrange",
@@ -14,6 +15,7 @@ def test_category_order_has_expected_entries():
         "Audio",
         "Text",
         "Word",
+        "LLM",
         "Experimental",
     ]
 
@@ -47,7 +49,8 @@ def test_multi_tagged_algorithms():
 
 def test_algorithm_count():
     # Bumped from 21 → 22 in U4 (added ``word_sequencer``).
-    assert len(ALGORITHM_CONFIG) == 22
+    # Bumped from 22 → 23 in U5 (added ``word_llm_composer``).
+    assert len(ALGORITHM_CONFIG) == 23
 
 
 def test_word_sequencer_registered():
@@ -57,4 +60,16 @@ def test_word_sequencer_registered():
     assert config["is_dialog"] is True
     assert config["required_analysis"] == ["transcription_with_words"]
     assert config["categories"] == ["word", "experimental"]
+    assert config["allow_duplicates"] is False
+
+
+def test_word_llm_composer_registered():
+    """U5 owns the ``word_llm_composer`` registration end-to-end."""
+    config = ALGORITHM_CONFIG["word_llm_composer"]
+    assert config["label"] == "LLM Word Composer"
+    assert config["is_dialog"] is True
+    # local_llm is NOT in required_analysis — Ollama availability is a
+    # runtime check, not per-clip metadata. Plan U5 is explicit.
+    assert config["required_analysis"] == ["transcription_with_words"]
+    assert config["categories"] == ["word", "experimental", "llm"]
     assert config["allow_duplicates"] is False

--- a/tests/test_algorithm_config.py
+++ b/tests/test_algorithm_config.py
@@ -3,8 +3,19 @@
 from ui.algorithm_config import ALGORITHM_CONFIG, CATEGORY_ORDER
 
 
-def test_category_order_has_six_entries():
-    assert CATEGORY_ORDER == ["All", "Arrange", "Find", "Connect", "Audio", "Text"]
+def test_category_order_has_expected_entries():
+    # "Word" and "Experimental" were added in U4 of the word-sequencer plan
+    # so the new ``word_sequencer`` algorithm has somewhere to live.
+    assert CATEGORY_ORDER == [
+        "All",
+        "Arrange",
+        "Find",
+        "Connect",
+        "Audio",
+        "Text",
+        "Word",
+        "Experimental",
+    ]
 
 
 def test_every_algorithm_has_categories():
@@ -35,4 +46,15 @@ def test_multi_tagged_algorithms():
 
 
 def test_algorithm_count():
-    assert len(ALGORITHM_CONFIG) == 21
+    # Bumped from 21 → 22 in U4 (added ``word_sequencer``).
+    assert len(ALGORITHM_CONFIG) == 22
+
+
+def test_word_sequencer_registered():
+    """U4 owns the ``word_sequencer`` registration end-to-end."""
+    config = ALGORITHM_CONFIG["word_sequencer"]
+    assert config["label"] == "Word Sequencer"
+    assert config["is_dialog"] is True
+    assert config["required_analysis"] == ["transcription_with_words"]
+    assert config["categories"] == ["word", "experimental"]
+    assert config["allow_duplicates"] is False

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -49,7 +49,7 @@ class TestAlignWordsLanguageGating(unittest.TestCase):
         """Empty segment list short-circuits before model load + ffmpeg."""
         from core.analysis import alignment
 
-        with patch.object(alignment, "_extract_audio_to_wav") as ffmpeg_mock, \
+        with patch.object(alignment, "extract_audio_to_wav") as ffmpeg_mock, \
              patch.object(alignment, "_run_alignment_engine") as engine_mock:
             result = alignment.align_words("/path/to/audio.wav", [])
 
@@ -91,7 +91,7 @@ class TestAlignWordsLanguageGating(unittest.TestCase):
         with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
             audio = Path(tmp.name)
         try:
-            with patch.object(alignment, "_extract_audio_to_wav") as ffmpeg_mock, \
+            with patch.object(alignment, "extract_audio_to_wav") as ffmpeg_mock, \
                  patch.object(alignment, "_run_alignment_engine") as engine_mock:
                 fake_wav = audio  # reuse the existing file for cleanup symmetry
                 ffmpeg_mock.return_value = fake_wav
@@ -131,7 +131,7 @@ class TestAlignWordsHappyPath(unittest.TestCase):
         """Helper: run align_words with mocked FFmpeg + engine."""
         from core.analysis import alignment
 
-        with patch.object(alignment, "_extract_audio_to_wav", return_value=self.fake_wav) as ffmpeg_mock, \
+        with patch.object(alignment, "extract_audio_to_wav", return_value=self.fake_wav) as ffmpeg_mock, \
              patch.object(alignment, "_run_alignment_engine", return_value=engine_output) as engine_mock:
             words = alignment.align_words(str(self.audio_path), segments)
         return words, ffmpeg_mock, engine_mock
@@ -235,7 +235,7 @@ class TestAlignWordsHappyPath(unittest.TestCase):
                 confidence=0.9, words=None, language="en",
             ),
         ]
-        with patch.object(alignment, "_extract_audio_to_wav") as ffmpeg_mock, \
+        with patch.object(alignment, "extract_audio_to_wav") as ffmpeg_mock, \
              patch.object(alignment, "_run_alignment_engine") as engine_mock:
             result = alignment.align_words(str(self.audio_path), segments)
 
@@ -248,7 +248,7 @@ class TestAlignWordsCleanup(unittest.TestCase):
     """Temp-file lifecycle around the engine call."""
 
     def test_temp_wav_is_removed_after_successful_run(self):
-        """Happy path: the temp WAV path returned by _extract_audio_to_wav is unlinked."""
+        """Happy path: the temp WAV path returned by extract_audio_to_wav is unlinked."""
         from core.analysis import alignment
 
         with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as src:
@@ -263,7 +263,7 @@ class TestAlignWordsCleanup(unittest.TestCase):
                 start_time=0.0, end_time=1.0, text="hello",
                 confidence=0.9, words=None, language="en",
             )
-            with patch.object(alignment, "_extract_audio_to_wav", return_value=wav_path), \
+            with patch.object(alignment, "extract_audio_to_wav", return_value=wav_path), \
                  patch.object(alignment, "_run_alignment_engine", return_value=[
                      {"start": 0.0, "end": 0.5, "text": "hello", "score": 0.9},
                  ]):
@@ -297,7 +297,7 @@ class TestAlignWordsCleanup(unittest.TestCase):
             def _boom(**kwargs):
                 raise alignment.AlignmentError("engine exploded")
 
-            with patch.object(alignment, "_extract_audio_to_wav", return_value=wav_path), \
+            with patch.object(alignment, "extract_audio_to_wav", return_value=wav_path), \
                  patch.object(alignment, "_run_alignment_engine", side_effect=_boom):
                 with self.assertRaises(alignment.AlignmentError):
                     alignment.align_words(str(src_path), [seg])
@@ -353,7 +353,7 @@ class TestAlignWordsErrors(unittest.TestCase):
                     "Install the 'word_alignment' feature first."
                 )
 
-            with patch.object(alignment, "_extract_audio_to_wav", return_value=wav_path), \
+            with patch.object(alignment, "extract_audio_to_wav", return_value=wav_path), \
                  patch.object(alignment, "_run_alignment_engine", side_effect=_fake_engine):
                 with self.assertRaises(alignment.AlignmentError) as ctx:
                     alignment.align_words(str(src_path), [seg])
@@ -369,7 +369,7 @@ class TestAlignWordsErrors(unittest.TestCase):
 
 
 class TestExtractAudioCleanup(unittest.TestCase):
-    """``_extract_audio_to_wav`` owns its temp file on the unhappy paths."""
+    """``extract_audio_to_wav`` owns its temp file on the unhappy paths."""
 
     def test_extract_failure_cleans_up_temp_wav(self):
         from core.analysis import alignment
@@ -398,7 +398,7 @@ class TestExtractAudioCleanup(unittest.TestCase):
                  patch.object(alignment.tempfile, "NamedTemporaryFile", side_effect=_capturing_tmp), \
                  patch.object(alignment.subprocess, "run", side_effect=_boom):
                 with self.assertRaises(alignment.AlignmentFFmpegError):
-                    alignment._extract_audio_to_wav(src_path)
+                    alignment.extract_audio_to_wav(src_path)
 
             self.assertIn("path", captured)
             self.assertFalse(
@@ -444,6 +444,81 @@ class TestFeatureRegistryEntry(unittest.TestCase):
         with patch.object(alignment_mod, "ensure_word_alignment_runtime_available") as ensure_mock:
             feature_registry._validate_feature_runtime("word_alignment")
         ensure_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# distribute_words_to_segments
+# ---------------------------------------------------------------------------
+
+
+class TestDistributeWordsToSegments(unittest.TestCase):
+    """The flat-word-list-to-segments distribution helper."""
+
+    @staticmethod
+    def _seg(start: float, end: float) -> TranscriptSegment:
+        return TranscriptSegment(
+            start_time=start,
+            end_time=end,
+            text="x",
+            confidence=0.9,
+            words=None,
+            language="en",
+        )
+
+    def test_word_midpoint_inside_segment_assigns_there(self):
+        from core.analysis.alignment import distribute_words_to_segments
+
+        segments = [self._seg(0.0, 1.0), self._seg(1.0, 2.0), self._seg(2.0, 3.0)]
+        words = [
+            WordTimestamp(start=0.10, end=0.30, text="a"),   # mid 0.20 → seg0
+            WordTimestamp(start=1.20, end=1.80, text="b"),   # mid 1.50 → seg1
+            WordTimestamp(start=2.30, end=2.70, text="c"),   # mid 2.50 → seg2
+        ]
+        distribute_words_to_segments(segments, words)
+        self.assertEqual([w.text for w in segments[0].words], ["a"])
+        self.assertEqual([w.text for w in segments[1].words], ["b"])
+        self.assertEqual([w.text for w in segments[2].words], ["c"])
+
+    def test_word_outside_all_segments_falls_back_to_nearest(self):
+        from core.analysis.alignment import distribute_words_to_segments
+
+        segments = [self._seg(0.0, 1.0), self._seg(2.0, 3.0)]
+        words = [
+            # midpoint 1.5 → equidistant. Nearest-boundary lambda compares
+            # min(|1.5-start|, |1.5-end|): seg0 → min(1.5, 0.5)=0.5;
+            # seg1 → min(0.5, 1.5)=0.5. Tie → ``min`` picks the first (seg0).
+            WordTimestamp(start=1.4, end=1.6, text="left"),
+            # midpoint 1.8 → seg1 wins (min(1.8, 0.8)=0.8 vs seg0 min(1.8, 0.8)=0.8;
+            # tie again, picks seg0). Use a midpoint that breaks the tie:
+            WordTimestamp(start=1.7, end=1.9, text="right"),  # mid 1.8 — actually still ties
+        ]
+        # Replace with a clearer case: 1.9 → seg1 closer.
+        words = [
+            WordTimestamp(start=1.85, end=1.95, text="right"),  # mid 1.9 → seg1
+            WordTimestamp(start=1.05, end=1.15, text="left"),   # mid 1.10 → seg0
+        ]
+        distribute_words_to_segments(segments, words)
+        self.assertEqual([w.text for w in segments[0].words], ["left"])
+        self.assertEqual([w.text for w in segments[1].words], ["right"])
+
+    def test_empty_words_assigns_empty_list_to_every_segment(self):
+        from core.analysis.alignment import distribute_words_to_segments
+
+        segments = [self._seg(0.0, 1.0), self._seg(1.0, 2.0)]
+        distribute_words_to_segments(segments, [])
+        # The contract: every segment gets ``.words = []`` (not None) so the
+        # skip predicate counts the clip as aligned.
+        for seg in segments:
+            self.assertEqual(seg.words, [])
+
+    def test_empty_segments_is_a_noop(self):
+        from core.analysis.alignment import distribute_words_to_segments
+
+        # Calling with no segments must not raise — and there's nothing to
+        # mutate.
+        distribute_words_to_segments([], [
+            WordTimestamp(start=0.0, end=0.5, text="orphan"),
+        ])
 
 
 if __name__ == "__main__":

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,0 +1,450 @@
+"""Tests for the forced-alignment runtime module (U2).
+
+These tests mock the heavy alignment engine (``_run_alignment_engine``) and the
+FFmpeg audio-extraction step where appropriate, so they exercise the module's
+control flow — language gating, empty-input fast paths, temp-file cleanup,
+error propagation — without requiring ``ctc-forced-aligner`` or ``torch`` to
+be installed.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from core.transcription import TranscriptSegment, WordTimestamp
+
+
+# ---------------------------------------------------------------------------
+# Module-import boundary
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImportBoundary(unittest.TestCase):
+    """``core.analysis.alignment`` must import on a clean env."""
+
+    def test_imports_without_ctc_forced_aligner(self):
+        # Ensure the module loads cleanly even if the heavy deps are absent
+        # from this Python environment. The pure-import path should not pull
+        # ``ctc_forced_aligner`` or ``torch`` into sys.modules.
+        sys.modules.pop("core.analysis.alignment", None)
+
+        import core.analysis.alignment  # noqa: F401
+
+        self.assertNotIn("ctc_forced_aligner", sys.modules)
+
+
+# ---------------------------------------------------------------------------
+# Public API: align_words
+# ---------------------------------------------------------------------------
+
+
+class TestAlignWordsLanguageGating(unittest.TestCase):
+    """Language signal handling on the public entry point."""
+
+    def test_empty_segments_returns_empty_no_engine_load(self):
+        """Empty segment list short-circuits before model load + ffmpeg."""
+        from core.analysis import alignment
+
+        with patch.object(alignment, "_extract_audio_to_wav") as ffmpeg_mock, \
+             patch.object(alignment, "_run_alignment_engine") as engine_mock:
+            result = alignment.align_words("/path/to/audio.wav", [])
+
+        self.assertEqual(result, [])
+        ffmpeg_mock.assert_not_called()
+        engine_mock.assert_not_called()
+
+    def test_segments_with_language_none_raises_language_unknown(self):
+        """Legacy transcripts (pre-U1) lack a language → explicit error."""
+        from core.analysis.alignment import LanguageUnknownError, align_words
+
+        seg = TranscriptSegment(
+            start_time=0.0, end_time=1.0, text="hello world",
+            confidence=0.9, words=None, language=None,
+        )
+        with self.assertRaises(LanguageUnknownError):
+            align_words("/path/to/audio.wav", [seg])
+
+    def test_unsupported_language_raises_unsupported_language_error(self):
+        """An ISO code outside the supported set → UnsupportedLanguageError."""
+        from core.analysis.alignment import UnsupportedLanguageError, align_words
+
+        seg = TranscriptSegment(
+            start_time=0.0, end_time=1.0, text="hello",
+            confidence=0.9, words=None, language="xx",
+        )
+        with self.assertRaises(UnsupportedLanguageError) as ctx:
+            align_words("/path/to/audio.wav", [seg])
+        self.assertEqual(ctx.exception.language, "xx")
+
+    def test_language_is_read_from_first_segment(self):
+        """Language passes through to the alignment engine call."""
+        from core.analysis import alignment
+
+        seg = TranscriptSegment(
+            start_time=0.0, end_time=1.0, text="hello world",
+            confidence=0.9, words=None, language="en",
+        )
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+            audio = Path(tmp.name)
+        try:
+            with patch.object(alignment, "_extract_audio_to_wav") as ffmpeg_mock, \
+                 patch.object(alignment, "_run_alignment_engine") as engine_mock:
+                fake_wav = audio  # reuse the existing file for cleanup symmetry
+                ffmpeg_mock.return_value = fake_wav
+                engine_mock.return_value = [
+                    {"start": 0.0, "end": 0.4, "text": "hello", "score": 0.95},
+                    {"start": 0.4, "end": 0.8, "text": "world", "score": 0.92},
+                ]
+                alignment.align_words(str(audio), [seg])
+
+            # Engine receives the language from segments[0].language.
+            kwargs = engine_mock.call_args.kwargs
+            self.assertEqual(kwargs["language"], "en")
+        finally:
+            audio.unlink(missing_ok=True)
+
+
+class TestAlignWordsHappyPath(unittest.TestCase):
+    """Successful alignment runs with mocked engine."""
+
+    def setUp(self):
+        # Create a real on-disk audio path so the .exists() check passes.
+        self.tmp_audio = tempfile.NamedTemporaryFile(suffix=".mp4", delete=False)
+        self.tmp_audio.close()
+        self.audio_path = Path(self.tmp_audio.name)
+
+        # Create a fake "extracted WAV" — also a real file so .stat()/.unlink work.
+        wav_handle = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        wav_handle.write(b"fake-wav-bytes")
+        wav_handle.close()
+        self.fake_wav = Path(wav_handle.name)
+
+    def tearDown(self):
+        self.audio_path.unlink(missing_ok=True)
+        self.fake_wav.unlink(missing_ok=True)
+
+    def _run_with_engine_output(self, segments, engine_output):
+        """Helper: run align_words with mocked FFmpeg + engine."""
+        from core.analysis import alignment
+
+        with patch.object(alignment, "_extract_audio_to_wav", return_value=self.fake_wav) as ffmpeg_mock, \
+             patch.object(alignment, "_run_alignment_engine", return_value=engine_output) as engine_mock:
+            words = alignment.align_words(str(self.audio_path), segments)
+        return words, ffmpeg_mock, engine_mock
+
+    def test_returns_word_timestamps_for_aligned_transcript(self):
+        """Engine output maps cleanly to WordTimestamp objects."""
+        segments = [
+            TranscriptSegment(
+                start_time=0.0, end_time=1.0, text="hello world",
+                confidence=0.9, words=None, language="en",
+            ),
+        ]
+        engine_output = [
+            {"start": 0.05, "end": 0.40, "text": "hello", "score": 0.95},
+            {"start": 0.45, "end": 0.95, "text": "world", "score": 0.92},
+        ]
+        words, ffmpeg_mock, engine_mock = self._run_with_engine_output(
+            segments, engine_output,
+        )
+
+        self.assertEqual(len(words), 2)
+        self.assertIsInstance(words[0], WordTimestamp)
+        self.assertEqual(words[0].text, "hello")
+        self.assertAlmostEqual(words[0].start, 0.05)
+        self.assertAlmostEqual(words[0].end, 0.40)
+        self.assertAlmostEqual(words[0].probability, 0.95)
+        self.assertEqual(words[1].text, "world")
+        ffmpeg_mock.assert_called_once_with(self.audio_path)
+        engine_mock.assert_called_once()
+
+    def test_word_count_matches_engine_output(self):
+        """The output count tracks the engine — not the transcript."""
+        segments = [
+            TranscriptSegment(
+                start_time=0.0, end_time=2.0, text="one two three four five",
+                confidence=0.9, words=None, language="en",
+            ),
+        ]
+        engine_output = [
+            {"start": float(i) * 0.4, "end": float(i + 1) * 0.4, "text": w, "score": 0.9}
+            for i, w in enumerate(["one", "two", "three", "four", "five"])
+        ]
+        words, _, _ = self._run_with_engine_output(segments, engine_output)
+        self.assertEqual(len(words), 5)
+
+    def test_timestamps_within_clip_audio_bounds(self):
+        """Word boundaries returned are >= 0 and ordered."""
+        segments = [
+            TranscriptSegment(
+                start_time=0.0, end_time=3.0, text="a b c",
+                confidence=0.9, words=None, language="en",
+            ),
+        ]
+        engine_output = [
+            {"start": 0.0, "end": 1.0, "text": "a", "score": 0.9},
+            {"start": 1.0, "end": 2.0, "text": "b", "score": 0.9},
+            {"start": 2.0, "end": 3.0, "text": "c", "score": 0.9},
+        ]
+        words, _, _ = self._run_with_engine_output(segments, engine_output)
+        self.assertEqual(words[0].start, 0.0)
+        self.assertGreaterEqual(words[0].start, 0.0)
+        for prev, curr in zip(words, words[1:]):
+            self.assertLessEqual(prev.start, curr.start)
+
+    def test_score_none_translates_to_probability_none(self):
+        """Missing score in engine output → probability is None on the WordTimestamp."""
+        segments = [
+            TranscriptSegment(
+                start_time=0.0, end_time=1.0, text="hello",
+                confidence=0.9, words=None, language="en",
+            ),
+        ]
+        engine_output = [
+            {"start": 0.0, "end": 0.5, "text": "hello", "score": None},
+        ]
+        words, _, _ = self._run_with_engine_output(segments, engine_output)
+        self.assertIsNone(words[0].probability)
+
+    def test_short_clip_audio_does_not_crash(self):
+        """A very short clip (engine returns one word) returns one WordTimestamp."""
+        segments = [
+            TranscriptSegment(
+                start_time=0.0, end_time=0.3, text="hi",
+                confidence=0.9, words=None, language="en",
+            ),
+        ]
+        engine_output = [
+            {"start": 0.0, "end": 0.2, "text": "hi", "score": 0.88},
+        ]
+        words, _, _ = self._run_with_engine_output(segments, engine_output)
+        self.assertEqual(len(words), 1)
+        self.assertEqual(words[0].text, "hi")
+
+    def test_all_empty_text_segments_returns_empty(self):
+        """Segments with only whitespace text → empty result, no engine call."""
+        from core.analysis import alignment
+
+        segments = [
+            TranscriptSegment(
+                start_time=0.0, end_time=1.0, text="   ",
+                confidence=0.9, words=None, language="en",
+            ),
+        ]
+        with patch.object(alignment, "_extract_audio_to_wav") as ffmpeg_mock, \
+             patch.object(alignment, "_run_alignment_engine") as engine_mock:
+            result = alignment.align_words(str(self.audio_path), segments)
+
+        self.assertEqual(result, [])
+        ffmpeg_mock.assert_not_called()
+        engine_mock.assert_not_called()
+
+
+class TestAlignWordsCleanup(unittest.TestCase):
+    """Temp-file lifecycle around the engine call."""
+
+    def test_temp_wav_is_removed_after_successful_run(self):
+        """Happy path: the temp WAV path returned by _extract_audio_to_wav is unlinked."""
+        from core.analysis import alignment
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as src:
+            src_path = Path(src.name)
+        wav_handle = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        wav_handle.write(b"data")
+        wav_handle.close()
+        wav_path = Path(wav_handle.name)
+
+        try:
+            seg = TranscriptSegment(
+                start_time=0.0, end_time=1.0, text="hello",
+                confidence=0.9, words=None, language="en",
+            )
+            with patch.object(alignment, "_extract_audio_to_wav", return_value=wav_path), \
+                 patch.object(alignment, "_run_alignment_engine", return_value=[
+                     {"start": 0.0, "end": 0.5, "text": "hello", "score": 0.9},
+                 ]):
+                alignment.align_words(str(src_path), [seg])
+
+            self.assertFalse(
+                wav_path.exists(),
+                "Temp WAV should be removed after successful alignment",
+            )
+        finally:
+            src_path.unlink(missing_ok=True)
+            wav_path.unlink(missing_ok=True)
+
+    def test_temp_wav_is_removed_when_engine_raises(self):
+        """Engine failure must still trigger temp-WAV cleanup."""
+        from core.analysis import alignment
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as src:
+            src_path = Path(src.name)
+        wav_handle = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        wav_handle.write(b"data")
+        wav_handle.close()
+        wav_path = Path(wav_handle.name)
+
+        try:
+            seg = TranscriptSegment(
+                start_time=0.0, end_time=1.0, text="hello",
+                confidence=0.9, words=None, language="en",
+            )
+
+            def _boom(**kwargs):
+                raise alignment.AlignmentError("engine exploded")
+
+            with patch.object(alignment, "_extract_audio_to_wav", return_value=wav_path), \
+                 patch.object(alignment, "_run_alignment_engine", side_effect=_boom):
+                with self.assertRaises(alignment.AlignmentError):
+                    alignment.align_words(str(src_path), [seg])
+
+            self.assertFalse(
+                wav_path.exists(),
+                "Temp WAV must still be removed when alignment raises",
+            )
+        finally:
+            src_path.unlink(missing_ok=True)
+            wav_path.unlink(missing_ok=True)
+
+
+class TestAlignWordsErrors(unittest.TestCase):
+    """Error-path behavior."""
+
+    def test_missing_audio_path_raises_file_not_found(self):
+        from core.analysis.alignment import align_words
+
+        seg = TranscriptSegment(
+            start_time=0.0, end_time=1.0, text="hello",
+            confidence=0.9, words=None, language="en",
+        )
+        with self.assertRaises(FileNotFoundError):
+            align_words("/definitely/does/not/exist-12345.wav", [seg])
+
+    def test_install_for_feature_path_triggered_on_missing_engine(self):
+        """When the engine import fails, AlignmentError is raised — the worker
+        layer (U3) is responsible for invoking install_for_feature.
+
+        This test simulates the missing-dep path by mocking
+        ``_run_alignment_engine`` to raise the same kind of error the real
+        function raises when ``ctc_forced_aligner`` / ``torch`` are absent.
+        """
+        from core.analysis import alignment
+
+        seg = TranscriptSegment(
+            start_time=0.0, end_time=1.0, text="hello",
+            confidence=0.9, words=None, language="en",
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as src:
+            src_path = Path(src.name)
+        wav_handle = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        wav_handle.write(b"data")
+        wav_handle.close()
+        wav_path = Path(wav_handle.name)
+
+        try:
+            def _fake_engine(**kwargs):
+                raise alignment.AlignmentError(
+                    "ctc-forced-aligner is not installed. "
+                    "Install the 'word_alignment' feature first."
+                )
+
+            with patch.object(alignment, "_extract_audio_to_wav", return_value=wav_path), \
+                 patch.object(alignment, "_run_alignment_engine", side_effect=_fake_engine):
+                with self.assertRaises(alignment.AlignmentError) as ctx:
+                    alignment.align_words(str(src_path), [seg])
+            self.assertIn("word_alignment", str(ctx.exception))
+        finally:
+            src_path.unlink(missing_ok=True)
+            wav_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# FFmpeg integration
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAudioCleanup(unittest.TestCase):
+    """``_extract_audio_to_wav`` owns its temp file on the unhappy paths."""
+
+    def test_extract_failure_cleans_up_temp_wav(self):
+        from core.analysis import alignment
+        import subprocess as _subprocess
+
+        with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as src:
+            src_path = Path(src.name)
+
+        try:
+            captured: dict[str, Path] = {}
+
+            real_named_tmp = tempfile.NamedTemporaryFile
+
+            def _capturing_tmp(*args, **kwargs):
+                handle = real_named_tmp(*args, **kwargs)
+                captured["path"] = Path(handle.name)
+                return handle
+
+            def _boom(*args, **kwargs):
+                # Simulate ffmpeg failing — propagates AlignmentFFmpegError.
+                exc = _subprocess.CalledProcessError(1, args[0])
+                exc.stderr = b"simulated ffmpeg failure"
+                raise exc
+
+            with patch.object(alignment, "_require_ffmpeg", return_value="/usr/bin/ffmpeg"), \
+                 patch.object(alignment.tempfile, "NamedTemporaryFile", side_effect=_capturing_tmp), \
+                 patch.object(alignment.subprocess, "run", side_effect=_boom):
+                with self.assertRaises(alignment.AlignmentFFmpegError):
+                    alignment._extract_audio_to_wav(src_path)
+
+            self.assertIn("path", captured)
+            self.assertFalse(
+                captured["path"].exists(),
+                "Failed extraction must clean up its temp WAV",
+            )
+        finally:
+            src_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Feature-registry integration
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureRegistryEntry(unittest.TestCase):
+    """The new ``word_alignment`` feature is wired into the registry."""
+
+    def test_word_alignment_present_in_feature_deps(self):
+        from core.feature_registry import FEATURE_DEPS
+        self.assertIn("word_alignment", FEATURE_DEPS)
+
+    def test_word_alignment_requires_ffmpeg_and_aligner(self):
+        from core.feature_registry import FEATURE_DEPS
+        deps = FEATURE_DEPS["word_alignment"]
+        self.assertIn("ffmpeg", deps.binaries)
+        self.assertIn("ctc_forced_aligner", deps.packages)
+        self.assertIn("torch", deps.packages)
+
+    def test_word_alignment_uses_native_install(self):
+        from core.feature_registry import FEATURE_DEPS
+        self.assertTrue(FEATURE_DEPS["word_alignment"].native_install)
+
+    def test_word_alignment_has_size_estimate(self):
+        from core.feature_registry import FEATURE_DEPS
+        self.assertGreater(FEATURE_DEPS["word_alignment"].size_estimate_mb, 0)
+
+    def test_runtime_validation_branch_calls_ensure(self):
+        """The _validate_feature_runtime hook delegates to the alignment module."""
+        from core import feature_registry
+        from core.analysis import alignment as alignment_mod
+
+        with patch.object(alignment_mod, "ensure_word_alignment_runtime_available") as ensure_mock:
+            feature_registry._validate_feature_runtime("word_alignment")
+        ensure_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cost_estimates.py
+++ b/tests/test_cost_estimates.py
@@ -272,6 +272,57 @@ class TestMetadataChecks:
         assert not METADATA_CHECKS["transcribe"](MockClip())
         assert METADATA_CHECKS["transcribe"](MockClip(transcript=[object()]))
 
+    def test_transcription_with_words_check(self):
+        """U4: METADATA_CHECKS recognizes the word-alignment key.
+
+        Without this entry, the cost-confirmation gate silently skips the
+        Word Sequencer algorithm.
+        """
+        from types import SimpleNamespace
+
+        # No transcript at all → False.
+        assert not METADATA_CHECKS["transcription_with_words"](MockClip())
+
+        # Transcript with a single segment that has ``words=None`` → False
+        # (alignment hasn't run for that segment).
+        seg_none = SimpleNamespace(words=None)
+        clip_unaligned = MockClip(transcript=[seg_none])
+        assert not METADATA_CHECKS["transcription_with_words"](clip_unaligned)
+
+        # Transcript with at least one segment carrying a non-empty word
+        # list → True.
+        seg_with_words = SimpleNamespace(words=[object()])
+        clip_aligned = MockClip(transcript=[seg_with_words])
+        assert METADATA_CHECKS["transcription_with_words"](clip_aligned)
+
+
+class TestTranscriptionWithWordsRegistered:
+    """U4: word_sequencer's required_analysis key resolves end-to-end."""
+
+    def test_key_is_in_operation_labels(self):
+        from core.cost_estimates import OPERATION_LABELS
+
+        assert "transcription_with_words" in OPERATION_LABELS
+        assert "alignment" in OPERATION_LABELS["transcription_with_words"].lower()
+
+    def test_key_is_in_time_per_clip(self):
+        from core.cost_estimates import TIME_PER_CLIP
+
+        assert "transcription_with_words" in TIME_PER_CLIP
+        assert TIME_PER_CLIP["transcription_with_words"]["local"] > 0
+
+    def test_word_sequencer_algorithm_estimate_surfaces_key(self):
+        """Running ``estimate_sequence_cost('word_sequencer', ...)`` produces a
+        non-empty estimate when clips lack word data — proving the gate
+        registered the new key.
+        """
+        clips = [MockClip(transcript=None) for _ in range(3)]
+        result = estimate_sequence_cost("word_sequencer", clips)
+        assert len(result) == 1
+        est = result[0]
+        assert est.operation == "transcription_with_words"
+        assert est.clips_needing == 3
+
 
 # --- Intention flow ---
 

--- a/tests/test_forced_alignment_worker.py
+++ b/tests/test_forced_alignment_worker.py
@@ -100,7 +100,7 @@ def _patch_feature_ready_and_audio_extract(monkeypatch_audio_path):
     )
     cm.enter_context(
         patch(
-            "ui.workers.forced_alignment_worker._extract_clip_audio_wav",
+            "core.analysis.alignment.extract_audio_to_wav",
             return_value=monkeypatch_audio_path,
         )
     )
@@ -290,7 +290,7 @@ class TestForcedAlignmentWorkerEmptyInput:
         ), patch(
             "core.analysis.alignment.align_words"
         ) as mock_align, patch(
-            "ui.workers.forced_alignment_worker._extract_clip_audio_wav"
+            "core.analysis.alignment.extract_audio_to_wav"
         ) as mock_extract:
             worker = ForcedAlignmentWorker(clips=[], sources_by_id={})
             worker.clip_aligned.connect(

--- a/tests/test_forced_alignment_worker.py
+++ b/tests/test_forced_alignment_worker.py
@@ -1,0 +1,602 @@
+"""Tests for ForcedAlignmentWorker.
+
+Following the convention from tests/test_embedding_worker.py: call worker.run()
+directly (synchronously) rather than start() to avoid QThread scheduling
+complications in the test environment.
+
+U3 of the Word Sequencer plan.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def qapp_fixture():
+    """Qt application required because the worker is a QThread subclass."""
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+@pytest.fixture
+def english_source(tmp_path):
+    """A Source with a real file path (used as the clip's source media)."""
+    from models.clip import Source
+
+    video_file = tmp_path / "video.mp4"
+    video_file.write_bytes(b"\x00" * 100)
+    return Source(
+        id="src-1",
+        file_path=video_file,
+        duration_seconds=60.0,
+        fps=30.0,
+    )
+
+
+def _make_segment(start, end, text, language="en", words=None):
+    """Build a TranscriptSegment with the U1 word/language fields."""
+    from core.transcription import TranscriptSegment
+
+    return TranscriptSegment(
+        start_time=start,
+        end_time=end,
+        text=text,
+        confidence=0.9,
+        words=words,
+        language=language,
+    )
+
+
+def _make_clip_with_transcript(
+    clip_id: str,
+    transcript: list,
+    source_id: str = "src-1",
+):
+    """Build a Clip with a transcript attached (no other analysis fields)."""
+    from tests.conftest import make_test_clip
+
+    clip = make_test_clip(clip_id, source_id=source_id)
+    clip.transcript = transcript
+    return clip
+
+
+def _make_word(start, end, text, probability=0.9):
+    """Build a WordTimestamp."""
+    from core.transcription import WordTimestamp
+
+    return WordTimestamp(start=start, end=end, text=text, probability=probability)
+
+
+# ---------------------------------------------------------------------------
+# Patches shared across the tests
+# ---------------------------------------------------------------------------
+
+
+def _patch_feature_ready_and_audio_extract(monkeypatch_audio_path):
+    """Return context-manager-style patches:
+
+    1. core.feature_registry.check_feature_ready -> (True, [])
+    2. The worker's per-clip audio extraction helper returns a fake WAV path
+       (so the worker doesn't actually shell out to FFmpeg).
+    """
+    from contextlib import ExitStack
+
+    cm = ExitStack()
+    cm.enter_context(
+        patch(
+            "core.feature_registry.check_feature_ready", return_value=(True, [])
+        )
+    )
+    cm.enter_context(
+        patch(
+            "ui.workers.forced_alignment_worker._extract_clip_audio_wav",
+            return_value=monkeypatch_audio_path,
+        )
+    )
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Cancellation contract — the U3 plan's mandatory FIRST failing test.
+# ---------------------------------------------------------------------------
+
+
+class TestForcedAlignmentWorkerCancelContract:
+    """`worker.cancel()` mid-run must:
+
+    - stop emitting further `clip_aligned` signals,
+    - still emit the lifecycle terminator (`alignment_completed`) exactly once,
+    - leave already-aligned clips' partial progress intact (the *handler* writes
+      back — the worker just emits; this test asserts no extra emissions).
+    """
+
+    def test_cancel_mid_run_stops_clip_aligned_and_emits_alignment_completed_once(
+        self, qapp_fixture, english_source, tmp_path
+    ):
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        # Three clips, all with English transcripts; words=None so each is a
+        # candidate for alignment.
+        clip1 = _make_clip_with_transcript(
+            "c1", [_make_segment(0.0, 2.0, "hello world")]
+        )
+        clip2 = _make_clip_with_transcript(
+            "c2", [_make_segment(0.0, 2.0, "second clip")]
+        )
+        clip3 = _make_clip_with_transcript(
+            "c3", [_make_segment(0.0, 2.0, "third clip")]
+        )
+
+        # Fake audio path returned by the mocked extract helper.
+        fake_wav = tmp_path / "fake.wav"
+        fake_wav.write_bytes(b"RIFF")
+
+        ready_calls: list[tuple[str, list]] = []
+        completions: list[bool] = []
+
+        call_count = {"n": 0}
+
+        def fake_align_words(audio_path, segments):
+            # Pretend we did the work and return one word per call.
+            call_count["n"] += 1
+            words = [_make_word(0.0, 0.5, "fakeword")]
+            # Cancel after the FIRST clip has been processed and emitted.
+            # The worker's loop checks cancellation at the top of each clip
+            # iteration, so this guarantees clip2 and clip3 never emit.
+            if call_count["n"] == 1:
+                worker.cancel()
+            return words
+
+        with _patch_feature_ready_and_audio_extract(fake_wav), patch(
+            "core.analysis.alignment.align_words",
+            side_effect=fake_align_words,
+        ):
+            worker = ForcedAlignmentWorker(
+                clips=[clip1, clip2, clip3],
+                sources_by_id={english_source.id: english_source},
+            )
+            worker.clip_aligned.connect(
+                lambda cid, words: ready_calls.append((cid, words))
+            )
+            worker.alignment_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        # Only the first clip's signal was emitted; the cancel was honoured
+        # at the top of the second iteration.
+        assert [cid for cid, _ in ready_calls] == ["c1"]
+        # Lifecycle terminator emits exactly once.
+        assert completions == [True]
+        # align_words was only called once — the worker did not re-enter for c2 or c3.
+        assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Happy path: 3-clip run emits clip_aligned 3 times, progress, then completed.
+# ---------------------------------------------------------------------------
+
+
+class TestForcedAlignmentWorkerHappyPath:
+    def test_three_clips_emit_three_clip_aligned_then_alignment_completed(
+        self, qapp_fixture, english_source, tmp_path
+    ):
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        clips = [
+            _make_clip_with_transcript(
+                f"c{i}", [_make_segment(0.0, 2.0, f"text {i}")]
+            )
+            for i in range(3)
+        ]
+
+        fake_wav = tmp_path / "fake.wav"
+        fake_wav.write_bytes(b"RIFF")
+
+        ready_calls: list[tuple[str, list]] = []
+        progress_events: list[tuple[int, int]] = []
+        completions: list[bool] = []
+
+        def fake_align_words(audio_path, segments):
+            return [_make_word(0.0, 0.5, "word")]
+
+        with _patch_feature_ready_and_audio_extract(fake_wav), patch(
+            "core.analysis.alignment.align_words",
+            side_effect=fake_align_words,
+        ):
+            worker = ForcedAlignmentWorker(
+                clips=clips,
+                sources_by_id={english_source.id: english_source},
+            )
+            worker.clip_aligned.connect(
+                lambda cid, words: ready_calls.append((cid, words))
+            )
+            worker.progress.connect(
+                lambda c, t: progress_events.append((c, t))
+            )
+            worker.alignment_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        assert [cid for cid, _ in ready_calls] == ["c0", "c1", "c2"]
+        # Each word list is the mocked single word per clip.
+        for _cid, words in ready_calls:
+            assert len(words) == 1
+            assert words[0].text == "word"
+
+        # Progress fires incrementally — initial (0, total) plus one per clip.
+        assert progress_events == [(0, 3), (1, 3), (2, 3), (3, 3)]
+        # Completion fires once at the end.
+        assert completions == [True]
+
+    def test_progress_emits_zero_total_at_start_before_first_clip(
+        self, qapp_fixture, english_source, tmp_path
+    ):
+        """Pattern from transcription_worker: emit (0, total) before loop."""
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        clips = [
+            _make_clip_with_transcript(
+                "c1", [_make_segment(0.0, 2.0, "text one")]
+            )
+        ]
+        fake_wav = tmp_path / "fake.wav"
+        fake_wav.write_bytes(b"RIFF")
+
+        progress_events: list[tuple[int, int]] = []
+
+        with _patch_feature_ready_and_audio_extract(fake_wav), patch(
+            "core.analysis.alignment.align_words",
+            return_value=[_make_word(0.0, 0.5, "word")],
+        ):
+            worker = ForcedAlignmentWorker(
+                clips=clips,
+                sources_by_id={english_source.id: english_source},
+            )
+            worker.progress.connect(
+                lambda c, t: progress_events.append((c, t))
+            )
+            worker.run()
+
+        # First event is (0, 1) (pre-loop preload progress); last is (1, 1).
+        assert progress_events[0] == (0, 1)
+        assert progress_events[-1] == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Empty input list: immediate completion, no clip_aligned, no model load.
+# ---------------------------------------------------------------------------
+
+
+class TestForcedAlignmentWorkerEmptyInput:
+    def test_empty_clip_list_emits_completion_without_clip_aligned(
+        self, qapp_fixture
+    ):
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        ready_calls: list = []
+        completions: list[bool] = []
+
+        with patch(
+            "core.feature_registry.check_feature_ready", return_value=(True, [])
+        ), patch(
+            "core.analysis.alignment.align_words"
+        ) as mock_align, patch(
+            "ui.workers.forced_alignment_worker._extract_clip_audio_wav"
+        ) as mock_extract:
+            worker = ForcedAlignmentWorker(clips=[], sources_by_id={})
+            worker.clip_aligned.connect(
+                lambda cid, words: ready_calls.append(cid)
+            )
+            worker.alignment_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        # No alignment work attempted, no audio extracted.
+        mock_align.assert_not_called()
+        mock_extract.assert_not_called()
+        assert ready_calls == []
+        assert completions == [True]
+
+
+# ---------------------------------------------------------------------------
+# Skip predicate: a clip whose every segment already has words is skipped.
+# ---------------------------------------------------------------------------
+
+
+class TestForcedAlignmentWorkerSkipPredicate:
+    def test_clip_with_all_segments_populated_is_skipped(
+        self, qapp_fixture, english_source, tmp_path
+    ):
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        already_aligned = _make_clip_with_transcript(
+            "c-aligned",
+            [
+                _make_segment(
+                    0.0,
+                    1.0,
+                    "done",
+                    words=[_make_word(0.0, 0.5, "done")],
+                )
+            ],
+        )
+        partially_aligned = _make_clip_with_transcript(
+            "c-partial",
+            [
+                _make_segment(
+                    0.0,
+                    1.0,
+                    "first",
+                    words=[_make_word(0.0, 0.5, "first")],
+                ),
+                # Second segment .words is None → clip needs re-alignment.
+                _make_segment(1.0, 2.0, "second", words=None),
+            ],
+        )
+        empty_words_clip = _make_clip_with_transcript(
+            "c-empty-words",
+            [
+                # Empty list means "aligned but produced no words" — still aligned.
+                _make_segment(0.0, 1.0, "silence", words=[]),
+            ],
+        )
+        unaligned = _make_clip_with_transcript(
+            "c-unaligned", [_make_segment(0.0, 2.0, "needs alignment")]
+        )
+
+        fake_wav = tmp_path / "fake.wav"
+        fake_wav.write_bytes(b"RIFF")
+
+        ready_calls: list[str] = []
+
+        with _patch_feature_ready_and_audio_extract(fake_wav), patch(
+            "core.analysis.alignment.align_words",
+            return_value=[_make_word(0.0, 0.5, "word")],
+        ) as mock_align:
+            worker = ForcedAlignmentWorker(
+                clips=[already_aligned, partially_aligned, empty_words_clip, unaligned],
+                sources_by_id={english_source.id: english_source},
+            )
+            worker.clip_aligned.connect(
+                lambda cid, words: ready_calls.append(cid)
+            )
+            worker.run()
+
+        # Only the partially-aligned and unaligned clips should run.
+        assert sorted(ready_calls) == ["c-partial", "c-unaligned"]
+        assert mock_align.call_count == 2
+
+    def test_clip_with_no_transcript_is_skipped(
+        self, qapp_fixture, english_source, tmp_path
+    ):
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        clip = _make_clip_with_transcript("c1", [])
+        clip.transcript = None  # entirely missing transcript
+
+        fake_wav = tmp_path / "fake.wav"
+        fake_wav.write_bytes(b"RIFF")
+
+        ready_calls: list[str] = []
+        completions: list[bool] = []
+
+        with _patch_feature_ready_and_audio_extract(fake_wav), patch(
+            "core.analysis.alignment.align_words"
+        ) as mock_align:
+            worker = ForcedAlignmentWorker(
+                clips=[clip],
+                sources_by_id={english_source.id: english_source},
+            )
+            worker.clip_aligned.connect(
+                lambda cid, words: ready_calls.append(cid)
+            )
+            worker.alignment_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        mock_align.assert_not_called()
+        assert ready_calls == []
+        assert completions == [True]
+
+
+# ---------------------------------------------------------------------------
+# Error path: align_words raises mid-run → error signal, no alignment_completed
+# regression for already-emitted clips.
+# ---------------------------------------------------------------------------
+
+
+class TestForcedAlignmentWorkerErrorPath:
+    def test_align_words_exception_emits_error_and_continues(
+        self, qapp_fixture, english_source, tmp_path
+    ):
+        """One bad clip should not poison the whole batch."""
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        clips = [
+            _make_clip_with_transcript(
+                f"c{i}", [_make_segment(0.0, 2.0, f"text {i}")]
+            )
+            for i in range(3)
+        ]
+
+        fake_wav = tmp_path / "fake.wav"
+        fake_wav.write_bytes(b"RIFF")
+
+        call_count = {"n": 0}
+
+        def fake_align_words(audio_path, segments):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("Simulated alignment failure")
+            return [_make_word(0.0, 0.5, "word")]
+
+        ready_calls: list[str] = []
+        errors: list[str] = []
+        completions: list[bool] = []
+
+        with _patch_feature_ready_and_audio_extract(fake_wav), patch(
+            "core.analysis.alignment.align_words",
+            side_effect=fake_align_words,
+        ):
+            worker = ForcedAlignmentWorker(
+                clips=clips,
+                sources_by_id={english_source.id: english_source},
+            )
+            worker.clip_aligned.connect(
+                lambda cid, words: ready_calls.append(cid)
+            )
+            worker.error.connect(lambda msg: errors.append(msg))
+            worker.alignment_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        # First and third clips succeeded; second raised.
+        assert ready_calls == ["c0", "c2"]
+        # At least one error message surfaced and mentions the failure.
+        assert len(errors) == 1
+        assert "Simulated alignment failure" in errors[0]
+        # Completion still fires so the analyze-tab pipeline can advance.
+        assert completions == [True]
+
+    def test_unsupported_language_raises_to_error_signal(
+        self, qapp_fixture, english_source, tmp_path
+    ):
+        """UnsupportedLanguageError must surface as an error message."""
+        from core.analysis.alignment import UnsupportedLanguageError
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        clip = _make_clip_with_transcript(
+            "c1",
+            [_make_segment(0.0, 2.0, "salut", language="xx")],
+        )
+        fake_wav = tmp_path / "fake.wav"
+        fake_wav.write_bytes(b"RIFF")
+
+        errors: list[str] = []
+        completions: list[bool] = []
+
+        def boom(audio_path, segments):
+            raise UnsupportedLanguageError("xx")
+
+        with _patch_feature_ready_and_audio_extract(fake_wav), patch(
+            "core.analysis.alignment.align_words",
+            side_effect=boom,
+        ):
+            worker = ForcedAlignmentWorker(
+                clips=[clip],
+                sources_by_id={english_source.id: english_source},
+            )
+            worker.error.connect(lambda msg: errors.append(msg))
+            worker.alignment_completed.connect(lambda: completions.append(True))
+            worker.run()
+
+        assert len(errors) == 1
+        assert "xx" in errors[0]
+        assert completions == [True]
+
+
+# ---------------------------------------------------------------------------
+# Re-run idempotency: running the worker twice on the same set is a no-op the
+# second time (the skip predicate sees populated word lists).
+# ---------------------------------------------------------------------------
+
+
+class TestForcedAlignmentWorkerIdempotentRerun:
+    def test_second_run_after_handler_writeback_is_a_noop(
+        self, qapp_fixture, english_source, tmp_path
+    ):
+        """Simulate the analyze-tab handler writing words back between runs."""
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        clip = _make_clip_with_transcript(
+            "c1", [_make_segment(0.0, 2.0, "hello world")]
+        )
+        fake_wav = tmp_path / "fake.wav"
+        fake_wav.write_bytes(b"RIFF")
+
+        with _patch_feature_ready_and_audio_extract(fake_wav), patch(
+            "core.analysis.alignment.align_words",
+            return_value=[_make_word(0.0, 0.5, "hello")],
+        ) as mock_align:
+            # First run — alignment happens.
+            worker = ForcedAlignmentWorker(
+                clips=[clip],
+                sources_by_id={english_source.id: english_source},
+            )
+            worker.run()
+            assert mock_align.call_count == 1
+
+            # Simulate the analyze-tab handler writing words back to every segment.
+            for seg in clip.transcript:
+                seg.words = [_make_word(0.0, 0.5, "hello")]
+
+            # Second run on the same clip — should be a no-op because every
+            # segment now has populated .words.
+            worker2 = ForcedAlignmentWorker(
+                clips=[clip],
+                sources_by_id={english_source.id: english_source},
+            )
+            worker2.run()
+            assert mock_align.call_count == 1  # no additional calls
+
+
+# ---------------------------------------------------------------------------
+# Integration: after a run, the words payload emitted via clip_aligned matches
+# what align_words returned, and the worker delivered them in order.
+# ---------------------------------------------------------------------------
+
+
+class TestForcedAlignmentWorkerWordPayload:
+    def test_emitted_words_match_align_words_return(
+        self, qapp_fixture, english_source, tmp_path
+    ):
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        clip = _make_clip_with_transcript(
+            "c1",
+            [
+                _make_segment(0.0, 1.5, "hello world"),
+                _make_segment(1.5, 3.0, "second segment"),
+            ],
+        )
+
+        fake_wav = tmp_path / "fake.wav"
+        fake_wav.write_bytes(b"RIFF")
+
+        words_payload = [
+            _make_word(0.0, 0.5, "hello"),
+            _make_word(0.5, 1.0, "world"),
+            _make_word(1.5, 2.0, "second"),
+            _make_word(2.0, 2.8, "segment"),
+        ]
+
+        ready_calls: list[tuple[str, list]] = []
+
+        with _patch_feature_ready_and_audio_extract(fake_wav), patch(
+            "core.analysis.alignment.align_words",
+            return_value=words_payload,
+        ):
+            worker = ForcedAlignmentWorker(
+                clips=[clip],
+                sources_by_id={english_source.id: english_source},
+            )
+            worker.clip_aligned.connect(
+                lambda cid, words: ready_calls.append((cid, words))
+            )
+            worker.run()
+
+        assert len(ready_calls) == 1
+        emitted_clip_id, emitted_words = ready_calls[0]
+        assert emitted_clip_id == "c1"
+        assert [w.text for w in emitted_words] == [
+            "hello",
+            "world",
+            "second",
+            "segment",
+        ]

--- a/tests/test_llm_client_constrained.py
+++ b/tests/test_llm_client_constrained.py
@@ -312,3 +312,44 @@ def test_zero_target_length_raises_value_error():
             prompt="p", vocabulary=["x"], target_length=0,
             model="m", api_base="http://localhost:11434",
         )
+
+
+# ---------------------------------------------------------------------------
+# check_ollama_health_sync — async-to-sync wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_check_ollama_health_sync_returns_async_result():
+    """The sync wrapper proxies the async helper's tuple verbatim."""
+    from core import llm_client
+
+    async def _fake_async_probe(api_base: str = "http://localhost:11434"):
+        return False, f"fake failure: {api_base}"
+
+    with patch.object(llm_client, "check_ollama_health", _fake_async_probe):
+        healthy, message = llm_client.check_ollama_health_sync(
+            "http://example:11434",
+        )
+
+    assert healthy is False
+    assert "example:11434" in message
+
+
+def test_check_ollama_health_sync_only_swallows_runtime_error():
+    """Non-``RuntimeError`` exceptions must propagate.
+
+    The old dialog wrapper used a bare ``except Exception``; this test
+    pins the new behavior: only the nested-loop ``RuntimeError`` is
+    silently treated as "healthy".
+    """
+    from core import llm_client
+
+    class _Boom(Exception):
+        pass
+
+    async def _explode(api_base: str = "http://localhost:11434"):
+        raise _Boom("real failure")
+
+    with patch.object(llm_client, "check_ollama_health", _explode):
+        with pytest.raises(_Boom):
+            llm_client.check_ollama_health_sync("http://example:11434")

--- a/tests/test_llm_client_constrained.py
+++ b/tests/test_llm_client_constrained.py
@@ -1,0 +1,314 @@
+"""Tests for ``core/llm_client.complete_with_enum_constraint``.
+
+Covers the Ollama-via-HTTP path for JSON-schema-enum constrained
+decoding. Real Ollama is not exercised here (unit tests only); the
+real-server integration test for ``compose_with_llm`` lives in
+``tests/test_word_llm_composer.py`` and is gated by the
+``SCENE_RIPPER_OLLAMA_INTEGRATION`` env var.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake httpx response objects
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, body: dict | str):
+        self.status_code = status_code
+        if isinstance(body, dict):
+            self._body = body
+            self.text = json.dumps(body)
+        else:
+            self._body = None
+            self.text = body
+
+    def json(self):
+        if self._body is None:
+            raise ValueError("not valid json")
+        return self._body
+
+
+class _FakeHttpxClient:
+    def __init__(self, response=None, exc=None):
+        self._response = response
+        self._exc = exc
+        self.posted_url = None
+        self.posted_json = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def post(self, url, json=None):  # noqa: A002 — match httpx kwarg
+        self.posted_url = url
+        self.posted_json = json
+        if self._exc is not None:
+            raise self._exc
+        return self._response
+
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def _ok_body(words: list[str]) -> dict:
+    return {"message": {"content": json.dumps({"words": words})}}
+
+
+def test_returns_words_on_happy_path():
+    from core.llm_client import complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(response=_FakeResponse(200, _ok_body(["the", "sky"])))
+
+    with patch("httpx.Client", return_value=fake):
+        out = complete_with_enum_constraint(
+            prompt="compose",
+            vocabulary=["the", "sky", "is"],
+            target_length=2,
+            model="qwen3:8b",
+            api_base="http://localhost:11434",
+        )
+
+    assert out == ["the", "sky"]
+
+
+def test_payload_carries_schema_with_enum():
+    from core.llm_client import complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(response=_FakeResponse(200, _ok_body(["a"])))
+
+    with patch("httpx.Client", return_value=fake):
+        complete_with_enum_constraint(
+            prompt="x",
+            vocabulary=["b", "a", "c"],
+            target_length=1,
+            model="qwen3:8b",
+            api_base="http://localhost:11434",
+        )
+
+    body = fake.posted_json
+    assert body["model"] == "qwen3:8b"
+    schema = body["format"]
+    assert schema["type"] == "object"
+    enum = schema["properties"]["words"]["items"]["enum"]
+    # Vocabulary is deduplicated and sorted for deterministic schema construction.
+    assert enum == ["a", "b", "c"]
+    # System prompt should mention vocabulary; frequencies omitted by default.
+    sys_msg = body["messages"][0]
+    assert sys_msg["role"] == "system"
+    assert "a" in sys_msg["content"] and "b" in sys_msg["content"]
+
+
+def test_frequency_annotation_in_system_prompt():
+    from core.llm_client import complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(response=_FakeResponse(200, _ok_body(["the"])))
+    with patch("httpx.Client", return_value=fake):
+        complete_with_enum_constraint(
+            prompt="x",
+            vocabulary=["the", "a"],
+            target_length=5,
+            frequencies={"the": 42, "a": 38},
+            model="qwen3:8b",
+            api_base="http://localhost:11434",
+        )
+
+    sys_content = fake.posted_json["messages"][0]["content"]
+    assert "the (42)" in sys_content
+    assert "a (38)" in sys_content
+
+
+def test_url_is_chat_endpoint():
+    """``complete_with_enum_constraint`` posts to /api/chat (chat endpoint)."""
+    from core.llm_client import complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(response=_FakeResponse(200, _ok_body(["x"])))
+    with patch("httpx.Client", return_value=fake):
+        complete_with_enum_constraint(
+            prompt="p",
+            vocabulary=["x"],
+            target_length=1,
+            model="qwen3:8b",
+            api_base="http://localhost:11434/",
+        )
+    assert fake.posted_url == "http://localhost:11434/api/chat"
+
+
+def test_model_prefix_stripped():
+    """``ollama/`` prefix is stripped before posting to Ollama directly."""
+    from core.llm_client import complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(response=_FakeResponse(200, _ok_body(["x"])))
+    with patch("httpx.Client", return_value=fake):
+        complete_with_enum_constraint(
+            prompt="p",
+            vocabulary=["x"],
+            target_length=1,
+            model="ollama/qwen3:8b",
+            api_base="http://localhost:11434",
+        )
+    assert fake.posted_json["model"] == "qwen3:8b"
+
+
+# ---------------------------------------------------------------------------
+# Error paths — LLMEmptyResponseError
+# ---------------------------------------------------------------------------
+
+
+def test_none_content_raises_empty_response_error():
+    from core.llm_client import LLMEmptyResponseError, complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(
+        response=_FakeResponse(200, {"message": {"content": None}})
+    )
+    with patch("httpx.Client", return_value=fake):
+        with pytest.raises(LLMEmptyResponseError) as exc:
+            complete_with_enum_constraint(
+                prompt="p", vocabulary=["x"], target_length=1,
+                model="m", api_base="http://localhost:11434",
+            )
+    assert "no content" in str(exc.value).lower() or "no content" in exc.value.hint.lower()
+
+
+def test_empty_string_content_raises_empty_response_error():
+    from core.llm_client import LLMEmptyResponseError, complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(
+        response=_FakeResponse(200, {"message": {"content": ""}})
+    )
+    with patch("httpx.Client", return_value=fake):
+        with pytest.raises(LLMEmptyResponseError):
+            complete_with_enum_constraint(
+                prompt="p", vocabulary=["x"], target_length=1,
+                model="m", api_base="http://localhost:11434",
+            )
+
+
+def test_empty_words_list_raises_empty_response_error():
+    from core.llm_client import LLMEmptyResponseError, complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(
+        response=_FakeResponse(
+            200, {"message": {"content": json.dumps({"words": []})}}
+        )
+    )
+    with patch("httpx.Client", return_value=fake):
+        with pytest.raises(LLMEmptyResponseError):
+            complete_with_enum_constraint(
+                prompt="p", vocabulary=["x"], target_length=1,
+                model="m", api_base="http://localhost:11434",
+            )
+
+
+def test_missing_words_key_raises_empty_response_error():
+    from core.llm_client import LLMEmptyResponseError, complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(
+        response=_FakeResponse(
+            200, {"message": {"content": json.dumps({"sentence": "hi"})}}
+        )
+    )
+    with patch("httpx.Client", return_value=fake):
+        with pytest.raises(LLMEmptyResponseError):
+            complete_with_enum_constraint(
+                prompt="p", vocabulary=["x"], target_length=1,
+                model="m", api_base="http://localhost:11434",
+            )
+
+
+def test_non_json_content_raises_empty_response_error():
+    from core.llm_client import LLMEmptyResponseError, complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(
+        response=_FakeResponse(200, {"message": {"content": "not json at all"}})
+    )
+    with patch("httpx.Client", return_value=fake):
+        with pytest.raises(LLMEmptyResponseError):
+            complete_with_enum_constraint(
+                prompt="p", vocabulary=["x"], target_length=1,
+                model="m", api_base="http://localhost:11434",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Error paths — OllamaUnreachableError
+# ---------------------------------------------------------------------------
+
+
+def test_connect_error_raises_ollama_unreachable():
+    import httpx
+
+    from core.llm_client import OllamaUnreachableError, complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(exc=httpx.ConnectError("connection refused"))
+    with patch("httpx.Client", return_value=fake):
+        with pytest.raises(OllamaUnreachableError) as exc:
+            complete_with_enum_constraint(
+                prompt="p", vocabulary=["x"], target_length=1,
+                model="m", api_base="http://localhost:11434",
+            )
+    assert "ollama" in str(exc.value).lower()
+
+
+def test_timeout_raises_ollama_unreachable_with_hint():
+    import httpx
+
+    from core.llm_client import OllamaUnreachableError, complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(exc=httpx.ReadTimeout("slow"))
+    with patch("httpx.Client", return_value=fake):
+        with pytest.raises(OllamaUnreachableError) as exc:
+            complete_with_enum_constraint(
+                prompt="p", vocabulary=["x"], target_length=1,
+                model="m", api_base="http://localhost:11434",
+            )
+    assert "timed out" in str(exc.value).lower() or "timeout" in str(exc.value).lower()
+
+
+def test_non_200_status_raises_ollama_unreachable():
+    from core.llm_client import OllamaUnreachableError, complete_with_enum_constraint
+
+    fake = _FakeHttpxClient(response=_FakeResponse(500, "boom"))
+    with patch("httpx.Client", return_value=fake):
+        with pytest.raises(OllamaUnreachableError) as exc:
+            complete_with_enum_constraint(
+                prompt="p", vocabulary=["x"], target_length=1,
+                model="m", api_base="http://localhost:11434",
+            )
+    assert "500" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+def test_empty_vocabulary_raises_value_error():
+    from core.llm_client import complete_with_enum_constraint
+
+    with pytest.raises(ValueError, match="vocabulary"):
+        complete_with_enum_constraint(
+            prompt="p", vocabulary=[], target_length=1,
+            model="m", api_base="http://localhost:11434",
+        )
+
+
+def test_zero_target_length_raises_value_error():
+    from core.llm_client import complete_with_enum_constraint
+
+    with pytest.raises(ValueError, match="target_length"):
+        complete_with_enum_constraint(
+            prompt="p", vocabulary=["x"], target_length=0,
+            model="m", api_base="http://localhost:11434",
+        )

--- a/tests/test_spine_imports.py
+++ b/tests/test_spine_imports.py
@@ -45,6 +45,7 @@ SPINE_MODULES: tuple[str, ...] = (
     "core.spine.analyze",
     "core.spine.thumbnails",
     "core.spine.downloads",
+    "core.spine.words",
 )
 
 

--- a/tests/test_spine_words.py
+++ b/tests/test_spine_words.py
@@ -1,0 +1,387 @@
+"""Tests for ``core/spine/words.py``: word inventory + 5 preset ordering modes.
+
+These tests pin the contract the U4 word-sequencer feature relies on:
+- Word normalization (lowercase + strip surrounding ASCII punctuation;
+  contractions kept whole).
+- ``WordInventory`` with both ``by_word`` and ``by_clip`` indices.
+- Five mode functions: ``alphabetical``, ``by_chosen_words``, ``by_frequency``,
+  ``by_property``, ``from_word_list`` — with the keyword-name and default
+  semantics documented in the plan.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+from core.spine.words import (
+    MissingWordsError,
+    WordInstance,
+    WordInventory,
+    alphabetical,
+    build_inventory,
+    by_chosen_words,
+    by_frequency,
+    by_property,
+    from_word_list,
+)
+from core.transcription import TranscriptSegment, WordTimestamp
+
+
+# ---------------------------------------------------------------------------
+# Mocks: lightweight stand-ins so the spine tests can stay decoupled from
+# the full Clip/Source dataclasses.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockSource:
+    id: str = "src1"
+    fps: float = 24.0
+
+
+@dataclass
+class MockClip:
+    id: str = "clip1"
+    source_id: str = "src1"
+    start_frame: int = 0
+    end_frame: int = 240  # 10 s at 24 fps
+    transcript: Optional[list[TranscriptSegment]] = None
+
+
+def _seg(words: list[tuple[str, float, float]], language: str = "en") -> TranscriptSegment:
+    """Build a TranscriptSegment with a list of (text, start, end) word tuples."""
+    word_list = [WordTimestamp(start=s, end=e, text=t) for (t, s, e) in words]
+    return TranscriptSegment(
+        start_time=words[0][1] if words else 0.0,
+        end_time=words[-1][2] if words else 0.0,
+        text=" ".join(t for t, _, _ in words),
+        confidence=1.0,
+        words=word_list,
+        language=language,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_inventory
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInventory:
+    def test_empty_clips_returns_empty_inventory(self):
+        inv = build_inventory([])
+        assert isinstance(inv, WordInventory)
+        assert inv.by_word == {}
+        assert inv.by_clip == {}
+
+    def test_clip_without_transcript_skipped_cleanly(self):
+        clip = MockClip(transcript=None)
+        inv = build_inventory([(clip, MockSource())])
+        assert inv.by_word == {}
+        assert inv.by_clip == {}
+
+    def test_clip_with_empty_segment_words_skipped(self):
+        clip = MockClip(
+            transcript=[
+                TranscriptSegment(
+                    start_time=0.0,
+                    end_time=1.0,
+                    text="",
+                    confidence=1.0,
+                    words=[],
+                    language="en",
+                )
+            ]
+        )
+        inv = build_inventory([(clip, MockSource())])
+        assert inv.by_word == {}
+        # An entry in by_clip is fine but must not invent words.
+        assert inv.by_clip.get(clip.id, []) == []
+
+    def test_normalization_lowercase_and_punctuation(self):
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("The", 0.0, 0.3),
+                        ("Sky,", 0.4, 0.8),
+                        ("blue!", 0.9, 1.2),
+                        ("the", 1.3, 1.5),
+                    ]
+                )
+            ]
+        )
+        inv = build_inventory([(clip, MockSource())])
+        assert set(inv.by_word.keys()) == {"the", "sky", "blue"}
+        # Original text is preserved on the instance.
+        the_instances = inv.by_word["the"]
+        assert {w.text for w in the_instances} == {"The", "the"}
+
+    def test_contractions_stay_whole(self):
+        clip = MockClip(
+            transcript=[_seg([("don't", 0.0, 0.4), ("don't", 0.5, 0.9)])]
+        )
+        inv = build_inventory([(clip, MockSource())])
+        assert list(inv.by_word.keys()) == ["don't"]
+        assert len(inv.by_word["don't"]) == 2
+
+    def test_by_clip_groups_words_by_clip_id(self):
+        clip_a = MockClip(id="A", transcript=[_seg([("alpha", 0.0, 0.5), ("beta", 0.6, 1.0)])])
+        clip_b = MockClip(id="B", transcript=[_seg([("alpha", 0.0, 0.5)])])
+        inv = build_inventory([(clip_a, MockSource()), (clip_b, MockSource())])
+        assert len(inv.by_clip["A"]) == 2
+        assert len(inv.by_clip["B"]) == 1
+        # Cross-check by_word
+        assert len(inv.by_word["alpha"]) == 2
+        assert len(inv.by_word["beta"]) == 1
+
+    def test_instance_records_indices_and_ids(self):
+        clip = MockClip(
+            id="clip_x",
+            source_id="src_x",
+            transcript=[_seg([("hello", 0.0, 0.5), ("world", 0.6, 1.0)])],
+        )
+        inv = build_inventory([(clip, MockSource(id="src_x"))])
+        hello = inv.by_word["hello"][0]
+        assert hello.source_id == "src_x"
+        assert hello.clip_id == "clip_x"
+        assert hello.segment_index == 0
+        assert hello.word_index == 0
+        world = inv.by_word["world"][0]
+        assert world.word_index == 1
+
+
+# ---------------------------------------------------------------------------
+# alphabetical
+# ---------------------------------------------------------------------------
+
+
+class TestAlphabetical:
+    def test_lexical_order(self):
+        clip = MockClip(
+            transcript=[
+                _seg([("zoo", 0.0, 0.3), ("apple", 0.4, 0.7), ("mango", 0.8, 1.1)])
+            ]
+        )
+        inv = build_inventory([(clip, MockSource())])
+        result = alphabetical(inv)
+        assert [w.text.lower() for w in result] == ["apple", "mango", "zoo"]
+
+    def test_encounter_order_within_word(self):
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("the", 0.0, 0.2),  # first
+                        ("apple", 0.3, 0.6),
+                        ("the", 0.7, 0.9),  # second
+                    ]
+                )
+            ]
+        )
+        inv = build_inventory([(clip, MockSource())])
+        result = alphabetical(inv)
+        # apple sorts before the
+        assert result[0].text == "apple"
+        # Both "the" come in encounter order (by start time).
+        the_starts = [w.start for w in result[1:]]
+        assert the_starts == sorted(the_starts)
+
+    def test_empty_inventory(self):
+        assert alphabetical(WordInventory(by_word={}, by_clip={})) == []
+
+
+# ---------------------------------------------------------------------------
+# by_frequency
+# ---------------------------------------------------------------------------
+
+
+class TestByFrequency:
+    def _inv(self) -> WordInventory:
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("the", 0.0, 0.2),
+                        ("dog", 0.3, 0.5),
+                        ("the", 0.6, 0.8),
+                        ("cat", 0.9, 1.1),
+                        ("the", 1.2, 1.4),
+                        ("dog", 1.5, 1.7),
+                    ]
+                )
+            ]
+        )
+        return build_inventory([(clip, MockSource())])
+
+    def test_descending_default(self):
+        inv = self._inv()
+        result = by_frequency(inv)  # default descending
+        # "the" (3) → "dog" (2) → "cat" (1)
+        words = [w.text.lower() for w in result]
+        assert words[:3] == ["the", "the", "the"]
+        assert words[3:5] == ["dog", "dog"]
+        assert words[5:] == ["cat"]
+
+    def test_ascending(self):
+        inv = self._inv()
+        result = by_frequency(inv, order="ascending")
+        words = [w.text.lower() for w in result]
+        assert words[0] == "cat"
+        assert words[1:3] == ["dog", "dog"]
+        assert words[3:] == ["the", "the", "the"]
+
+
+# ---------------------------------------------------------------------------
+# by_chosen_words
+# ---------------------------------------------------------------------------
+
+
+class TestByChosenWords:
+    def _inv(self) -> WordInventory:
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("never", 0.0, 0.3),
+                        ("always", 0.4, 0.7),
+                        ("never", 0.8, 1.1),
+                        ("silence", 1.2, 1.5),
+                        ("always", 1.6, 1.9),
+                    ]
+                )
+            ]
+        )
+        return build_inventory([(clip, MockSource())])
+
+    def test_grouped_by_include_order(self):
+        inv = self._inv()
+        result = by_chosen_words(inv, include=["never", "always"])
+        words = [w.text.lower() for w in result]
+        # Every "never" first, then every "always".
+        assert words == ["never", "never", "always", "always"]
+
+    def test_case_insensitive(self):
+        inv = self._inv()
+        result = by_chosen_words(inv, include=["Never", "ALWAYS"])
+        assert len(result) == 4
+
+    def test_unknown_words_silently_dropped(self):
+        inv = self._inv()
+        result = by_chosen_words(inv, include=["never", "xyz"])
+        words = [w.text.lower() for w in result]
+        assert words == ["never", "never"]
+
+    def test_all_unknown_returns_empty(self):
+        inv = self._inv()
+        assert by_chosen_words(inv, include=["xyz", "abc"]) == []
+
+
+# ---------------------------------------------------------------------------
+# by_property
+# ---------------------------------------------------------------------------
+
+
+class TestByProperty:
+    def _inv(self) -> WordInventory:
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("a", 0.0, 0.1),  # length 1, dur 0.1
+                        ("bb", 0.2, 0.6),  # length 2, dur 0.4
+                        ("ccc", 0.7, 0.9),  # length 3, dur 0.2
+                        ("a", 1.0, 1.5),  # repeat: bumps "a" frequency to 2
+                    ]
+                )
+            ]
+        )
+        return build_inventory([(clip, MockSource())])
+
+    def test_length_ascending_default(self):
+        inv = self._inv()
+        result = by_property(inv, key="length")
+        lengths = [len(w.text) for w in result]
+        assert lengths == sorted(lengths)
+        assert lengths[0] == 1
+        assert lengths[-1] == 3
+
+    def test_length_descending(self):
+        inv = self._inv()
+        result = by_property(inv, key="length", order="descending")
+        lengths = [len(w.text) for w in result]
+        assert lengths == sorted(lengths, reverse=True)
+
+    def test_duration_ascending(self):
+        inv = self._inv()
+        result = by_property(inv, key="duration")
+        durations = [w.end - w.start for w in result]
+        assert durations == sorted(durations)
+
+    def test_log_frequency_ascending(self):
+        inv = self._inv()
+        # "a" appears twice, "bb"/"ccc" once each → "bb"/"ccc" come first (lower freq).
+        result = by_property(inv, key="log_frequency")
+        # Two least-frequent words first (singletons), then the doubled "a"s.
+        words = [w.text for w in result]
+        assert words[-2:] == ["a", "a"]
+
+
+# ---------------------------------------------------------------------------
+# from_word_list
+# ---------------------------------------------------------------------------
+
+
+class TestFromWordList:
+    def _inv(self) -> WordInventory:
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("the", 0.0, 0.2),
+                        ("sky", 0.3, 0.6),
+                        ("the", 0.7, 0.9),
+                    ]
+                )
+            ]
+        )
+        return build_inventory([(clip, MockSource())])
+
+    def test_literal_materialization_with_repeats(self):
+        inv = self._inv()
+        result = from_word_list(inv, sequence=["the", "the", "the", "sky"])
+        # Exactly 4 slots — repeats produce multiple instance picks.
+        assert len(result) == 4
+        # The non-"the" entry is "sky".
+        assert result[3].text.lower() == "sky"
+
+    def test_skip_missing_default(self):
+        inv = self._inv()
+        result = from_word_list(inv, sequence=["the", "missing", "sky"])
+        assert [w.text.lower() for w in result] == ["the", "sky"]
+
+    def test_raise_missing(self):
+        inv = self._inv()
+        with pytest.raises(MissingWordsError) as exc:
+            from_word_list(inv, sequence=["the", "missing", "sky", "also_missing"], on_missing="raise")
+        assert "missing" in exc.value.missing
+        assert "also_missing" in exc.value.missing
+
+    def test_case_insensitive_lookup(self):
+        inv = self._inv()
+        result = from_word_list(inv, sequence=["The", "SKY"])
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# WordInventory dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestWordInventory:
+    def test_inventory_is_frozen(self):
+        inv = WordInventory(by_word={}, by_clip={})
+        with pytest.raises((AttributeError, TypeError)):
+            inv.by_word = {}  # type: ignore[misc]

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,10 +1,18 @@
 """Regression tests for transcription edge cases."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
-from core.transcription import FFmpegNotFoundError, transcribe_clip, transcribe_video
+from core.transcription import (
+    FFmpegNotFoundError,
+    TranscriptSegment,
+    WordTimestamp,
+    _parse_mlx_result,
+    transcribe_clip,
+    transcribe_video,
+)
 
 
 def test_transcribe_clip_skips_video_without_audio(monkeypatch):
@@ -64,3 +72,263 @@ def test_transcribe_clip_missing_ffmpeg_raises_clear_error(monkeypatch):
             end_time=5.0,
             backend="faster-whisper",
         )
+
+
+# ---------------------------------------------------------------------------
+# U1: TranscriptSegment word-data schema + language capture
+# ---------------------------------------------------------------------------
+
+
+def test_word_timestamp_round_trip():
+    """WordTimestamp round-trips through to_dict/from_dict with and without probability."""
+    word = WordTimestamp(start=0.5, end=0.8, text="hello", probability=0.92)
+    round_tripped = WordTimestamp.from_dict(word.to_dict())
+    assert round_tripped == word
+
+    bare = WordTimestamp(start=1.0, end=1.2, text="world")
+    bare_rt = WordTimestamp.from_dict(bare.to_dict())
+    assert bare_rt == bare
+    assert bare_rt.probability is None
+
+
+def test_transcript_segment_round_trip_with_words_and_language():
+    """A segment with words and language round-trips identically."""
+    seg = TranscriptSegment(
+        start_time=0.0,
+        end_time=1.5,
+        text="hello world",
+        confidence=-0.1,
+        words=[
+            WordTimestamp(start=0.0, end=0.4, text="hello", probability=0.95),
+            WordTimestamp(start=0.5, end=1.5, text="world", probability=0.88),
+        ],
+        language="en",
+    )
+    round_tripped = TranscriptSegment.from_dict(seg.to_dict())
+    assert round_tripped == seg
+
+
+def test_transcript_segment_round_trip_old_format_back_compat():
+    """An old-format dict (no words, no language) deserializes with words=None, language=None."""
+    legacy_data = {
+        "start_time": 0.0,
+        "end_time": 1.0,
+        "text": "legacy",
+        "confidence": 0.0,
+    }
+    seg = TranscriptSegment.from_dict(legacy_data)
+    assert seg.words is None
+    assert seg.language is None
+    # And the segment otherwise functions normally.
+    assert seg.start_time == 0.0
+    assert seg.end_time == 1.0
+    assert seg.text == "legacy"
+
+
+def test_transcript_segment_distinguishes_none_from_empty_words_list():
+    """words=None and words=[] are distinct states and must both survive a round trip.
+
+    None == "no word data surfaced yet" (MLX pre-alignment, or legacy projects).
+    []   == "alignment ran and produced no words" (silence/instrumental).
+    """
+    none_seg = TranscriptSegment(
+        start_time=0.0,
+        end_time=1.0,
+        text="silence",
+        confidence=0.0,
+        words=None,
+        language="en",
+    )
+    empty_seg = TranscriptSegment(
+        start_time=0.0,
+        end_time=1.0,
+        text="silence",
+        confidence=0.0,
+        words=[],
+        language="en",
+    )
+
+    none_rt = TranscriptSegment.from_dict(none_seg.to_dict())
+    empty_rt = TranscriptSegment.from_dict(empty_seg.to_dict())
+
+    assert none_rt.words is None
+    assert empty_rt.words == []
+    assert none_rt != empty_rt
+
+
+def test_transcribe_video_faster_whisper_captures_words_and_language(monkeypatch):
+    """faster-whisper segments' .words and info.language must be captured onto every segment."""
+
+    # Build mock faster-whisper segment with .words and info with .language
+    word_a = MagicMock()
+    word_a.start = 0.0
+    word_a.end = 0.4
+    word_a.word = "hello"
+    word_a.probability = 0.95
+
+    word_b = MagicMock()
+    word_b.start = 0.5
+    word_b.end = 1.5
+    word_b.word = "world"
+    word_b.probability = 0.88
+
+    fake_segment = MagicMock()
+    fake_segment.start = 0.0
+    fake_segment.end = 1.5
+    fake_segment.text = "hello world"
+    fake_segment.avg_logprob = -0.1
+    fake_segment.words = [word_a, word_b]
+
+    fake_info = MagicMock()
+    fake_info.language = "en"
+
+    fake_model = MagicMock()
+    fake_model.transcribe.return_value = (iter([fake_segment]), fake_info)
+
+    monkeypatch.setattr("core.transcription._has_audio_stream", lambda _p: True)
+    monkeypatch.setattr("core.transcription.get_model", lambda _name: fake_model)
+
+    result = transcribe_video(
+        Path("/tmp/x.mp4"),
+        backend="faster-whisper",
+    )
+
+    assert len(result) == 1
+    seg = result[0]
+    assert seg.language == "en"
+    assert seg.words is not None
+    assert len(seg.words) == 2
+    assert seg.words[0].text == "hello"
+    assert seg.words[0].start == 0.0
+    assert seg.words[0].end == 0.4
+    assert seg.words[0].probability == pytest.approx(0.95)
+    assert seg.words[1].text == "world"
+
+
+def test_transcribe_video_faster_whisper_handles_segment_without_words(monkeypatch):
+    """If a faster-whisper segment surfaces no .words (e.g., disabled timestamps), words=None."""
+    fake_segment = MagicMock()
+    fake_segment.start = 0.0
+    fake_segment.end = 1.0
+    fake_segment.text = "silent"
+    fake_segment.avg_logprob = -0.5
+    fake_segment.words = None  # Defensive: word_timestamps may not have produced data
+
+    fake_info = MagicMock()
+    fake_info.language = "fr"
+
+    fake_model = MagicMock()
+    fake_model.transcribe.return_value = (iter([fake_segment]), fake_info)
+
+    monkeypatch.setattr("core.transcription._has_audio_stream", lambda _p: True)
+    monkeypatch.setattr("core.transcription.get_model", lambda _name: fake_model)
+
+    result = transcribe_video(Path("/tmp/x.mp4"), backend="faster-whisper")
+
+    assert len(result) == 1
+    assert result[0].words is None
+    assert result[0].language == "fr"
+
+
+def test_parse_mlx_result_captures_language():
+    """MLX `result["language"]` must populate TranscriptSegment.language; words stays None.
+
+    U2 will fill words via forced alignment; U1's job is only to surface the language signal
+    MLX was previously discarding.
+    """
+    mlx_result = {
+        "text": "bonjour le monde",
+        "language": "fr",
+        "segments": [
+            {"start": 0.0, "end": 1.0, "text": "bonjour"},
+            [100, 200, "le monde"],  # frames format
+        ],
+    }
+    segments = _parse_mlx_result(mlx_result)
+    assert len(segments) == 2
+    assert all(s.language == "fr" for s in segments)
+    assert all(s.words is None for s in segments)
+
+
+def test_parse_mlx_result_language_none_when_absent():
+    """If MLX result omits 'language' (unusual), segments have language=None."""
+    mlx_result = {
+        "text": "hello",
+        "segments": [{"start": 0.0, "end": 0.5, "text": "hello"}],
+    }
+    segments = _parse_mlx_result(mlx_result)
+    assert len(segments) == 1
+    assert segments[0].language is None
+    assert segments[0].words is None
+
+
+def test_clip_with_no_transcript_round_trips():
+    """A Clip with transcript=None is unaffected by the schema change."""
+    from models.clip import Clip
+
+    clip = Clip(
+        id="c1",
+        source_id="s1",
+        start_frame=0,
+        end_frame=24,
+        name="clip-1",
+    )
+    data = clip.to_dict()
+    restored = Clip.from_dict(data)
+    assert restored.transcript is None
+
+
+def test_clip_transcript_round_trips_with_new_fields():
+    """An existing Clip.from_dict path forwards new TranscriptSegment fields cleanly."""
+    from models.clip import Clip
+
+    clip = Clip(
+        id="c1",
+        source_id="s1",
+        start_frame=0,
+        end_frame=24,
+        name="clip-1",
+        transcript=[
+            TranscriptSegment(
+                start_time=0.0,
+                end_time=1.0,
+                text="hello",
+                confidence=-0.1,
+                words=[WordTimestamp(start=0.0, end=0.5, text="hello", probability=0.9)],
+                language="en",
+            )
+        ],
+    )
+    data = clip.to_dict()
+    restored = Clip.from_dict(data)
+    assert restored.transcript is not None
+    assert len(restored.transcript) == 1
+    assert restored.transcript[0].language == "en"
+    assert restored.transcript[0].words is not None
+    assert restored.transcript[0].words[0].text == "hello"
+
+
+def test_clip_transcript_round_trips_legacy_format():
+    """A legacy clip dict whose transcript entries lack 'words' and 'language' still loads."""
+    from models.clip import Clip
+
+    legacy_data = {
+        "id": "c1",
+        "source_id": "s1",
+        "start_frame": 0,
+        "end_frame": 24,
+        "name": "clip-1",
+        "transcript": [
+            {
+                "start_time": 0.0,
+                "end_time": 1.0,
+                "text": "legacy",
+                "confidence": 0.0,
+            }
+        ],
+    }
+    restored = Clip.from_dict(legacy_data)
+    assert restored.transcript is not None
+    assert len(restored.transcript) == 1
+    assert restored.transcript[0].words is None
+    assert restored.transcript[0].language is None

--- a/tests/test_word_llm_composer.py
+++ b/tests/test_word_llm_composer.py
@@ -1,0 +1,543 @@
+"""Tests for the LLM Word Composer (U5).
+
+Covers:
+- ``core.spine.words.compose_with_llm`` instance-picking + repeat policies.
+- ``core.remix.word_llm_composer.generate_llm_word_sequence`` end-to-end
+  with a stubbed LLM.
+- Round-robin distribution across multiple corpus instances (AE3).
+- OOV emission failure (AE4 negative).
+- Seeded random reproducibility.
+- ``LLMEmptyResponseError`` propagation.
+- Real-Ollama integration test (gated by ``SCENE_RIPPER_OLLAMA_INTEGRATION``).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+from core.llm_client import LLMEmptyResponseError, OllamaUnreachableError
+from core.remix.word_llm_composer import (
+    MissingWordDataError,
+    generate_llm_word_sequence,
+)
+from core.spine.words import (
+    WordInstance,
+    build_inventory,
+    compose_with_llm,
+)
+from core.transcription import TranscriptSegment, WordTimestamp
+
+
+# ---------------------------------------------------------------------------
+# Mocks
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MockSource:
+    id: str = "src1"
+    fps: float = 24.0
+
+
+@dataclass
+class MockClip:
+    id: str = "clip1"
+    source_id: str = "src1"
+    start_frame: int = 0
+    end_frame: int = 480  # 20 s at 24 fps
+    transcript: Optional[list[TranscriptSegment]] = None
+
+
+def _seg(words: list[tuple[str, float, float]], language: str = "en") -> TranscriptSegment:
+    word_list = [WordTimestamp(start=s, end=e, text=t) for (t, s, e) in words]
+    return TranscriptSegment(
+        start_time=words[0][1] if words else 0.0,
+        end_time=words[-1][2] if words else 0.0,
+        text=" ".join(t for t, _, _ in words),
+        confidence=1.0,
+        words=word_list,
+        language=language,
+    )
+
+
+def _fake_completion(words: list[str]):
+    """Build a stub for ``compose_with_llm``'s ``_completion_fn`` hook."""
+
+    def _fn(**kwargs):  # noqa: ANN003
+        return list(words)
+
+    return _fn
+
+
+# ---------------------------------------------------------------------------
+# compose_with_llm — spine layer
+# ---------------------------------------------------------------------------
+
+
+class TestComposeWithLlmHappyPath:
+    def test_basic_five_word_response(self):
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("i", 0.0, 0.2),
+                        ("have", 0.3, 0.5),
+                        ("always", 0.6, 1.0),
+                        ("loved", 1.1, 1.5),
+                        ("silence", 1.6, 2.2),
+                    ]
+                )
+            ]
+        )
+        inv = build_inventory([(clip, MockSource())])
+
+        result = compose_with_llm(
+            inv,
+            prompt="compose",
+            target_length=5,
+            _completion_fn=_fake_completion(
+                ["i", "have", "always", "loved", "silence"]
+            ),
+        )
+        assert len(result) == 5
+        assert [w.text for w in result] == [
+            "i", "have", "always", "loved", "silence"
+        ]
+
+    def test_single_word_response(self):
+        clip = MockClip(transcript=[_seg([("hello", 0.0, 0.3)])])
+        inv = build_inventory([(clip, MockSource())])
+        result = compose_with_llm(
+            inv,
+            prompt="x",
+            target_length=1,
+            _completion_fn=_fake_completion(["hello"]),
+        )
+        assert len(result) == 1
+
+
+class TestRoundRobinPolicyAE3:
+    def test_round_robin_cycles_through_instances(self):
+        """With 12 instances of 'the' and 4 emissions under round-robin,
+        the 4 emitted SequenceClips reference 4 different source instances
+        in inventory order. Covers AE3.
+        """
+        # Build a clip with 12 instances of "the".
+        words = [("the", i * 0.5, i * 0.5 + 0.3) for i in range(12)]
+        clip = MockClip(
+            end_frame=480,  # 20s @ 24fps so all "the" instances fit
+            transcript=[_seg(words)],
+        )
+        inv = build_inventory([(clip, MockSource())])
+        # Sanity: 12 instances in inventory.
+        assert len(inv.by_word["the"]) == 12
+
+        result = compose_with_llm(
+            inv,
+            prompt="x",
+            target_length=4,
+            repeat_policy="round-robin",
+            _completion_fn=_fake_completion(["the", "the", "the", "the"]),
+        )
+
+        # 4 *different* instances, in inventory order (instances 0, 1, 2, 3).
+        assert len(result) == 4
+        # All from same word but different word_index — i.e., different
+        # corpus instances.
+        word_indices = [r.word_index for r in result]
+        assert word_indices == [0, 1, 2, 3]
+        assert len(set(word_indices)) == 4
+
+    def test_round_robin_wraps_when_more_emissions_than_instances(self):
+        """Documented: with a single corpus instance and 3 emissions, the
+        same instance is reused 3 times (round-robin wraps).
+        """
+        clip = MockClip(transcript=[_seg([("solo", 0.0, 0.5)])])
+        inv = build_inventory([(clip, MockSource())])
+        result = compose_with_llm(
+            inv,
+            prompt="x",
+            target_length=3,
+            repeat_policy="round-robin",
+            _completion_fn=_fake_completion(["solo", "solo", "solo"]),
+        )
+        assert len(result) == 3
+        # All reuse the single instance.
+        assert all(r.word_index == 0 for r in result)
+
+
+class TestRepeatPolicies:
+    def _three_the_clip(self) -> MockClip:
+        return MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("the", 0.0, 0.2),  # short
+                        ("the", 0.3, 1.0),  # long (0.7)
+                        ("the", 1.1, 1.5),  # medium (0.4)
+                    ]
+                )
+            ]
+        )
+
+    def test_first_always_returns_index_0(self):
+        clip = self._three_the_clip()
+        inv = build_inventory([(clip, MockSource())])
+        result = compose_with_llm(
+            inv, prompt="x", target_length=3,
+            repeat_policy="first",
+            _completion_fn=_fake_completion(["the", "the", "the"]),
+        )
+        assert all(r.word_index == 0 for r in result)
+
+    def test_longest_picks_the_longest(self):
+        clip = self._three_the_clip()
+        inv = build_inventory([(clip, MockSource())])
+        result = compose_with_llm(
+            inv, prompt="x", target_length=1,
+            repeat_policy="longest",
+            _completion_fn=_fake_completion(["the"]),
+        )
+        # word_index=1 has end-start = 0.7, the longest.
+        assert result[0].word_index == 1
+
+    def test_shortest_picks_the_shortest(self):
+        clip = self._three_the_clip()
+        inv = build_inventory([(clip, MockSource())])
+        result = compose_with_llm(
+            inv, prompt="x", target_length=1,
+            repeat_policy="shortest",
+            _completion_fn=_fake_completion(["the"]),
+        )
+        # word_index=0 has end-start = 0.2, the shortest.
+        assert result[0].word_index == 0
+
+    def test_random_seeded_reproducible(self):
+        """Same seed → identical output across runs."""
+        # Build inventory with 5 instances of "x" so the policy actually
+        # has choices to make.
+        clip = MockClip(
+            transcript=[
+                _seg([("x", i * 0.5, i * 0.5 + 0.3) for i in range(5)])
+            ]
+        )
+        inv = build_inventory([(clip, MockSource())])
+
+        result_a = compose_with_llm(
+            inv, prompt="p", target_length=10,
+            repeat_policy="random", seed=42,
+            _completion_fn=_fake_completion(["x"] * 10),
+        )
+        result_b = compose_with_llm(
+            inv, prompt="p", target_length=10,
+            repeat_policy="random", seed=42,
+            _completion_fn=_fake_completion(["x"] * 10),
+        )
+        assert [r.word_index for r in result_a] == [r.word_index for r in result_b]
+
+    def test_unknown_policy_raises(self):
+        clip = MockClip(transcript=[_seg([("a", 0.0, 0.5)])])
+        inv = build_inventory([(clip, MockSource())])
+        with pytest.raises(ValueError, match="repeat_policy"):
+            compose_with_llm(
+                inv, prompt="p", target_length=1,
+                repeat_policy="bogus",  # type: ignore[arg-type]
+                _completion_fn=_fake_completion(["a"]),
+            )
+
+
+class TestOOVAndEmptyHandling:
+    def test_oov_emission_raises_loudly_ae4(self):
+        """LLM emits a word that's not in the corpus → raise loudly.
+
+        The format+enum constraint should make this impossible. If we see
+        an OOV word, the bug must surface — silently dropping the slot
+        would hide a serious constraint-decoding failure. Covers AE4.
+        """
+        clip = MockClip(transcript=[_seg([("hello", 0.0, 0.3)])])
+        inv = build_inventory([(clip, MockSource())])
+        with pytest.raises(ValueError, match="out-of-vocabulary"):
+            compose_with_llm(
+                inv, prompt="x", target_length=2,
+                _completion_fn=_fake_completion(["hello", "world"]),
+            )
+
+    def test_empty_inventory_raises(self):
+        # No clips → empty inventory.
+        from core.spine.words import WordInventory
+        inv = WordInventory(by_word={}, by_clip={})
+        with pytest.raises(ValueError, match="empty"):
+            compose_with_llm(
+                inv, prompt="x", target_length=2,
+                _completion_fn=_fake_completion(["x"]),
+            )
+
+    def test_zero_target_length_raises(self):
+        clip = MockClip(transcript=[_seg([("a", 0.0, 0.5)])])
+        inv = build_inventory([(clip, MockSource())])
+        with pytest.raises(ValueError, match="target_length"):
+            compose_with_llm(
+                inv, prompt="x", target_length=0,
+                _completion_fn=_fake_completion(["a"]),
+            )
+
+
+class TestLLMEmptyResponsePropagates:
+    def test_empty_response_error_bubbles_up(self):
+        from core.llm_client import LLMEmptyResponseError
+
+        clip = MockClip(transcript=[_seg([("a", 0.0, 0.5)])])
+        inv = build_inventory([(clip, MockSource())])
+
+        def _fail(**kwargs):
+            raise LLMEmptyResponseError(prompt="p", hint="empty")
+
+        with pytest.raises(LLMEmptyResponseError):
+            compose_with_llm(
+                inv, prompt="p", target_length=1,
+                _completion_fn=_fail,
+            )
+
+    def test_ollama_unreachable_bubbles_up(self):
+        from core.llm_client import OllamaUnreachableError
+
+        clip = MockClip(transcript=[_seg([("a", 0.0, 0.5)])])
+        inv = build_inventory([(clip, MockSource())])
+
+        def _fail(**kwargs):
+            raise OllamaUnreachableError("nope")
+
+        with pytest.raises(OllamaUnreachableError):
+            compose_with_llm(
+                inv, prompt="p", target_length=1,
+                _completion_fn=_fail,
+            )
+
+
+# ---------------------------------------------------------------------------
+# generate_llm_word_sequence — remix wrapper
+# ---------------------------------------------------------------------------
+
+
+def _fake_spine_composer(words: list[str]):
+    """Fake the spine ``compose_with_llm`` for the wrapper-level tests.
+
+    Returns a callable matching ``compose_with_llm`` signature; ignores the
+    LLM entirely and walks the inventory directly.
+    """
+
+    def _fn(inv, *, prompt, target_length, repeat_policy="round-robin",
+            seed=None, model=None, api_base=None, temperature=0.7,
+            timeout=120.0, system_prompt=None, think=False):  # noqa: ANN001
+        # Translate the requested words into round-robin instance picks
+        # so the test exercises the wrapper's plumbing without involving
+        # any LLM.
+        counters: dict[str, int] = {}
+        out: list[WordInstance] = []
+        for raw in words:
+            key = raw.lower()
+            candidates = inv.by_word.get(key)
+            if not candidates:
+                raise ValueError(f"OOV {raw!r}")
+            c = counters.get(key, 0)
+            out.append(candidates[c % len(candidates)])
+            counters[key] = c + 1
+        return out
+
+    return _fn
+
+
+class TestGenerateLlmWordSequence:
+    def test_end_to_end_stubbed_llm(self):
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("i", 0.0, 0.2),
+                        ("have", 0.3, 0.5),
+                        ("always", 0.6, 1.0),
+                        ("loved", 1.1, 1.5),
+                        ("silence", 1.6, 2.2),
+                    ]
+                )
+            ]
+        )
+        result = generate_llm_word_sequence(
+            clips=[(clip, MockSource())],
+            prompt="compose",
+            target_length=5,
+            _compose_fn=_fake_spine_composer(
+                ["i", "have", "always", "loved", "silence"]
+            ),
+        )
+        assert len(result) == 5
+        # All entries reference the same source clip and have well-formed
+        # frame coords.
+        for sc in result:
+            assert sc.source_clip_id == clip.id
+            assert sc.source_id == clip.source_id
+            assert sc.in_point >= 0
+            assert sc.out_point > sc.in_point
+
+    def test_frame_math_matches_word_sequencer(self):
+        """The U5 wrapper must use the same floor/ceil/handle frame math
+        as U4's preset-modes path — they share the
+        ``instances_to_sequence_clips`` helper, so identical inputs must
+        produce byte-identical outputs.
+        """
+        from core.remix.word_sequencer import generate_word_sequence
+
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("apple", 0.5, 0.9),  # in=floor(0.5*24)=12, out=ceil(0.9*24)=22
+                    ]
+                )
+            ]
+        )
+
+        # U4: alphabetical mode on a single-word corpus yields the single
+        # instance.
+        preset_result = generate_word_sequence(
+            clips=[(clip, MockSource(fps=24.0))],
+            mode="alphabetical",
+            mode_params={},
+            handle_frames=0,
+        )
+
+        # U5: LLM emits the same single word.
+        llm_result = generate_llm_word_sequence(
+            clips=[(clip, MockSource(fps=24.0))],
+            prompt="x",
+            target_length=1,
+            handle_frames=0,
+            _compose_fn=_fake_spine_composer(["apple"]),
+        )
+
+        assert len(preset_result) == len(llm_result) == 1
+        assert preset_result[0].in_point == llm_result[0].in_point
+        assert preset_result[0].out_point == llm_result[0].out_point
+
+    def test_empty_clips_returns_empty(self):
+        result = generate_llm_word_sequence(
+            clips=[], prompt="x", target_length=1,
+            _compose_fn=_fake_spine_composer([]),
+        )
+        assert result == []
+
+    def test_missing_word_data_raises(self):
+        """Same MissingWordDataError contract as the preset-modes path —
+        the dialog catches this and triggers alignment.
+        """
+        clip = MockClip(
+            transcript=[
+                TranscriptSegment(
+                    start_time=0.0, end_time=1.0, text="x",
+                    confidence=1.0, words=None, language="en",
+                )
+            ]
+        )
+        with pytest.raises(MissingWordDataError) as exc:
+            generate_llm_word_sequence(
+                clips=[(clip, MockSource())],
+                prompt="x", target_length=1,
+                _compose_fn=_fake_spine_composer([]),
+            )
+        assert clip.id in exc.value.clip_ids
+
+    def test_handle_frames_passed_through(self):
+        clip = MockClip(
+            transcript=[_seg([("mid", 1.0, 2.0)])]
+        )
+        result = generate_llm_word_sequence(
+            clips=[(clip, MockSource(fps=24.0))],
+            prompt="x", target_length=1,
+            handle_frames=2,
+            _compose_fn=_fake_spine_composer(["mid"]),
+        )
+        # Same math as U4 test_handle_widens_window:
+        # in = floor((1.0 - 2/24)*24) = 22
+        # out = ceil((2.0 + 2/24)*24) = 50
+        assert result[0].in_point == 22
+        assert result[0].out_point == 50
+
+
+# ---------------------------------------------------------------------------
+# Real-Ollama integration test (gated)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    os.environ.get("SCENE_RIPPER_OLLAMA_INTEGRATION") != "1",
+    reason="Set SCENE_RIPPER_OLLAMA_INTEGRATION=1 to run real-Ollama checks",
+)
+def test_ollama_integration_constrained_decode_latency(capsys):
+    """Real-Ollama smoke against qwen3:8b.
+
+    The plan's go/no-go threshold for v1 ship: a 1000-word corpus + 20-word
+    target should complete in under ~30s. This test records latency as a
+    SOFT signal (printed warning) rather than a hard CI gate — the plan
+    explicitly documents that latency at corpus scale is unknown and
+    deferred to implementation-time measurement.
+
+    Initial measurement on the implementing engineer's M-series Mac
+    (qwen3:8b, vocab=1000, target=20): ~169s. That is well above the plan's
+    30s threshold, confirming the plan's pre-existing concern that Tier 1
+    (Ollama JSON-schema enum) does not parallelize the enum mask. The plan
+    explicitly anticipates this: ``llama-cpp-python`` GBNF (Tier 2) is the
+    documented follow-up if Tier 1 latency is unacceptable for artistic
+    corpora. See docs/plans/2026-05-11-001-feat-word-sequencer-plan.md
+    "Deferred to Implementation".
+
+    To avoid noisy CI failures during the deferred-Tier-2 window, this
+    test asserts only the *correctness* contract (non-empty result, output
+    has a usable shape) and emits latency as a warning when it exceeds the
+    plan threshold. Hard-fail conditions are reserved for catastrophic
+    timeouts (>5min, which would mask a stuck process).
+    """
+    # Build a 1000-unique-word corpus by synthesizing per-word
+    # TranscriptSegment entries. Use throwaway words ``w0001`` … ``w1000``.
+    n_unique = 1000
+    words = [(f"w{idx:04d}", idx * 0.01, idx * 0.01 + 0.005) for idx in range(n_unique)]
+    clip = MockClip(end_frame=int(n_unique * 0.01 * 24) + 100, transcript=[_seg(words)])
+
+    t0 = time.perf_counter()
+    result = generate_llm_word_sequence(
+        clips=[(clip, MockSource())],
+        prompt="produce twenty distinct words from the vocabulary",
+        target_length=20,
+        timeout=300.0,
+    )
+    elapsed = time.perf_counter() - t0
+
+    plan_threshold = 30.0  # seconds (from plan "Deferred to Implementation")
+    over_budget = elapsed > plan_threshold
+
+    print(
+        f"\n[ollama-integration] vocab={n_unique} target=20 elapsed={elapsed:.2f}s "
+        f"got={len(result)} clips threshold={plan_threshold}s "
+        f"({'OVER' if over_budget else 'UNDER'} budget)"
+    )
+    if over_budget:
+        # Soft warning surfaces the Tier-2 trigger condition.
+        import warnings
+        warnings.warn(
+            f"Ollama constrained-decode latency {elapsed:.1f}s exceeded "
+            f"plan threshold {plan_threshold}s for vocab=1000 target=20 — "
+            "Tier 2 (llama-cpp-python GBNF) is the documented follow-up.",
+            stacklevel=2,
+        )
+
+    # Hard-fail only on catastrophic latency that would mask a stuck process.
+    assert elapsed < 300.0, (
+        f"Catastrophic constrained-decode latency: {elapsed:.1f}s > 300s. "
+        "Likely a stuck Ollama process; check `ollama ps` and the server log."
+    )
+    assert len(result) > 0, "Real-Ollama integration returned zero clips"

--- a/tests/test_word_llm_composer_dialog.py
+++ b/tests/test_word_llm_composer_dialog.py
@@ -1,0 +1,241 @@
+"""Tests for ``WordLLMComposerDialog``.
+
+These exercise the dialog's pure-Python flow without invoking the real
+Ollama HTTP path. The Ollama health probe is injected via the dialog's
+``_ollama_health_fn`` keyword arg; the compose worker is monkeypatched to a
+fake that produces deterministic ``SequenceClip[]`` payloads.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from core.transcription import TranscriptSegment, WordTimestamp
+from models.clip import Clip, Source
+from models.sequence import SequenceClip
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _aligned_clip(clip_id: str = "clip-1", source_id: str = "src-1") -> tuple:
+    source = Source(
+        id=source_id,
+        file_path=Path(f"/test/{source_id}.mp4"),
+        duration_seconds=30.0,
+        fps=24.0,
+        width=640,
+        height=360,
+    )
+    clip = Clip(
+        id=clip_id,
+        source_id=source_id,
+        start_frame=0,
+        end_frame=240,
+    )
+    clip.transcript = [
+        TranscriptSegment(
+            start_time=0.0,
+            end_time=1.0,
+            text="quiet light",
+            confidence=0.9,
+            words=[
+                WordTimestamp(start=0.0, end=0.4, text="quiet"),
+                WordTimestamp(start=0.4, end=1.0, text="light"),
+            ],
+            language="en",
+        )
+    ]
+    return clip, source
+
+
+def test_ollama_absent_shows_install_page(qapp):
+    from ui.dialogs.word_llm_composer_dialog import WordLLMComposerDialog
+
+    clip, source = _aligned_clip()
+    dialog = WordLLMComposerDialog(
+        clips=[(clip, source)],
+        project=None,
+        _ollama_health_fn=lambda: (False, "Ollama is not running"),
+    )
+
+    # Page index 2 = ollama-absent page.
+    assert dialog._stack.currentIndex() == 2
+    assert "Local LLM not detected" in dialog._ollama_message_label.text()
+    assert dialog._accept_btn.isEnabled() is False
+
+
+def test_ollama_healthy_shows_form(qapp):
+    from ui.dialogs.word_llm_composer_dialog import WordLLMComposerDialog
+
+    clip, source = _aligned_clip()
+    dialog = WordLLMComposerDialog(
+        clips=[(clip, source)],
+        project=None,
+        _ollama_health_fn=lambda: (True, ""),
+    )
+
+    assert dialog._stack.currentIndex() == 0
+    # Source picker populated.
+    assert dialog._source_list.count() == 1
+
+
+def test_seed_visible_only_for_random_policy(qapp):
+    from ui.dialogs.word_llm_composer_dialog import WordLLMComposerDialog
+
+    clip, source = _aligned_clip()
+    dialog = WordLLMComposerDialog(
+        clips=[(clip, source)],
+        project=None,
+        _ollama_health_fn=lambda: (True, ""),
+    )
+
+    # Round-robin default → seed hidden.
+    assert dialog._seed_container.isHidden() is True
+
+    # Switch to random → seed shows.
+    for i in range(dialog._repeat_combo.count()):
+        if dialog._repeat_combo.itemData(i) == "random":
+            dialog._repeat_combo.setCurrentIndex(i)
+            break
+    assert dialog._seed_container.isHidden() is False
+
+
+def test_validation_requires_prompt(qapp):
+    from ui.dialogs.word_llm_composer_dialog import WordLLMComposerDialog
+
+    clip, source = _aligned_clip()
+    dialog = WordLLMComposerDialog(
+        clips=[(clip, source)],
+        project=None,
+        _ollama_health_fn=lambda: (True, ""),
+    )
+
+    dialog._prompt_input.setPlainText("")
+    dialog._refresh_validation()
+    assert dialog._accept_btn.isEnabled() is False
+
+    dialog._prompt_input.setPlainText("hello")
+    dialog._refresh_validation()
+    assert dialog._accept_btn.isEnabled() is True
+
+
+def test_accept_dispatches_compose_worker(qapp, monkeypatch):
+    from ui.dialogs.word_llm_composer_dialog import WordLLMComposerDialog
+
+    clip, source = _aligned_clip()
+    dialog = WordLLMComposerDialog(
+        clips=[(clip, source)],
+        project=None,
+        _ollama_health_fn=lambda: (True, ""),
+    )
+
+    starts: list = []
+
+    class FakeComposeWorker:
+        def __init__(self, *, clips, prompt, target_length, repeat_policy,
+                     seed=None, handle_frames=0, parent=None, **kwargs):
+            self._prompt = prompt
+            self._target_length = target_length
+
+            class _Sig:
+                def connect(self, *args, **kwargs):
+                    return None
+
+            self.progress = _Sig()
+            self.sequence_ready = _Sig()
+            self.error = _Sig()
+
+        def isRunning(self):
+            return True
+
+        def start(self):
+            starts.append((self._prompt, self._target_length))
+
+        def cancel(self):
+            pass
+
+        def wait(self, _ms):
+            return True
+
+    monkeypatch.setattr(
+        "ui.workers.llm_composer_worker.LLMComposerWorker",
+        FakeComposeWorker,
+    )
+
+    dialog._prompt_input.setPlainText("compose a quiet sentence")
+    dialog._length_spin.setValue(7)
+    dialog._refresh_validation()
+    dialog._on_accept()
+
+    assert starts == [("compose a quiet sentence", 7)]
+
+
+def test_compose_ready_emits_sequence(qapp):
+    from ui.dialogs.word_llm_composer_dialog import WordLLMComposerDialog
+
+    clip, source = _aligned_clip()
+    dialog = WordLLMComposerDialog(
+        clips=[(clip, source)],
+        project=None,
+        _ollama_health_fn=lambda: (True, ""),
+    )
+
+    captured: list = []
+    dialog.sequence_ready.connect(captured.append)
+
+    fake_seq = [
+        SequenceClip(
+            source_clip_id=clip.id,
+            source_id=source.id,
+            in_point=0,
+            out_point=10,
+        )
+    ]
+    dialog._on_compose_ready(fake_seq)
+
+    assert captured == [fake_seq]
+
+
+def test_compose_error_keeps_dialog_open(qapp):
+    from ui.dialogs.word_llm_composer_dialog import WordLLMComposerDialog
+
+    clip, source = _aligned_clip()
+    dialog = WordLLMComposerDialog(
+        clips=[(clip, source)],
+        project=None,
+        _ollama_health_fn=lambda: (True, ""),
+    )
+
+    dialog._stack.setCurrentIndex(1)  # progress page
+    dialog._on_compose_error("LLM returned empty response")
+
+    # Stack returned to form page, error label populated.
+    assert dialog._stack.currentIndex() == 0
+    assert "empty response" in dialog._error_label.text()
+
+
+def test_empty_corpus_disables_accept(qapp):
+    """With no source clips at all, accept stays disabled."""
+    from ui.dialogs.word_llm_composer_dialog import WordLLMComposerDialog
+
+    dialog = WordLLMComposerDialog(
+        clips=[],
+        project=None,
+        _ollama_health_fn=lambda: (True, ""),
+    )
+    dialog._prompt_input.setPlainText("hello")
+    dialog._refresh_validation()
+    assert dialog._accept_btn.isEnabled() is False

--- a/tests/test_word_sequencer.py
+++ b/tests/test_word_sequencer.py
@@ -1,0 +1,326 @@
+"""Tests for ``core/remix/word_sequencer.py``.
+
+Covers frame-math conventions (floor on in, ceil on out, handle-frame
+clamping), validation of word-data presence, and zero-duration word
+dropping.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional
+
+import pytest
+
+from core.remix.word_sequencer import MissingWordDataError, generate_word_sequence
+from core.transcription import TranscriptSegment, WordTimestamp
+
+
+@dataclass
+class MockSource:
+    id: str = "src1"
+    fps: float = 24.0
+
+
+@dataclass
+class MockClip:
+    id: str = "clip1"
+    source_id: str = "src1"
+    start_frame: int = 0
+    end_frame: int = 240  # 10 s at 24 fps
+    transcript: Optional[list[TranscriptSegment]] = None
+
+
+def _seg(words: list[tuple[str, float, float]], language: str = "en") -> TranscriptSegment:
+    word_list = [WordTimestamp(start=s, end=e, text=t) for (t, s, e) in words]
+    return TranscriptSegment(
+        start_time=words[0][1] if words else 0.0,
+        end_time=words[-1][2] if words else 0.0,
+        text=" ".join(t for t, _, _ in words),
+        confidence=1.0,
+        words=word_list,
+        language=language,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path framing
+# ---------------------------------------------------------------------------
+
+
+class TestAlphabeticalSequence:
+    def test_basic_alphabetical_sequence(self):
+        clip = MockClip(
+            transcript=[
+                _seg([("zoo", 0.0, 0.5), ("apple", 0.6, 1.0)])
+            ]
+        )
+        result = generate_word_sequence(
+            clips=[(clip, MockSource())],
+            mode="alphabetical",
+            mode_params={},
+            handle_frames=0,
+        )
+        # Two words, alphabetical order: apple → zoo
+        assert len(result) == 2
+        assert result[0].source_clip_id == clip.id
+        assert result[0].source_id == clip.source_id
+
+    def test_in_point_floor_out_point_ceil(self):
+        # Word at 0.5–0.9 s @ 24 fps → in_point=floor(0.5*24)=12, out_point=ceil(0.9*24)=ceil(21.6)=22
+        clip = MockClip(
+            transcript=[_seg([("hello", 0.5, 0.9)])]
+        )
+        result = generate_word_sequence(
+            clips=[(clip, MockSource(fps=24.0))],
+            mode="alphabetical",
+            mode_params={},
+            handle_frames=0,
+        )
+        assert len(result) == 1
+        assert result[0].in_point == 12
+        assert result[0].out_point == 22
+
+
+# ---------------------------------------------------------------------------
+# Handle-frame padding & clamping
+# ---------------------------------------------------------------------------
+
+
+class TestHandleFrameClamping:
+    def test_handle_clamps_at_clip_start(self):
+        # Word starts at 0.0 with handle=2 → would push in_point negative; clamps to 0.
+        clip = MockClip(
+            start_frame=0,
+            end_frame=240,
+            transcript=[_seg([("hi", 0.0, 0.4)])],
+        )
+        result = generate_word_sequence(
+            clips=[(clip, MockSource(fps=24.0))],
+            mode="alphabetical",
+            mode_params={},
+            handle_frames=2,
+        )
+        assert result[0].in_point == 0
+
+    def test_handle_clamps_at_clip_end(self):
+        # Clip duration = 240 frames @ 24fps = 10 s.  Word at 9.9–10.0 with handle=4 → end clamps to 240.
+        clip = MockClip(
+            start_frame=0,
+            end_frame=240,
+            transcript=[_seg([("end", 9.9, 10.0)])],
+        )
+        result = generate_word_sequence(
+            clips=[(clip, MockSource(fps=24.0))],
+            mode="alphabetical",
+            mode_params={},
+            handle_frames=4,
+        )
+        assert result[0].out_point == 240
+
+    def test_handle_widens_window(self):
+        # Word at 1.0–2.0 with handle_frames=2 (at 24 fps = 0.0833 s):
+        # in_seconds  = 1.0  - 2/24  ≈ 0.9167  → in_point  = floor(0.9167*24)  = 22
+        # out_seconds = 2.0  + 2/24  ≈ 2.0833  → out_point = ceil(2.0833*24)   = 50
+        clip = MockClip(transcript=[_seg([("mid", 1.0, 2.0)])])
+        result = generate_word_sequence(
+            clips=[(clip, MockSource(fps=24.0))],
+            mode="alphabetical",
+            mode_params={},
+            handle_frames=2,
+        )
+        assert result[0].in_point == 22
+        assert result[0].out_point == 50
+
+
+# ---------------------------------------------------------------------------
+# Zero-duration words
+# ---------------------------------------------------------------------------
+
+
+class TestZeroDurationDropped:
+    def test_zero_duration_word_dropped(self):
+        clip = MockClip(
+            transcript=[
+                _seg([("real", 0.0, 0.5), ("ghost", 1.0, 1.0), ("end", 2.0, 2.5)])
+            ]
+        )
+        result = generate_word_sequence(
+            clips=[(clip, MockSource())],
+            mode="alphabetical",
+            mode_params={},
+            handle_frames=0,
+        )
+        # "ghost" (start == end) is dropped.
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+class TestMissingWordData:
+    def test_clip_with_none_words_raises(self):
+        clip = MockClip(
+            transcript=[
+                TranscriptSegment(
+                    start_time=0.0,
+                    end_time=1.0,
+                    text="x y",
+                    confidence=1.0,
+                    words=None,
+                    language="en",
+                )
+            ]
+        )
+        with pytest.raises(MissingWordDataError) as exc:
+            generate_word_sequence(
+                clips=[(clip, MockSource())],
+                mode="alphabetical",
+                mode_params={},
+            )
+        assert clip.id in exc.value.clip_ids
+
+    def test_aggregates_multiple_missing(self):
+        bad_seg = TranscriptSegment(
+            start_time=0.0, end_time=1.0, text="x", confidence=1.0, words=None, language="en"
+        )
+        clip_a = MockClip(id="A", transcript=[bad_seg])
+        clip_b = MockClip(id="B", transcript=[bad_seg])
+        with pytest.raises(MissingWordDataError) as exc:
+            generate_word_sequence(
+                clips=[(clip_a, MockSource()), (clip_b, MockSource())],
+                mode="alphabetical",
+                mode_params={},
+            )
+        assert "A" in exc.value.clip_ids
+        assert "B" in exc.value.clip_ids
+
+
+class TestMissingFps:
+    def test_none_fps_raises(self):
+        clip = MockClip(transcript=[_seg([("a", 0.0, 0.5)])])
+        src = MockSource(fps=None)  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="fps"):
+            generate_word_sequence(
+                clips=[(clip, src)],
+                mode="alphabetical",
+                mode_params={},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Mode plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestModeDispatch:
+    def test_by_frequency_descending(self):
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("the", 0.0, 0.2),
+                        ("dog", 0.3, 0.5),
+                        ("the", 0.6, 0.8),
+                    ]
+                )
+            ]
+        )
+        result = generate_word_sequence(
+            clips=[(clip, MockSource())],
+            mode="by_frequency",
+            mode_params={"order": "descending"},
+        )
+        assert len(result) == 3  # the, the, dog
+
+    def test_by_chosen_words(self):
+        clip = MockClip(
+            transcript=[
+                _seg(
+                    [
+                        ("never", 0.0, 0.3),
+                        ("always", 0.4, 0.7),
+                        ("never", 0.8, 1.1),
+                    ]
+                )
+            ]
+        )
+        result = generate_word_sequence(
+            clips=[(clip, MockSource())],
+            mode="by_chosen_words",
+            mode_params={"include": ["never"]},
+        )
+        assert len(result) == 2
+
+    def test_from_word_list(self):
+        clip = MockClip(
+            transcript=[_seg([("the", 0.0, 0.2), ("sky", 0.3, 0.6)])]
+        )
+        result = generate_word_sequence(
+            clips=[(clip, MockSource())],
+            mode="from_word_list",
+            mode_params={"sequence": ["the", "the", "sky"]},
+        )
+        assert len(result) == 3
+
+    def test_by_property(self):
+        clip = MockClip(
+            transcript=[
+                _seg([("a", 0.0, 0.1), ("bb", 0.2, 0.5), ("ccc", 0.6, 0.7)])
+            ]
+        )
+        result = generate_word_sequence(
+            clips=[(clip, MockSource())],
+            mode="by_property",
+            mode_params={"key": "length"},
+        )
+        assert len(result) == 3
+
+    def test_unknown_mode_raises(self):
+        clip = MockClip(transcript=[_seg([("a", 0.0, 0.5)])])
+        with pytest.raises(ValueError, match="mode"):
+            generate_word_sequence(
+                clips=[(clip, MockSource())],
+                mode="nope",
+                mode_params={},
+            )
+
+
+# ---------------------------------------------------------------------------
+# Empty input
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyInput:
+    def test_empty_clips_returns_empty(self):
+        result = generate_word_sequence(
+            clips=[],
+            mode="alphabetical",
+            mode_params={},
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Fraction-fps handling (per the cut-tab-fractional-duration learning)
+# ---------------------------------------------------------------------------
+
+
+class TestFractionFps:
+    def test_fraction_fps_converted_to_float(self):
+        from fractions import Fraction
+
+        clip = MockClip(transcript=[_seg([("hi", 0.5, 0.9)])])
+        src = MockSource(fps=Fraction(24000, 1001))  # type: ignore[arg-type]
+        result = generate_word_sequence(
+            clips=[(clip, src)],
+            mode="alphabetical",
+            mode_params={},
+        )
+        assert len(result) == 1
+        # Frame numbers are ints.
+        assert isinstance(result[0].in_point, int)
+        assert isinstance(result[0].out_point, int)

--- a/tests/test_word_sequencer_dialog.py
+++ b/tests/test_word_sequencer_dialog.py
@@ -1,0 +1,353 @@
+"""Tests for ``WordSequencerDialog``.
+
+Run under offscreen Qt so these don't open windows in CI. Tests exercise the
+dialog's pure-Python paths — picker population, validation, mode-conditional
+visibility, accept-path delegation — without spinning up the Ollama or
+alignment workers.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from core.transcription import TranscriptSegment, WordTimestamp
+from models.clip import Clip, Source
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _aligned_segment(words: list[tuple[str, float, float]], language: str = "en") -> TranscriptSegment:
+    seg = TranscriptSegment(
+        start_time=words[0][1] if words else 0.0,
+        end_time=words[-1][2] if words else 0.0,
+        text=" ".join(w[0] for w in words),
+        confidence=0.9,
+        words=[WordTimestamp(start=s, end=e, text=t) for t, s, e in words],
+        language=language,
+    )
+    return seg
+
+
+def _unaligned_segment(text: str, start: float, end: float, language: str = "en") -> TranscriptSegment:
+    return TranscriptSegment(
+        start_time=start,
+        end_time=end,
+        text=text,
+        confidence=0.9,
+        words=None,
+        language=language,
+    )
+
+
+def _make_aligned_clip(clip_id: str = "clip-1", source_id: str = "src-1") -> tuple:
+    source = Source(
+        id=source_id,
+        file_path=Path(f"/test/{source_id}.mp4"),
+        duration_seconds=30.0,
+        fps=24.0,
+        width=640,
+        height=360,
+    )
+    clip = Clip(
+        id=clip_id,
+        source_id=source_id,
+        start_frame=0,
+        end_frame=240,
+    )
+    clip.transcript = [
+        _aligned_segment([
+            ("the", 0.0, 0.2),
+            ("apple", 0.2, 0.5),
+            ("falls", 0.5, 0.9),
+        ]),
+    ]
+    return clip, source
+
+
+def _make_unaligned_clip(clip_id: str = "clip-2", source_id: str = "src-2") -> tuple:
+    source = Source(
+        id=source_id,
+        file_path=Path(f"/test/{source_id}.mp4"),
+        duration_seconds=30.0,
+        fps=24.0,
+        width=640,
+        height=360,
+    )
+    clip = Clip(
+        id=clip_id,
+        source_id=source_id,
+        start_frame=0,
+        end_frame=240,
+    )
+    clip.transcript = [_unaligned_segment("the sky is blue", 0.0, 1.0)]
+    return clip, source
+
+
+def _make_unsupported_lang_clip(clip_id: str = "clip-3", source_id: str = "src-3") -> tuple:
+    """Build a clip whose transcript language is not in the supported set."""
+    source = Source(
+        id=source_id,
+        file_path=Path(f"/test/{source_id}.mp4"),
+        duration_seconds=30.0,
+        fps=24.0,
+        width=640,
+        height=360,
+    )
+    clip = Clip(
+        id=clip_id,
+        source_id=source_id,
+        start_frame=0,
+        end_frame=240,
+    )
+    # "xx" — guaranteed not to appear in any real ISO 639-1 list.
+    clip.transcript = [_aligned_segment([("foo", 0.0, 0.2)], language="xx")]
+    return clip, source
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_dialog_opens_with_aligned_clips(qapp):
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    clip, source = _make_aligned_clip()
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+
+    # Source picker populated, row enabled and checked.
+    assert dialog._source_list.count() == 1
+    item = dialog._source_list.item(0)
+    from PySide6.QtCore import Qt
+    assert item.checkState() == Qt.Checked
+    assert "✓ aligned" in item.text()
+
+    # Accept enabled in alphabetical mode for a non-empty corpus.
+    assert dialog._accept_btn.isEnabled() is True
+
+
+def test_mode_visibility_toggles(qapp):
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    clip, source = _make_aligned_clip()
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+
+    # Initial mode = Alphabetical → no mode-specific container visible
+    # (isHidden() reflects explicit setVisible state independent of parent).
+    assert dialog._chosen_container.isHidden() is True
+    assert dialog._property_container.isHidden() is True
+    assert dialog._userlist_container.isHidden() is True
+    assert dialog._frequency_container.isHidden() is True
+
+    # Switch to Chosen Words.
+    dialog._mode_combo.setCurrentIndex(1)
+    assert dialog._chosen_container.isHidden() is False
+    assert dialog._property_container.isHidden() is True
+
+    # Switch to By Property.
+    dialog._mode_combo.setCurrentIndex(3)
+    assert dialog._property_container.isHidden() is False
+    assert dialog._chosen_container.isHidden() is True
+
+    # Switch to User-Curated.
+    dialog._mode_combo.setCurrentIndex(4)
+    assert dialog._userlist_container.isHidden() is False
+
+
+def test_text_state_preserved_across_mode_switch(qapp):
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    clip, source = _make_aligned_clip()
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+
+    dialog._mode_combo.setCurrentIndex(1)  # chosen
+    dialog._chosen_words_input.setPlainText("apple")
+    dialog._mode_combo.setCurrentIndex(4)  # user-curated
+    dialog._userlist_input.setPlainText("the the apple")
+
+    # Switch back; both fields retain their values.
+    dialog._mode_combo.setCurrentIndex(1)
+    assert "apple" in dialog._chosen_words_input.toPlainText()
+    dialog._mode_combo.setCurrentIndex(4)
+    assert "the the apple" in dialog._userlist_input.toPlainText()
+
+
+def test_unsupported_language_source_disabled(qapp):
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+    from PySide6.QtCore import Qt
+
+    aligned_clip, aligned_source = _make_aligned_clip()
+    bad_clip, bad_source = _make_unsupported_lang_clip()
+    dialog = WordSequencerDialog(
+        clips=[(aligned_clip, aligned_source), (bad_clip, bad_source)],
+        project=None,
+    )
+
+    assert dialog._source_list.count() == 2
+
+    bad_row = None
+    aligned_row = None
+    for i in range(dialog._source_list.count()):
+        item = dialog._source_list.item(i)
+        if "unsupported" in item.text():
+            bad_row = item
+        elif "aligned" in item.text():
+            aligned_row = item
+    assert bad_row is not None
+    assert aligned_row is not None
+    assert not (bad_row.flags() & Qt.ItemIsEnabled)
+    assert bad_row.checkState() == Qt.Unchecked
+    assert aligned_row.checkState() == Qt.Checked
+    # Accept stays enabled because aligned row is still valid.
+    assert dialog._accept_btn.isEnabled() is True
+
+
+def test_chosen_words_validation(qapp):
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    clip, source = _make_aligned_clip()
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+    dialog._mode_combo.setCurrentIndex(1)  # chosen
+
+    # Empty input → disabled.
+    dialog._chosen_words_input.setPlainText("")
+    assert dialog._accept_btn.isEnabled() is False
+
+    # All entries miss the corpus → disabled, error label populated.
+    dialog._chosen_words_input.setPlainText("zzz, qqq")
+    assert dialog._accept_btn.isEnabled() is False
+    assert "0 of 2" in dialog._error_label.text()
+
+    # Mixed: one hit → enabled.
+    dialog._chosen_words_input.setPlainText("apple, qqq")
+    assert dialog._accept_btn.isEnabled() is True
+
+
+def test_unchecking_all_disables_accept(qapp):
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+    from PySide6.QtCore import Qt
+
+    clip, source = _make_aligned_clip()
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+    item = dialog._source_list.item(0)
+    item.setCheckState(Qt.Unchecked)
+    # Force re-validate (itemChanged should fire but be explicit).
+    dialog._refresh_validation()
+    assert dialog._accept_btn.isEnabled() is False
+
+
+def test_accept_emits_sequence_for_alphabetical(qapp):
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    clip, source = _make_aligned_clip()
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+
+    captured = []
+    dialog.sequence_ready.connect(captured.append)
+
+    # Force-accept programmatically.
+    dialog._mode_combo.setCurrentIndex(0)  # alphabetical
+    dialog._on_accept()
+
+    assert len(captured) == 1
+    seq_clips = captured[0]
+    # Three words → three SequenceClip entries, alphabetical: apple, falls, the.
+    assert len(seq_clips) == 3
+    # source_clip_id always set to our single clip.
+    for sc in seq_clips:
+        assert sc.source_clip_id == clip.id
+
+
+def test_accept_with_unaligned_triggers_alignment_worker(qapp, monkeypatch):
+    """Accept with missing word data must start ForcedAlignmentWorker, not
+    call the sequencer directly."""
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    aligned_clip, aligned_source = _make_aligned_clip()
+    bad_clip, bad_source = _make_unaligned_clip()
+    dialog = WordSequencerDialog(
+        clips=[(aligned_clip, aligned_source), (bad_clip, bad_source)],
+        project=None,
+    )
+
+    starts = []
+
+    class FakeAlignmentWorker:
+        def __init__(self, *, clips, sources_by_id, skip_existing, parent=None):
+            self._clips = clips
+            from PySide6.QtCore import Signal
+
+            # Use real Signal-shaped attribute holders so .connect works.
+            class _Sig:
+                def connect(self, *args, **kwargs):
+                    return None
+
+            self.progress = _Sig()
+            self.clip_aligned = _Sig()
+            self.alignment_completed = _Sig()
+            self.error = _Sig()
+
+        def isRunning(self):
+            return True
+
+        def start(self):
+            starts.append(self._clips)
+
+        def wait(self, _ms):
+            return True
+
+        def cancel(self):
+            pass
+
+    monkeypatch.setattr(
+        "ui.workers.forced_alignment_worker.ForcedAlignmentWorker",
+        FakeAlignmentWorker,
+    )
+
+    dialog._on_accept()
+    # Exactly one alignment run started, only the unaligned clip queued.
+    assert len(starts) == 1
+    assert [c.id for c in starts[0]] == [bad_clip.id]
+
+
+def test_collect_mode_params_for_by_property(qapp):
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    clip, source = _make_aligned_clip()
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+    dialog._mode_combo.setCurrentIndex(3)  # by_property
+    dialog._property_combo.setCurrentIndex(2)  # log_frequency → defaults descending
+
+    params = dialog._collect_mode_params()
+    assert params["key"] == "log_frequency"
+    assert params["order"] == "descending"
+
+
+def test_user_curated_list_match_preview(qapp):
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    clip, source = _make_aligned_clip()
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+    dialog._mode_combo.setCurrentIndex(4)  # from_word_list
+    dialog._userlist_input.setPlainText("the the apple zzz")
+    text = dialog._userlist_match_label.text()
+    assert "4 slots" in text
+    assert "1 unrecognized" in text

--- a/tests/test_word_sequencer_e2e.py
+++ b/tests/test_word_sequencer_e2e.py
@@ -1,0 +1,173 @@
+"""End-to-end smoke test for the Word Sequencer pipeline.
+
+Covers the path U6 wires up:
+
+    aligned (Clip, Source) inputs
+        → ``WordSequencerDialog`` programmatic accept
+        → ``generate_word_sequence`` (spine + remix)
+        → ``SequenceClip[]`` emitted on ``sequence_ready``
+
+This is a *Python-level* smoke that proves the dialog → worker → spine →
+SequenceClip wiring is intact. The optional MP4 render step is gated behind
+``SCENE_RIPPER_E2E_RENDER=1`` because rendering pulls in FFmpeg and real
+source media that aren't available in CI.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from core.transcription import TranscriptSegment, WordTimestamp
+from models.clip import Clip, Source
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture
+def qapp():
+    from PySide6.QtWidgets import QApplication
+
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+def _make_50_word_source() -> tuple[Clip, Source]:
+    """Build a 30-second synthetic clip with 50 aligned words.
+
+    Each word spans 600ms (50 × 0.6 = 30s). Word texts are chosen so that
+    alphabetical order produces a deterministic 50-cut timeline.
+    """
+    source = Source(
+        id="src-e2e",
+        file_path=Path("/test/e2e.mp4"),
+        duration_seconds=30.0,
+        fps=24.0,
+        width=640,
+        height=360,
+    )
+    clip = Clip(
+        id="clip-e2e",
+        source_id=source.id,
+        start_frame=0,
+        end_frame=int(30.0 * 24.0),  # 720
+    )
+    word_texts = [
+        # 50 deliberately distinct lowercase words.
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf",
+        "hotel", "india", "juliet", "kilo", "lima", "mike", "november",
+        "oscar", "papa", "quebec", "romeo", "sierra", "tango", "uniform",
+        "victor", "whiskey", "xray", "yankee", "zulu", "amber", "blossom",
+        "cinder", "dune", "ember", "flint", "gable", "harbor", "ivy",
+        "jasper", "kestrel", "loam", "moss", "nimbus", "ochre", "pine",
+        "quartz", "ridge", "stone", "tide", "umber", "vale", "willow", "yew",
+    ]
+    assert len(word_texts) == 50
+
+    words = []
+    for i, text in enumerate(word_texts):
+        start = i * 0.6
+        end = start + 0.6
+        words.append(WordTimestamp(start=start, end=end, text=text))
+
+    clip.transcript = [
+        TranscriptSegment(
+            start_time=0.0,
+            end_time=30.0,
+            text=" ".join(word_texts),
+            confidence=0.95,
+            words=words,
+            language="en",
+        )
+    ]
+    return clip, source
+
+
+def test_alphabetical_50_word_smoke(qapp):
+    """The integration gate: 30-second seeded source → 50 SequenceClip entries."""
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    clip, source = _make_50_word_source()
+
+    captured: list = []
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+    dialog.sequence_ready.connect(captured.append)
+
+    # Alphabetical mode is the default (index 0).
+    assert dialog._mode_combo.currentIndex() == 0
+
+    dialog._on_accept()
+
+    assert len(captured) == 1, "dialog must emit sequence_ready exactly once"
+    sequence_clips = captured[0]
+    assert len(sequence_clips) == 50, (
+        f"expected 50 SequenceClips from 50 aligned words, got {len(sequence_clips)}"
+    )
+
+    # Frame coords are clip-relative integers within the clip bounds.
+    for sc in sequence_clips:
+        assert sc.source_clip_id == clip.id
+        assert sc.source_id == source.id
+        assert sc.in_point >= 0
+        assert sc.out_point > sc.in_point
+        assert sc.out_point <= clip.end_frame - clip.start_frame
+
+    # Materializing into a Sequence/Track must produce a contiguous timeline.
+    from models.sequence import Sequence, Track
+
+    track = Track(name="Video 1")
+    current_frame = 0
+    for sc in sequence_clips:
+        sc.start_frame = current_frame
+        track.clips.append(sc)
+        current_frame += sc.out_point - sc.in_point
+
+    sequence = Sequence(
+        name="e2e",
+        fps=source.fps,
+        tracks=[track],
+        algorithm="word_sequencer",
+    )
+    assert sequence.duration_frames == current_frame
+    assert sequence.duration_frames > 0
+
+
+@pytest.mark.skipif(
+    os.environ.get("SCENE_RIPPER_E2E_RENDER") != "1",
+    reason="optional MP4 render gate; set SCENE_RIPPER_E2E_RENDER=1 to enable",
+)
+def test_render_produces_mp4(tmp_path, qapp):
+    """When opted in, render the 50-clip sequence to an MP4 and check the
+    file exists with non-zero size."""
+    from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+    clip, source = _make_50_word_source()
+
+    captured: list = []
+    dialog = WordSequencerDialog(clips=[(clip, source)], project=None)
+    dialog.sequence_ready.connect(captured.append)
+    dialog._on_accept()
+
+    assert captured, "no sequence emitted; render step cannot run"
+    sequence_clips = captured[0]
+
+    # The renderer lives in core/export; pull it lazily so the smoke test
+    # doesn't import heavy dependencies unless this branch runs.
+    try:
+        from core.export import render_sequence_to_mp4  # type: ignore
+    except Exception as exc:  # noqa: BLE001
+        pytest.skip(f"render entrypoint unavailable: {exc}")
+
+    output = tmp_path / "e2e.mp4"
+    render_sequence_to_mp4(  # type: ignore[misc]
+        sequence_clips=sequence_clips,
+        sources=[source],
+        clips=[clip],
+        output_path=output,
+    )
+    assert output.exists()
+    assert output.stat().st_size > 0

--- a/ui/algorithm_config.py
+++ b/ui/algorithm_config.py
@@ -8,7 +8,7 @@ macOS can hit a CoreText sbix→ImageIO crash (EXC_BAD_ACCESS at 0xbad4007
 inside CopyEmojiImage); SVG icons will replace this field in a later pass.
 """
 
-CATEGORY_ORDER = ["All", "Arrange", "Find", "Connect", "Audio", "Text", "Word", "Experimental"]
+CATEGORY_ORDER = ["All", "Arrange", "Find", "Connect", "Audio", "Text", "Word", "LLM", "Experimental"]
 
 ALGORITHM_CONFIG = {
     "color": {
@@ -200,6 +200,18 @@ ALGORITHM_CONFIG = {
         "required_analysis": ["transcription_with_words"],
         "is_dialog": True,
         "categories": ["word", "experimental"],
+    },
+    "word_llm_composer": {
+        "icon": "",
+        "label": "LLM Word Composer",
+        "description": "Compose a sentence-collage from your clips' spoken words — a local LLM drafts the sequence using only your corpus vocabulary",
+        "allow_duplicates": False,
+        # ``local_llm`` is NOT a required_analysis key — that drives the
+        # per-clip METADATA_CHECKS gate, not runtime service availability.
+        # Ollama health is checked at dialog open and inside the worker.
+        "required_analysis": ["transcription_with_words"],
+        "is_dialog": True,
+        "categories": ["word", "experimental", "llm"],
     },
 }
 

--- a/ui/algorithm_config.py
+++ b/ui/algorithm_config.py
@@ -8,7 +8,7 @@ macOS can hit a CoreText sbix→ImageIO crash (EXC_BAD_ACCESS at 0xbad4007
 inside CopyEmojiImage); SVG icons will replace this field in a later pass.
 """
 
-CATEGORY_ORDER = ["All", "Arrange", "Find", "Connect", "Audio", "Text"]
+CATEGORY_ORDER = ["All", "Arrange", "Find", "Connect", "Audio", "Text", "Word", "Experimental"]
 
 ALGORITHM_CONFIG = {
     "color": {
@@ -191,6 +191,15 @@ ALGORITHM_CONFIG = {
         "required_analysis": ["gaze"],
         "is_dialog": True,
         "categories": ["find", "connect"],
+    },
+    "word_sequencer": {
+        "icon": "",
+        "label": "Word Sequencer",
+        "description": "Compose a film from individual spoken words — order them alphabetically, by frequency, or by a custom list",
+        "allow_duplicates": False,
+        "required_analysis": ["transcription_with_words"],
+        "is_dialog": True,
+        "categories": ["word", "experimental"],
     },
 }
 

--- a/ui/dialogs/_word_source_picker.py
+++ b/ui/dialogs/_word_source_picker.py
@@ -1,0 +1,252 @@
+"""Shared source-picker scaffolding for the two word-sequencer dialogs.
+
+This module hosts the parts the ``WordSequencerDialog`` (U6 preset modes)
+and ``WordLLMComposerDialog`` (U6 LLM composer) used to duplicate verbatim:
+
+- The four per-source badge constants (``BADGE_ALIGNED`` etc.) and the
+  ``classify_source_alignment`` helper that picks one for a given source.
+- ``WordAlignmentController`` — a small ``QObject`` that owns the
+  ``ForcedAlignmentWorker`` lifecycle. The two dialogs each instantiate one
+  of these instead of duplicating the worker wiring (start, progress,
+  per-clip distribution back onto transcript segments, completion, error,
+  cancel). The QListWidget population stays per-dialog because the row
+  formatting is the same shape but minor layout details belong to the
+  dialog that owns the widget.
+
+Why ``QObject`` and not a free-standing utility? The controller needs to
+emit Qt signals (``progress``, ``error``, ``completed``) back to the
+dialog, and we want ``Qt.UniqueConnection`` semantics on those signals so
+the dialog's duplicate-signal guard pattern still works.
+
+The module imports PySide6 — it is a UI-layer module, not part of the
+GUI-agnostic spine.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from PySide6.QtCore import QObject, Qt, Signal, Slot
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "BADGE_ALIGNED",
+    "BADGE_MISSING_FPS",
+    "BADGE_NEEDS_ALIGNMENT",
+    "BADGE_UNSUPPORTED_LANGUAGE",
+    "WordAlignmentController",
+    "classify_source_alignment",
+]
+
+
+# ---------------------------------------------------------------------------
+# Per-source badge constants — replace the underscore-private names that
+# were previously imported across dialog modules.
+# ---------------------------------------------------------------------------
+
+BADGE_ALIGNED = "aligned"
+BADGE_NEEDS_ALIGNMENT = "needs_alignment"
+BADGE_UNSUPPORTED_LANGUAGE = "unsupported_language"
+BADGE_MISSING_FPS = "missing_fps"
+
+
+def classify_source_alignment(
+    clips_for_source: list[tuple[Any, Any]],
+) -> tuple[str, Optional[str]]:
+    """Return ``(badge_key, language)`` describing a source's alignment status.
+
+    The badge key is one of the ``BADGE_*`` constants. The language string
+    is the first transcript language found across the source's clips, or
+    ``None`` when no clip has surfaced one.
+
+    Args:
+        clips_for_source: ``[(Clip, Source), ...]`` for a single source.
+
+    Returns:
+        ``(badge_key, language)``. Possible badges, in priority order:
+
+        - ``BADGE_MISSING_FPS`` — the source has no ``fps`` (we can't convert
+          word boundaries to frames; the source is hard-unavailable).
+        - ``BADGE_UNSUPPORTED_LANGUAGE`` — the alignment model rejects the
+          detected language; source is unavailable for word sequencing.
+        - ``BADGE_NEEDS_ALIGNMENT`` — at least one segment has
+          ``words is None`` (i.e. needs alignment before sequencing).
+        - ``BADGE_ALIGNED`` — every segment already has word data.
+    """
+    language: Optional[str] = None
+    needs_alignment = False
+    for clip, source in clips_for_source:
+        if getattr(source, "fps", None) in (None, 0):
+            return BADGE_MISSING_FPS, language
+        transcript = getattr(clip, "transcript", None) or []
+        for seg in transcript:
+            seg_lang = getattr(seg, "language", None)
+            if seg_lang and language is None:
+                language = seg_lang
+            if getattr(seg, "words", None) is None:
+                needs_alignment = True
+
+    if language:
+        try:
+            # Reuse the runtime / fallback gate from U2. We deliberately
+            # call the underscore name from a single place (here) instead
+            # of every dialog.
+            from core.analysis.alignment import (
+                UnsupportedLanguageError,
+                _check_language_supported,
+            )
+            _check_language_supported(language)
+        except UnsupportedLanguageError:
+            return BADGE_UNSUPPORTED_LANGUAGE, language
+        except Exception:
+            # Fail open — if the gate itself errored we don't want to lock
+            # users out of every source.
+            pass
+
+    if needs_alignment:
+        return BADGE_NEEDS_ALIGNMENT, language
+    return BADGE_ALIGNED, language
+
+
+# ---------------------------------------------------------------------------
+# WordAlignmentController — wraps the worker lifecycle the two dialogs
+# share.
+# ---------------------------------------------------------------------------
+
+
+class WordAlignmentController(QObject):
+    """Run forced alignment over a list of clips and emit lifecycle signals.
+
+    Both word dialogs need exactly the same alignment-handling logic: spin
+    up a ``ForcedAlignmentWorker``, route per-clip ``clip_aligned`` payloads
+    back onto transcript segments via
+    ``core.analysis.alignment.distribute_words_to_segments``, expose
+    progress / error / completion signals to the dialog, and support
+    cancellation.
+
+    The controller owns the worker's lifetime. The dialog connects to
+    ``progress``, ``error``, and ``completed`` and remains responsible for
+    its own UI state (which stack page is showing, what error label says,
+    etc.). The controller does NOT mutate the dialog.
+
+    Signals:
+        progress: ``(current, total)`` — proxied straight from the worker.
+        error: ``(message)`` — proxied straight from the worker. May fire
+            zero or one times before ``completed``.
+        completed: emitted exactly once at the end of a run (success,
+            cancellation, or fatal error).
+
+    Lifecycle methods are :meth:`start` and :meth:`cancel`. :meth:`wait`
+    is a convenience for the dialog's ``closeEvent``.
+    """
+
+    progress = Signal(int, int)
+    error = Signal(str)
+    completed = Signal()
+
+    def __init__(self, dialog_clips: list[tuple[Any, Any]], parent: QObject = None):
+        """
+        Args:
+            dialog_clips: The dialog's full ``[(Clip, Source), ...]`` set.
+                The controller uses it to look up the ``Clip`` object for a
+                payload's ``clip_id`` (so it can mutate the matching
+                clip's transcript). Workers can't carry the project model
+                themselves, so each dialog passes in its known selection.
+            parent: Qt parent (typically the dialog).
+        """
+        super().__init__(parent)
+        self._dialog_clips = list(dialog_clips or [])
+        self._worker = None
+        self._finished_handled = False
+
+    def is_running(self) -> bool:
+        worker = self._worker
+        return worker is not None and worker.isRunning()
+
+    def start(
+        self,
+        pending_clips: list,
+        sources_by_id: dict,
+    ) -> None:
+        """Spawn a ``ForcedAlignmentWorker`` over the given clips.
+
+        Args:
+            pending_clips: Clips that need alignment (filtered by the
+                dialog from its checked selection).
+            sources_by_id: Source-id → ``Source`` lookup the worker uses to
+                resolve clip audio paths.
+        """
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        self._finished_handled = False
+
+        worker = ForcedAlignmentWorker(
+            clips=pending_clips,
+            sources_by_id=sources_by_id,
+            skip_existing=True,
+            parent=self,
+        )
+        worker.progress.connect(self._on_worker_progress, Qt.UniqueConnection)
+        worker.clip_aligned.connect(self._on_worker_clip_aligned, Qt.UniqueConnection)
+        worker.alignment_completed.connect(
+            self._on_worker_completed, Qt.UniqueConnection,
+        )
+        worker.error.connect(self._on_worker_error, Qt.UniqueConnection)
+        self._worker = worker
+        worker.start()
+
+    def cancel(self) -> None:
+        worker = self._worker
+        if worker is not None and worker.isRunning():
+            worker.cancel()
+
+    def wait(self, msecs: int = 50) -> None:
+        worker = self._worker
+        if worker is None:
+            return
+        try:
+            worker.wait(msecs)
+        except Exception:  # noqa: BLE001 — best-effort, dialog is closing
+            pass
+
+    # -- Slots --------------------------------------------------------------
+
+    @Slot(int, int)
+    def _on_worker_progress(self, current: int, total: int) -> None:
+        self.progress.emit(current, total)
+
+    @Slot(str, list)
+    def _on_worker_clip_aligned(self, clip_id: str, words: list) -> None:
+        """Find the matching clip and distribute words onto its segments."""
+        clip = None
+        for c, _ in self._dialog_clips:
+            if getattr(c, "id", None) == clip_id:
+                clip = c
+                break
+        if clip is None or not getattr(clip, "transcript", None):
+            logger.warning(
+                "WordAlignmentController: clip %s no longer present; dropping payload",
+                clip_id,
+            )
+            return
+
+        # The actual distribute logic lives in core.analysis.alignment so the
+        # analyze-tab path and both dialogs share one implementation.
+        from core.analysis.alignment import distribute_words_to_segments
+        distribute_words_to_segments(list(clip.transcript), words)
+
+    @Slot(str)
+    def _on_worker_error(self, message: str) -> None:
+        self.error.emit(message)
+
+    @Slot()
+    def _on_worker_completed(self) -> None:
+        if self._finished_handled:
+            return
+        self._finished_handled = True
+        self.wait(50)
+        self._worker = None
+        self.completed.emit()

--- a/ui/dialogs/word_llm_composer_dialog.py
+++ b/ui/dialogs/word_llm_composer_dialog.py
@@ -1,0 +1,701 @@
+"""LLM Word Composer dialog — prompt-driven, corpus-constrained sequencing.
+
+Lets the user pick the source(s) whose word inventory to draw from, type a
+generation prompt, and run a local LLM (Ollama) whose decoding is constrained
+to that exact word vocabulary. The result is emitted as
+``list[SequenceClip]`` materialized through
+``core.remix.word_llm_composer.generate_llm_word_sequence``.
+
+Behaviour mirrors ``WordSequencerDialog`` — same source picker, same
+missing-alignment auto-run, same inline error / progress UX — but the
+generation step calls into a separate worker
+(``ui.workers.llm_composer_worker.LLMComposerWorker``) since the Ollama call
+can take many seconds at corpus scale.
+
+Ollama health is probed once at dialog construction via
+``check_ollama_health``. When Ollama is unreachable the dialog renders an
+explanatory message + a "Recheck" button instead of the normal form, so the
+user gets a clear next step without a modal trap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Optional
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPlainTextEdit,
+    QProgressBar,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from core.remix.word_llm_composer import generate_llm_word_sequence  # noqa: F401 - re-exported symbol used in tests
+from core.remix.word_sequencer import MissingWordDataError
+from ui.dialogs.word_sequencer_dialog import (
+    _BADGE_ALIGNED,
+    _BADGE_MISSING_FPS,
+    _BADGE_NEEDS_ALIGNMENT,
+    _BADGE_UNSUPPORTED_LANGUAGE,
+    _classify_source,
+)
+from ui.theme import theme, Spacing, TypeScale, UISizes
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["WordLLMComposerDialog"]
+
+
+_REPEAT_POLICIES = [
+    ("round-robin", "Round-robin"),
+    ("random", "Random (with seed)"),
+    ("first", "First"),
+    ("longest", "Longest"),
+    ("shortest", "Shortest"),
+]
+
+
+def _check_ollama_health_sync(api_base: str = "http://localhost:11434") -> tuple[bool, str]:
+    """Synchronously call the async ``check_ollama_health`` helper."""
+    try:
+        from core.llm_client import check_ollama_health
+    except Exception as exc:  # noqa: BLE001
+        return False, f"LLM client unavailable: {exc}"
+    try:
+        return asyncio.run(check_ollama_health(api_base))
+    except RuntimeError:
+        # Already inside an event loop (e.g. async test harness). Skip the
+        # probe — the worker call will surface a clear error if needed.
+        return True, ""
+    except Exception as exc:  # noqa: BLE001
+        return False, str(exc)
+
+
+class WordLLMComposerDialog(QDialog):
+    """Modal dialog for the LLM Word Composer."""
+
+    sequence_ready = Signal(list)
+
+    def __init__(
+        self,
+        clips: list[tuple[Any, Any]],
+        project: Any = None,
+        parent=None,
+        *,
+        _ollama_health_fn=None,
+    ) -> None:
+        super().__init__(parent)
+        self._clips = list(clips or [])
+        self._project = project
+        self._health_probe = _ollama_health_fn or _check_ollama_health_sync
+
+        # Worker state.
+        self._alignment_worker = None
+        self._alignment_finished_handled = False
+        self._compose_worker = None
+        self._compose_finished_handled = False
+        self._pending_after_alignment = False
+        self._ollama_healthy = False
+
+        self._sources_by_id: dict[str, Any] = {}
+        self._clips_by_source_id: dict[str, list[tuple[Any, Any]]] = {}
+        for clip, source in self._clips:
+            source_id = getattr(source, "id", None)
+            if source_id is None:
+                continue
+            self._sources_by_id.setdefault(source_id, source)
+            self._clips_by_source_id.setdefault(source_id, []).append((clip, source))
+
+        self._source_status: dict[str, tuple[str, Optional[str]]] = {
+            sid: _classify_source(s_clips)
+            for sid, s_clips in self._clips_by_source_id.items()
+        }
+
+        self.setWindowTitle("LLM Word Composer")
+        self.setMinimumWidth(560)
+        self.setMinimumHeight(580)
+        self._setup_ui()
+        self._populate_source_picker()
+        self._on_repeat_policy_changed(self._repeat_combo.currentIndex())
+        self._probe_ollama()
+        self._refresh_validation()
+
+    # ------------------------------------------------------------------ UI
+
+    def _setup_ui(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(24, 24, 24, 24)
+        outer.setSpacing(Spacing.MD)
+
+        title = QLabel("LLM Word Composer")
+        title.setStyleSheet(f"font-size: {TypeScale.XL}px; font-weight: bold;")
+        outer.addWidget(title)
+
+        desc = QLabel(
+            "Write a prompt; a local LLM drafts a sequence using only words "
+            "from your corpus. Decoding is constrained to your vocabulary, so "
+            "every word maps to a real clip."
+        )
+        desc.setWordWrap(True)
+        desc.setStyleSheet(f"color: {theme().text_secondary};")
+        outer.addWidget(desc)
+
+        self._stack = QStackedWidget()
+        outer.addWidget(self._stack, 1)
+
+        self._stack.addWidget(self._build_form_page())
+        self._stack.addWidget(self._build_progress_page())
+        self._stack.addWidget(self._build_ollama_absent_page())
+        self._stack.setCurrentIndex(0)
+
+    def _build_form_page(self) -> QWidget:
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.MD)
+
+        # --- Source picker ------------------------------------------------
+        sources_label = QLabel("Sources")
+        sources_label.setStyleSheet(
+            f"color: {theme().text_secondary}; font-size: {TypeScale.SM}px;"
+        )
+        layout.addWidget(sources_label)
+        self._source_list = QListWidget()
+        self._source_list.setMinimumHeight(120)
+        self._source_list.itemChanged.connect(self._refresh_validation)
+        layout.addWidget(self._source_list)
+
+        # --- Prompt -------------------------------------------------------
+        prompt_label = QLabel("Prompt")
+        prompt_label.setStyleSheet(
+            f"color: {theme().text_secondary}; font-size: {TypeScale.SM}px;"
+        )
+        layout.addWidget(prompt_label)
+        self._prompt_input = QPlainTextEdit()
+        self._prompt_input.setPlaceholderText(
+            "e.g., 'compose a sentence about silence'"
+        )
+        self._prompt_input.setMinimumHeight(80)
+        self._prompt_input.textChanged.connect(self._refresh_validation)
+        layout.addWidget(self._prompt_input)
+
+        # --- Target length -----------------------------------------------
+        length_row = QHBoxLayout()
+        length_label = QLabel("Target length")
+        length_label.setMinimumWidth(UISizes.FORM_LABEL_WIDTH)
+        length_row.addWidget(length_label)
+        self._length_spin = QSpinBox()
+        self._length_spin.setMinimumHeight(UISizes.LINE_EDIT_MIN_HEIGHT)
+        self._length_spin.setRange(1, 200)
+        self._length_spin.setValue(20)
+        length_row.addWidget(self._length_spin)
+        length_row.addStretch()
+        layout.addLayout(length_row)
+
+        # --- Repeat policy ------------------------------------------------
+        policy_row = QHBoxLayout()
+        policy_label = QLabel("Repeat policy")
+        policy_label.setMinimumWidth(UISizes.FORM_LABEL_WIDTH)
+        policy_row.addWidget(policy_label)
+        self._repeat_combo = QComboBox()
+        self._repeat_combo.setMinimumHeight(UISizes.COMBO_BOX_MIN_HEIGHT)
+        self._repeat_combo.setMinimumWidth(UISizes.COMBO_BOX_MIN_WIDTH)
+        for key, label in _REPEAT_POLICIES:
+            self._repeat_combo.addItem(label, key)
+        self._repeat_combo.currentIndexChanged.connect(
+            self._on_repeat_policy_changed
+        )
+        policy_row.addWidget(self._repeat_combo, 1)
+        layout.addLayout(policy_row)
+
+        # --- Seed (visible only with random policy) ----------------------
+        self._seed_container = QWidget()
+        seed_row = QHBoxLayout(self._seed_container)
+        seed_row.setContentsMargins(0, 0, 0, 0)
+        seed_label = QLabel("Random seed")
+        seed_label.setMinimumWidth(UISizes.FORM_LABEL_WIDTH)
+        seed_row.addWidget(seed_label)
+        self._seed_spin = QSpinBox()
+        self._seed_spin.setMinimumHeight(UISizes.LINE_EDIT_MIN_HEIGHT)
+        self._seed_spin.setRange(0, 2 ** 31 - 1)
+        self._seed_spin.setValue(0)
+        seed_row.addWidget(self._seed_spin)
+        seed_row.addStretch()
+        layout.addWidget(self._seed_container)
+
+        # --- Inline error -------------------------------------------------
+        self._error_label = QLabel("")
+        self._error_label.setWordWrap(True)
+        self._error_label.setStyleSheet(
+            f"color: {theme().accent_red}; font-size: {TypeScale.SM}px;"
+        )
+        self._error_label.setVisible(False)
+        layout.addWidget(self._error_label)
+
+        layout.addStretch()
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        self._cancel_btn = QPushButton("Cancel")
+        self._cancel_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        self._cancel_btn.clicked.connect(self.reject)
+        btn_row.addWidget(self._cancel_btn)
+        self._accept_btn = QPushButton("Generate")
+        self._accept_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        self._accept_btn.setStyleSheet("font-weight: bold;")
+        self._accept_btn.clicked.connect(self._on_accept)
+        btn_row.addWidget(self._accept_btn)
+        layout.addLayout(btn_row)
+
+        scroll.setWidget(page)
+        return scroll
+
+    def _build_progress_page(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.MD)
+
+        self._progress_title = QLabel("Generating...")
+        self._progress_title.setStyleSheet(
+            f"font-size: {TypeScale.LG}px; font-weight: bold;"
+        )
+        layout.addWidget(self._progress_title)
+
+        self._progress_label = QLabel("")
+        self._progress_label.setStyleSheet(f"color: {theme().text_secondary};")
+        layout.addWidget(self._progress_label)
+
+        self._progress_bar = QProgressBar()
+        self._progress_bar.setMinimum(0)
+        self._progress_bar.setMaximum(100)
+        layout.addWidget(self._progress_bar)
+
+        layout.addStretch()
+
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        self._progress_cancel_btn = QPushButton("Cancel")
+        self._progress_cancel_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        self._progress_cancel_btn.clicked.connect(self._on_cancel_workers)
+        btn_row.addWidget(self._progress_cancel_btn)
+        btn_row.addStretch()
+        layout.addLayout(btn_row)
+        return page
+
+    def _build_ollama_absent_page(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.MD)
+
+        title = QLabel("Local LLM not detected")
+        title.setStyleSheet(
+            f"font-size: {TypeScale.LG}px; font-weight: bold;"
+        )
+        layout.addWidget(title)
+
+        self._ollama_message_label = QLabel("")
+        self._ollama_message_label.setWordWrap(True)
+        self._ollama_message_label.setStyleSheet(
+            f"color: {theme().text_secondary};"
+        )
+        layout.addWidget(self._ollama_message_label)
+
+        layout.addStretch()
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        close_btn = QPushButton("Close")
+        close_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        close_btn.clicked.connect(self.reject)
+        btn_row.addWidget(close_btn)
+        recheck_btn = QPushButton("Recheck")
+        recheck_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        recheck_btn.clicked.connect(self._on_recheck_ollama)
+        btn_row.addWidget(recheck_btn)
+        btn_row.addStretch()
+        layout.addLayout(btn_row)
+        return page
+
+    # -------------------------------------------------------- Source picker
+
+    def _populate_source_picker(self) -> None:
+        self._source_list.blockSignals(True)
+        self._source_list.clear()
+        for source_id, src_clips in self._clips_by_source_id.items():
+            source = self._sources_by_id.get(source_id)
+            badge_key, language = self._source_status.get(
+                source_id, (_BADGE_ALIGNED, None)
+            )
+            label = self._format_source_row(source, src_clips, badge_key, language)
+            item = QListWidgetItem(label)
+            item.setData(Qt.UserRole, source_id)
+            disabled = badge_key in (_BADGE_UNSUPPORTED_LANGUAGE, _BADGE_MISSING_FPS)
+            if disabled:
+                item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
+                item.setCheckState(Qt.Unchecked)
+                if badge_key == _BADGE_UNSUPPORTED_LANGUAGE:
+                    item.setToolTip(
+                        f"alignment model does not support {language!r}; "
+                        "source unavailable for word-level sequencing"
+                    )
+                else:
+                    item.setToolTip("source missing fps metadata")
+            else:
+                item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+                item.setCheckState(Qt.Checked)
+            self._source_list.addItem(item)
+        self._source_list.blockSignals(False)
+
+    def _format_source_row(
+        self,
+        source: Any,
+        src_clips: list[tuple[Any, Any]],
+        badge_key: str,
+        language: Optional[str],
+    ) -> str:
+        filename = (
+            getattr(source, "filename", None)
+            or str(getattr(source, "file_path", "")) or "unknown"
+        )
+        duration = getattr(source, "duration_seconds", None)
+        if duration is None:
+            duration_str = getattr(source, "duration_str", "?")
+        else:
+            duration_str = f"{float(duration):.1f}s"
+        if badge_key == _BADGE_ALIGNED:
+            badge = "✓ aligned"
+        elif badge_key == _BADGE_NEEDS_ALIGNMENT:
+            badge = "… needs alignment"
+        elif badge_key == _BADGE_UNSUPPORTED_LANGUAGE:
+            badge = f"⚠ unsupported language ({language})"
+        else:
+            badge = "⚠ missing fps"
+        return f"{filename}  ·  {duration_str}  ·  {badge}  ·  {len(src_clips)} clip(s)"
+
+    def _checked_clips(self) -> list[tuple[Any, Any]]:
+        out: list[tuple[Any, Any]] = []
+        for i in range(self._source_list.count()):
+            item = self._source_list.item(i)
+            if item.checkState() != Qt.Checked:
+                continue
+            source_id = item.data(Qt.UserRole)
+            out.extend(self._clips_by_source_id.get(source_id, []))
+        return out
+
+    def _alignable_pending_clips(self) -> list:
+        pending: list = []
+        for clip, _source in self._checked_clips():
+            transcript = getattr(clip, "transcript", None) or []
+            if any(getattr(seg, "words", None) is None for seg in transcript):
+                pending.append(clip)
+        return pending
+
+    # ------------------------------------------------------------ Slots
+
+    @Slot(int)
+    def _on_repeat_policy_changed(self, _index: int) -> None:
+        policy = self._repeat_combo.currentData()
+        self._seed_container.setVisible(policy == "random")
+
+    def _set_error(self, message: Optional[str]) -> None:
+        if message:
+            self._error_label.setText(message)
+            self._error_label.setVisible(True)
+        else:
+            self._error_label.clear()
+            self._error_label.setVisible(False)
+
+    def _refresh_validation(self) -> None:
+        if not self._ollama_healthy:
+            self._accept_btn.setEnabled(False)
+            return
+        checked = self._checked_clips()
+        if not checked:
+            self._set_error("Select at least one source to continue.")
+            self._accept_btn.setEnabled(False)
+            return
+
+        prompt_text = self._prompt_input.toPlainText().strip()
+        if not prompt_text:
+            self._set_error("Enter a prompt.")
+            self._accept_btn.setEnabled(False)
+            return
+
+        try:
+            from core.spine.words import build_inventory
+            inv = build_inventory(checked)
+            corpus_size = len(inv.by_word)
+        except Exception:
+            corpus_size = 0
+        any_needs_alignment = any(
+            self._source_status.get(sid, (_BADGE_ALIGNED, None))[0]
+            == _BADGE_NEEDS_ALIGNMENT
+            for sid in self._checked_source_ids()
+        )
+        if corpus_size == 0 and not any_needs_alignment:
+            self._set_error(
+                "no words in selected sources — adjust your selection or include list"
+            )
+            self._accept_btn.setEnabled(False)
+            return
+
+        self._set_error(None)
+        self._accept_btn.setEnabled(True)
+
+    def _checked_source_ids(self) -> list[str]:
+        out: list[str] = []
+        for i in range(self._source_list.count()):
+            item = self._source_list.item(i)
+            if item.checkState() == Qt.Checked:
+                src_id = item.data(Qt.UserRole)
+                if src_id:
+                    out.append(src_id)
+        return out
+
+    # --------------------------------------------------------- Ollama gate
+
+    def _probe_ollama(self) -> None:
+        healthy, message = self._health_probe()
+        self._ollama_healthy = bool(healthy)
+        if not healthy:
+            self._ollama_message_label.setText(
+                "Local LLM not detected — install or start Ollama, then click "
+                "Recheck.\n\nDetails: " + (message or "(no diagnostic message)")
+            )
+            self._stack.setCurrentIndex(2)
+            self._accept_btn.setEnabled(False)
+        else:
+            self._stack.setCurrentIndex(0)
+
+    @Slot()
+    def _on_recheck_ollama(self) -> None:
+        self._probe_ollama()
+        self._refresh_validation()
+
+    # ------------------------------------------------------------ Accept
+
+    @Slot()
+    def _on_accept(self) -> None:
+        if not self._ollama_healthy:
+            self._set_error("Local LLM not detected. Start Ollama and recheck.")
+            return
+        checked = self._checked_clips()
+        if not checked:
+            return
+        pending = self._alignable_pending_clips()
+        if pending:
+            self._start_alignment(pending)
+            return
+        self._start_compose()
+
+    # --------------------------------------------------------- Composition
+
+    def _start_compose(self) -> None:
+        from ui.workers.llm_composer_worker import LLMComposerWorker
+
+        self._compose_finished_handled = False
+        self._stack.setCurrentIndex(1)
+        self._progress_title.setText("Composing with LLM")
+        self._progress_label.setText(
+            f"Calling local LLM to generate {self._length_spin.value()} words..."
+        )
+        self._progress_bar.setValue(0)
+        # Lock the prompt while generating.
+        self._prompt_input.setReadOnly(True)
+
+        policy = self._repeat_combo.currentData()
+        seed = self._seed_spin.value() if policy == "random" else None
+
+        worker = LLMComposerWorker(
+            clips=self._checked_clips(),
+            prompt=self._prompt_input.toPlainText().strip(),
+            target_length=self._length_spin.value(),
+            repeat_policy=policy,
+            seed=seed,
+            handle_frames=0,
+            parent=self,
+        )
+        worker.progress.connect(self._on_compose_progress, Qt.UniqueConnection)
+        worker.sequence_ready.connect(
+            self._on_compose_ready, Qt.UniqueConnection,
+        )
+        worker.error.connect(self._on_compose_error, Qt.UniqueConnection)
+        self._compose_worker = worker
+        worker.start()
+
+    @Slot(int, int)
+    def _on_compose_progress(self, current: int, total: int) -> None:
+        if total > 0:
+            self._progress_bar.setValue(int(current / total * 100))
+
+    @Slot(list)
+    def _on_compose_ready(self, sequence_clips: list) -> None:
+        if self._compose_finished_handled:
+            return
+        self._compose_finished_handled = True
+        self._prompt_input.setReadOnly(False)
+        worker = self._compose_worker
+        self._compose_worker = None
+        if worker is not None:
+            try:
+                worker.wait(50)
+            except Exception:
+                pass
+        if not sequence_clips:
+            self._set_error(
+                "LLM produced no sequence. Adjust the prompt and try again."
+            )
+            self._stack.setCurrentIndex(0)
+            return
+        self.sequence_ready.emit(sequence_clips)
+        self.accept()
+
+    @Slot(str)
+    def _on_compose_error(self, message: str) -> None:
+        if self._compose_finished_handled:
+            return
+        self._compose_finished_handled = True
+        self._prompt_input.setReadOnly(False)
+        worker = self._compose_worker
+        self._compose_worker = None
+        if worker is not None:
+            try:
+                worker.wait(50)
+            except Exception:
+                pass
+        self._set_error(message)
+        self._stack.setCurrentIndex(0)
+
+    # --------------------------------------------------------- Alignment
+
+    def _start_alignment(self, pending_clips: list) -> None:
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        self._alignment_finished_handled = False
+        self._pending_after_alignment = True
+
+        sources_by_id = {
+            src.id: src for src in self._sources_by_id.values() if src is not None
+        }
+
+        self._stack.setCurrentIndex(1)
+        self._progress_title.setText("Aligning words")
+        self._progress_label.setText(
+            f"Running word-level alignment on {len(pending_clips)} clip(s)..."
+        )
+        self._progress_bar.setValue(0)
+
+        worker = ForcedAlignmentWorker(
+            clips=pending_clips,
+            sources_by_id=sources_by_id,
+            skip_existing=True,
+            parent=self,
+        )
+        worker.progress.connect(self._on_alignment_progress, Qt.UniqueConnection)
+        worker.clip_aligned.connect(self._on_clip_aligned, Qt.UniqueConnection)
+        worker.alignment_completed.connect(
+            self._on_alignment_completed, Qt.UniqueConnection,
+        )
+        worker.error.connect(self._on_alignment_error, Qt.UniqueConnection)
+        self._alignment_worker = worker
+        worker.start()
+
+    @Slot(int, int)
+    def _on_alignment_progress(self, current: int, total: int) -> None:
+        if total > 0:
+            self._progress_bar.setValue(int(current / total * 100))
+        self._progress_label.setText(f"Aligning clip {current} of {total}...")
+
+    @Slot(str, list)
+    def _on_clip_aligned(self, clip_id: str, words: list) -> None:
+        clip = None
+        for c, _ in self._clips:
+            if getattr(c, "id", None) == clip_id:
+                clip = c
+                break
+        if clip is None or not getattr(clip, "transcript", None):
+            return
+        segments = list(clip.transcript)
+        per_segment: list[list] = [[] for _ in segments]
+        for word in words:
+            midpoint = (float(word.start) + float(word.end)) / 2.0
+            chosen_idx: Optional[int] = None
+            for i, seg in enumerate(segments):
+                if seg.start_time <= midpoint <= seg.end_time:
+                    chosen_idx = i
+                    break
+            if chosen_idx is None:
+                chosen_idx = min(
+                    range(len(segments)),
+                    key=lambda i: min(
+                        abs(midpoint - segments[i].start_time),
+                        abs(midpoint - segments[i].end_time),
+                    ),
+                )
+            per_segment[chosen_idx].append(word)
+        for seg, seg_words in zip(segments, per_segment):
+            seg.words = seg_words
+
+    @Slot(str)
+    def _on_alignment_error(self, message: str) -> None:
+        self._set_error(f"Alignment failed: {message}")
+
+    @Slot()
+    def _on_alignment_completed(self) -> None:
+        if self._alignment_finished_handled:
+            return
+        self._alignment_finished_handled = True
+        for source_id, src_clips in self._clips_by_source_id.items():
+            self._source_status[source_id] = _classify_source(src_clips)
+        worker = self._alignment_worker
+        self._alignment_worker = None
+        if worker is not None:
+            try:
+                worker.wait(50)
+            except Exception:
+                pass
+        if not self._pending_after_alignment:
+            self._stack.setCurrentIndex(0)
+            return
+        self._pending_after_alignment = False
+        self._start_compose()
+
+    # ------------------------------------------------------------ Cancel
+
+    @Slot()
+    def _on_cancel_workers(self) -> None:
+        cancelled = False
+        for worker in (self._alignment_worker, self._compose_worker):
+            if worker is not None and worker.isRunning():
+                worker.cancel()
+                cancelled = True
+        self._pending_after_alignment = False
+        if not cancelled:
+            self._stack.setCurrentIndex(0)
+
+    # --------------------------------------------------------- Lifecycle
+
+    def closeEvent(self, event) -> None:  # noqa: D401
+        for worker in (self._alignment_worker, self._compose_worker):
+            if worker is not None and worker.isRunning():
+                worker.cancel()
+                worker.wait(2000)
+        super().closeEvent(event)

--- a/ui/dialogs/word_llm_composer_dialog.py
+++ b/ui/dialogs/word_llm_composer_dialog.py
@@ -20,7 +20,6 @@ user gets a clear next step without a modal trap.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any, Optional
 
@@ -44,14 +43,24 @@ from PySide6.QtWidgets import (
 
 from core.remix.word_llm_composer import generate_llm_word_sequence  # noqa: F401 - re-exported symbol used in tests
 from core.remix.word_sequencer import MissingWordDataError
-from ui.dialogs.word_sequencer_dialog import (
-    _BADGE_ALIGNED,
-    _BADGE_MISSING_FPS,
-    _BADGE_NEEDS_ALIGNMENT,
-    _BADGE_UNSUPPORTED_LANGUAGE,
-    _classify_source,
+from ui.dialogs._word_source_picker import (
+    BADGE_ALIGNED,
+    BADGE_MISSING_FPS,
+    BADGE_NEEDS_ALIGNMENT,
+    BADGE_UNSUPPORTED_LANGUAGE,
+    WordAlignmentController,
+    classify_source_alignment,
 )
 from ui.theme import theme, Spacing, TypeScale, UISizes
+
+# Backward-compat aliases. The canonical names live in
+# ``ui.dialogs._word_source_picker``; these short-lived underscore aliases
+# keep any external imports from the previous module working.
+_BADGE_ALIGNED = BADGE_ALIGNED
+_BADGE_NEEDS_ALIGNMENT = BADGE_NEEDS_ALIGNMENT
+_BADGE_UNSUPPORTED_LANGUAGE = BADGE_UNSUPPORTED_LANGUAGE
+_BADGE_MISSING_FPS = BADGE_MISSING_FPS
+_classify_source = classify_source_alignment
 
 logger = logging.getLogger(__name__)
 
@@ -69,19 +78,17 @@ _REPEAT_POLICIES = [
 
 
 def _check_ollama_health_sync(api_base: str = "http://localhost:11434") -> tuple[bool, str]:
-    """Synchronously call the async ``check_ollama_health`` helper."""
+    """Synchronously call the async ``check_ollama_health`` helper.
+
+    Thin shim over :func:`core.llm_client.check_ollama_health_sync` so the
+    dialog has a stable default for the ``_ollama_health_fn`` injection
+    point (tests pass a stub).
+    """
     try:
-        from core.llm_client import check_ollama_health
-    except Exception as exc:  # noqa: BLE001
+        from core.llm_client import check_ollama_health_sync
+    except Exception as exc:  # noqa: BLE001 — import-time error, surface it
         return False, f"LLM client unavailable: {exc}"
-    try:
-        return asyncio.run(check_ollama_health(api_base))
-    except RuntimeError:
-        # Already inside an event loop (e.g. async test harness). Skip the
-        # probe — the worker call will surface a clear error if needed.
-        return True, ""
-    except Exception as exc:  # noqa: BLE001
-        return False, str(exc)
+    return check_ollama_health_sync(api_base)
 
 
 class WordLLMComposerDialog(QDialog):
@@ -102,9 +109,8 @@ class WordLLMComposerDialog(QDialog):
         self._project = project
         self._health_probe = _ollama_health_fn or _check_ollama_health_sync
 
-        # Worker state.
-        self._alignment_worker = None
-        self._alignment_finished_handled = False
+        # Worker state. The alignment controller owns the alignment-worker
+        # lifetime; only the LLM compose worker is owned directly here.
         self._compose_worker = None
         self._compose_finished_handled = False
         self._pending_after_alignment = False
@@ -120,9 +126,21 @@ class WordLLMComposerDialog(QDialog):
             self._clips_by_source_id.setdefault(source_id, []).append((clip, source))
 
         self._source_status: dict[str, tuple[str, Optional[str]]] = {
-            sid: _classify_source(s_clips)
+            sid: classify_source_alignment(s_clips)
             for sid, s_clips in self._clips_by_source_id.items()
         }
+
+        # Shared alignment controller — replaces the per-dialog
+        # ``ForcedAlignmentWorker`` wiring. The dialog still owns the
+        # compose worker because that's LLM-specific.
+        self._alignment_ctrl: Optional[WordAlignmentController] = None
+
+        # Validation-time inventory cache. Keyed by frozenset of checked
+        # source ids; invalidated on source-picker toggles and after
+        # alignment runs. Without this, every keystroke in the prompt
+        # input would rebuild the full corpus inventory.
+        self._inventory_cache_key: Optional[frozenset] = None
+        self._inventory_cache: Optional[Any] = None
 
         self.setWindowTitle("LLM Word Composer")
         self.setMinimumWidth(560)
@@ -179,7 +197,7 @@ class WordLLMComposerDialog(QDialog):
         layout.addWidget(sources_label)
         self._source_list = QListWidget()
         self._source_list.setMinimumHeight(120)
-        self._source_list.itemChanged.connect(self._refresh_validation)
+        self._source_list.itemChanged.connect(self._on_source_checked_changed)
         layout.addWidget(self._source_list)
 
         # --- Prompt -------------------------------------------------------
@@ -423,6 +441,31 @@ class WordLLMComposerDialog(QDialog):
             self._error_label.clear()
             self._error_label.setVisible(False)
 
+    @Slot()
+    def _on_source_checked_changed(self, _item) -> None:
+        # The set of checked sources changed → corpus changed.
+        self._invalidate_inventory_cache()
+        self._refresh_validation()
+
+    def _invalidate_inventory_cache(self) -> None:
+        """Drop the cached ``WordInventory`` so the next access rebuilds it."""
+        self._inventory_cache_key = None
+        self._inventory_cache = None
+
+    def _get_cached_inventory(self, checked_clips: list[tuple[Any, Any]]):
+        """Build (or return cached) ``WordInventory`` for the checked set."""
+        key = frozenset(self._checked_source_ids())
+        if self._inventory_cache_key == key and self._inventory_cache is not None:
+            return self._inventory_cache
+        try:
+            from core.spine.words import build_inventory
+            inv = build_inventory(checked_clips)
+        except Exception:
+            inv = None
+        self._inventory_cache_key = key
+        self._inventory_cache = inv
+        return inv
+
     def _refresh_validation(self) -> None:
         if not self._ollama_healthy:
             self._accept_btn.setEnabled(False)
@@ -439,12 +482,8 @@ class WordLLMComposerDialog(QDialog):
             self._accept_btn.setEnabled(False)
             return
 
-        try:
-            from core.spine.words import build_inventory
-            inv = build_inventory(checked)
-            corpus_size = len(inv.by_word)
-        except Exception:
-            corpus_size = 0
+        inv = self._get_cached_inventory(checked)
+        corpus_size = len(inv.by_word) if inv is not None else 0
         any_needs_alignment = any(
             self._source_status.get(sid, (_BADGE_ALIGNED, None))[0]
             == _BADGE_NEEDS_ALIGNMENT
@@ -587,9 +626,7 @@ class WordLLMComposerDialog(QDialog):
     # --------------------------------------------------------- Alignment
 
     def _start_alignment(self, pending_clips: list) -> None:
-        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
-
-        self._alignment_finished_handled = False
+        """Spawn a ``WordAlignmentController`` over the pending clips."""
         self._pending_after_alignment = True
 
         sources_by_id = {
@@ -603,20 +640,12 @@ class WordLLMComposerDialog(QDialog):
         )
         self._progress_bar.setValue(0)
 
-        worker = ForcedAlignmentWorker(
-            clips=pending_clips,
-            sources_by_id=sources_by_id,
-            skip_existing=True,
-            parent=self,
-        )
-        worker.progress.connect(self._on_alignment_progress, Qt.UniqueConnection)
-        worker.clip_aligned.connect(self._on_clip_aligned, Qt.UniqueConnection)
-        worker.alignment_completed.connect(
-            self._on_alignment_completed, Qt.UniqueConnection,
-        )
-        worker.error.connect(self._on_alignment_error, Qt.UniqueConnection)
-        self._alignment_worker = worker
-        worker.start()
+        ctrl = WordAlignmentController(self._clips, parent=self)
+        ctrl.progress.connect(self._on_alignment_progress, Qt.UniqueConnection)
+        ctrl.completed.connect(self._on_alignment_completed, Qt.UniqueConnection)
+        ctrl.error.connect(self._on_alignment_error, Qt.UniqueConnection)
+        self._alignment_ctrl = ctrl
+        ctrl.start(pending_clips, sources_by_id)
 
     @Slot(int, int)
     def _on_alignment_progress(self, current: int, total: int) -> None:
@@ -624,54 +653,18 @@ class WordLLMComposerDialog(QDialog):
             self._progress_bar.setValue(int(current / total * 100))
         self._progress_label.setText(f"Aligning clip {current} of {total}...")
 
-    @Slot(str, list)
-    def _on_clip_aligned(self, clip_id: str, words: list) -> None:
-        clip = None
-        for c, _ in self._clips:
-            if getattr(c, "id", None) == clip_id:
-                clip = c
-                break
-        if clip is None or not getattr(clip, "transcript", None):
-            return
-        segments = list(clip.transcript)
-        per_segment: list[list] = [[] for _ in segments]
-        for word in words:
-            midpoint = (float(word.start) + float(word.end)) / 2.0
-            chosen_idx: Optional[int] = None
-            for i, seg in enumerate(segments):
-                if seg.start_time <= midpoint <= seg.end_time:
-                    chosen_idx = i
-                    break
-            if chosen_idx is None:
-                chosen_idx = min(
-                    range(len(segments)),
-                    key=lambda i: min(
-                        abs(midpoint - segments[i].start_time),
-                        abs(midpoint - segments[i].end_time),
-                    ),
-                )
-            per_segment[chosen_idx].append(word)
-        for seg, seg_words in zip(segments, per_segment):
-            seg.words = seg_words
-
     @Slot(str)
     def _on_alignment_error(self, message: str) -> None:
         self._set_error(f"Alignment failed: {message}")
 
     @Slot()
     def _on_alignment_completed(self) -> None:
-        if self._alignment_finished_handled:
-            return
-        self._alignment_finished_handled = True
         for source_id, src_clips in self._clips_by_source_id.items():
-            self._source_status[source_id] = _classify_source(src_clips)
-        worker = self._alignment_worker
-        self._alignment_worker = None
-        if worker is not None:
-            try:
-                worker.wait(50)
-            except Exception:
-                pass
+            self._source_status[source_id] = classify_source_alignment(src_clips)
+        self._alignment_ctrl = None
+        # The clips' word data has changed — invalidate the inventory
+        # cache so the next ``_refresh_validation`` rebuilds.
+        self._invalidate_inventory_cache()
         if not self._pending_after_alignment:
             self._stack.setCurrentIndex(0)
             return
@@ -683,10 +676,13 @@ class WordLLMComposerDialog(QDialog):
     @Slot()
     def _on_cancel_workers(self) -> None:
         cancelled = False
-        for worker in (self._alignment_worker, self._compose_worker):
-            if worker is not None and worker.isRunning():
-                worker.cancel()
-                cancelled = True
+        ctrl = self._alignment_ctrl
+        if ctrl is not None and ctrl.is_running():
+            ctrl.cancel()
+            cancelled = True
+        if self._compose_worker is not None and self._compose_worker.isRunning():
+            self._compose_worker.cancel()
+            cancelled = True
         self._pending_after_alignment = False
         if not cancelled:
             self._stack.setCurrentIndex(0)
@@ -694,8 +690,14 @@ class WordLLMComposerDialog(QDialog):
     # --------------------------------------------------------- Lifecycle
 
     def closeEvent(self, event) -> None:  # noqa: D401
-        for worker in (self._alignment_worker, self._compose_worker):
-            if worker is not None and worker.isRunning():
-                worker.cancel()
-                worker.wait(2000)
+        ctrl = self._alignment_ctrl
+        if ctrl is not None and ctrl.is_running():
+            ctrl.cancel()
+            ctrl.wait(2000)
+        if self._compose_worker is not None and self._compose_worker.isRunning():
+            self._compose_worker.cancel()
+            try:
+                self._compose_worker.wait(2000)
+            except Exception:
+                pass
         super().closeEvent(event)

--- a/ui/dialogs/word_llm_composer_dialog.py
+++ b/ui/dialogs/word_llm_composer_dialog.py
@@ -685,6 +685,10 @@ class WordLLMComposerDialog(QDialog):
             ctrl.cancel()
             cancelled = True
         if self._compose_worker is not None and self._compose_worker.isRunning():
+            # Mark the compose result as already handled *before* cancelling
+            # so a queued `sequence_ready` emission from the in-flight call
+            # cannot race the cancel and silently accept the dialog.
+            self._compose_finished_handled = True
             self._compose_worker.cancel()
             cancelled = True
         self._pending_after_alignment = False

--- a/ui/dialogs/word_llm_composer_dialog.py
+++ b/ui/dialogs/word_llm_composer_dialog.py
@@ -662,6 +662,10 @@ class WordLLMComposerDialog(QDialog):
         for source_id, src_clips in self._clips_by_source_id.items():
             self._source_status[source_id] = classify_source_alignment(src_clips)
         self._alignment_ctrl = None
+        # The controller mutated Clip.transcript[*].words in place; mark the
+        # project dirty so the new alignment data survives save.
+        if self._project is not None:
+            self._project.mark_dirty()
         # The clips' word data has changed — invalidate the inventory
         # cache so the next ``_refresh_validation`` rebuilds.
         self._invalidate_inventory_cache()

--- a/ui/dialogs/word_sequencer_dialog.py
+++ b/ui/dialogs/word_sequencer_dialog.py
@@ -1,0 +1,799 @@
+"""Word Sequencer dialog — preset-mode word-level sequencing.
+
+Lets the user pick the source(s) whose word inventory to draw from, choose one
+of five preset modes (alphabetical / chosen-words / by-frequency / by-property
+/ user-curated ordered list), and emit a ``list[SequenceClip]`` materialized
+through ``core.remix.word_sequencer.generate_word_sequence``.
+
+If any of the user's selected clips lack word-level alignment data, accepting
+the dialog auto-runs the ``ForcedAlignmentWorker`` (U3) on the offending
+clips. Word data is distributed back onto each clip's transcript on the main
+thread before the dialog re-attempts the sequencer call.
+
+Follows the staccato-dialog pattern:
+  - modal ``QDialog`` subclass,
+  - owns its worker(s) internally,
+  - feature-registry preflight runs inside the worker, not here,
+  - builds a ``list[SequenceClip]`` and emits via ``sequence_ready``; the
+    Sequence tab is responsible for wrapping the result in a ``Sequence`` and
+    assigning it to ``project.sequence``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from PySide6.QtCore import Qt, Signal, Slot
+from PySide6.QtWidgets import (
+    QComboBox,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QPlainTextEdit,
+    QProgressBar,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from core.remix.word_sequencer import (
+    MissingWordDataError,
+    generate_word_sequence,
+)
+from ui.theme import theme, Spacing, TypeScale, UISizes
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["WordSequencerDialog"]
+
+
+# Mode display labels keyed by spine-level mode names. Order matches the
+# brainstorm's enumeration.
+_MODE_OPTIONS: list[tuple[str, str]] = [
+    ("alphabetical", "Alphabetical"),
+    ("by_chosen_words", "Chosen Words"),
+    ("by_frequency", "By Frequency"),
+    ("by_property", "By Property"),
+    ("from_word_list", "User-Curated Ordered List"),
+]
+
+
+# Per-source alignment status flags surfaced in the source picker.
+_BADGE_ALIGNED = "aligned"
+_BADGE_NEEDS_ALIGNMENT = "needs_alignment"
+_BADGE_UNSUPPORTED_LANGUAGE = "unsupported_language"
+_BADGE_MISSING_FPS = "missing_fps"
+
+
+def _parse_word_list(text: str) -> list[str]:
+    """Tokenize a user-entered word list (comma / whitespace / newline)."""
+    if not text:
+        return []
+    parts: list[str] = []
+    for line in text.splitlines():
+        for piece in line.replace(",", " ").split():
+            piece = piece.strip()
+            if piece:
+                parts.append(piece)
+    return parts
+
+
+def _normalize_for_lookup(word: str) -> str:
+    """Lazy import of the spine normalizer to keep this module light."""
+    from core.spine.words import normalize_word
+    return normalize_word(word)
+
+
+def _classify_source(clips_for_source: list[tuple[Any, Any]]) -> tuple[str, Optional[str]]:
+    """Return (badge_key, language) for a source's clips.
+
+    The badge key is one of ``_BADGE_*``. The language string is the first
+    transcript language found across the source's clips, or ``None``.
+    """
+    language: Optional[str] = None
+    needs_alignment = False
+    for clip, source in clips_for_source:
+        if getattr(source, "fps", None) in (None, 0):
+            return _BADGE_MISSING_FPS, language
+        transcript = getattr(clip, "transcript", None) or []
+        for seg in transcript:
+            seg_lang = getattr(seg, "language", None)
+            if seg_lang and language is None:
+                language = seg_lang
+            if getattr(seg, "words", None) is None:
+                needs_alignment = True
+
+    if language:
+        try:
+            # Reuse the runtime / fallback gate from U2. Private name, but
+            # the only path that combines runtime introspection with the
+            # static fallback list.
+            from core.analysis.alignment import (
+                UnsupportedLanguageError,
+                _check_language_supported,
+            )
+            _check_language_supported(language)
+        except UnsupportedLanguageError:
+            return _BADGE_UNSUPPORTED_LANGUAGE, language
+        except Exception:
+            # Fail open — if the gate itself errored we don't want to lock
+            # users out of every source.
+            pass
+
+    if needs_alignment:
+        return _BADGE_NEEDS_ALIGNMENT, language
+    return _BADGE_ALIGNED, language
+
+
+class WordSequencerDialog(QDialog):
+    """Modal dialog for the Word Sequencer (preset modes)."""
+
+    # Emits ``list[SequenceClip]`` ordered as the preset mode produced them.
+    sequence_ready = Signal(list)
+
+    def __init__(
+        self,
+        clips: list[tuple[Any, Any]],
+        project: Any = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self._clips = list(clips or [])
+        self._project = project
+
+        # Worker state. The guard flag prevents the alignment-finished slot
+        # firing twice for a single run (qthread-destroyed-duplicate-signal
+        # learning).
+        self._alignment_worker = None
+        self._alignment_finished_handled = False
+        self._pending_after_alignment = False
+
+        # Per-source classification cache, keyed by Source.id.
+        self._source_status: dict[str, tuple[str, Optional[str]]] = {}
+        # Source id -> list of (Clip, Source) tuples for that source from the
+        # user's selection.
+        self._clips_by_source_id: dict[str, list[tuple[Any, Any]]] = {}
+        self._sources_by_id: dict[str, Any] = {}
+
+        for clip, source in self._clips:
+            source_id = getattr(source, "id", None)
+            if source_id is None:
+                continue
+            self._sources_by_id.setdefault(source_id, source)
+            self._clips_by_source_id.setdefault(source_id, []).append((clip, source))
+
+        for source_id, src_clips in self._clips_by_source_id.items():
+            self._source_status[source_id] = _classify_source(src_clips)
+
+        self.setWindowTitle("Word Sequencer")
+        self.setMinimumWidth(560)
+        self.setMinimumHeight(560)
+        self._setup_ui()
+        self._populate_source_picker()
+        self._on_mode_changed(self._mode_combo.currentIndex())
+        self._refresh_validation()
+
+    # ------------------------------------------------------------------ UI
+
+    def _setup_ui(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(24, 24, 24, 24)
+        outer.setSpacing(Spacing.MD)
+
+        title = QLabel("Word Sequencer")
+        title.setStyleSheet(f"font-size: {TypeScale.XL}px; font-weight: bold;")
+        outer.addWidget(title)
+
+        desc = QLabel(
+            "Compose a film from individual spoken words. Order by alphabet, "
+            "frequency, a property like word length, or a list you supply."
+        )
+        desc.setWordWrap(True)
+        desc.setStyleSheet(f"color: {theme().text_secondary};")
+        outer.addWidget(desc)
+
+        self._stack = QStackedWidget()
+        outer.addWidget(self._stack, 1)
+
+        self._stack.addWidget(self._build_form_page())
+        self._stack.addWidget(self._build_progress_page())
+        self._stack.setCurrentIndex(0)
+
+    def _build_form_page(self) -> QWidget:
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.NoFrame)
+
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.MD)
+
+        # --- Source picker ------------------------------------------------
+        source_label = QLabel("Sources")
+        source_label.setStyleSheet(
+            f"color: {theme().text_secondary}; font-size: {TypeScale.SM}px;"
+        )
+        layout.addWidget(source_label)
+
+        self._source_list = QListWidget()
+        self._source_list.setMinimumHeight(120)
+        self._source_list.itemChanged.connect(self._on_source_checked_changed)
+        layout.addWidget(self._source_list)
+
+        # --- Mode select --------------------------------------------------
+        mode_row = QHBoxLayout()
+        mode_label_widget = QLabel("Mode")
+        mode_label_widget.setMinimumWidth(UISizes.FORM_LABEL_WIDTH)
+        mode_row.addWidget(mode_label_widget)
+
+        self._mode_combo = QComboBox()
+        self._mode_combo.setMinimumHeight(UISizes.COMBO_BOX_MIN_HEIGHT)
+        self._mode_combo.setMinimumWidth(UISizes.COMBO_BOX_MIN_WIDTH)
+        for _key, label in _MODE_OPTIONS:
+            self._mode_combo.addItem(label)
+        self._mode_combo.currentIndexChanged.connect(self._on_mode_changed)
+        mode_row.addWidget(self._mode_combo, 1)
+        layout.addLayout(mode_row)
+
+        # --- Chosen-words container --------------------------------------
+        self._chosen_container = QWidget()
+        chosen_layout = QVBoxLayout(self._chosen_container)
+        chosen_layout.setContentsMargins(0, 0, 0, 0)
+        chosen_layout.setSpacing(Spacing.SM)
+        chosen_label = QLabel("Words to include (one per line, comma or space-separated):")
+        chosen_label.setStyleSheet(
+            f"color: {theme().text_secondary}; font-size: {TypeScale.SM}px;"
+        )
+        chosen_layout.addWidget(chosen_label)
+        self._chosen_words_input = QPlainTextEdit()
+        self._chosen_words_input.setPlaceholderText("the, sky, light")
+        self._chosen_words_input.setMinimumHeight(80)
+        self._chosen_words_input.textChanged.connect(self._refresh_validation)
+        chosen_layout.addWidget(self._chosen_words_input)
+        self._chosen_match_label = QLabel("")
+        self._chosen_match_label.setStyleSheet(
+            f"color: {theme().text_muted}; font-size: {TypeScale.XS}px;"
+        )
+        chosen_layout.addWidget(self._chosen_match_label)
+        layout.addWidget(self._chosen_container)
+
+        # --- Property select container -----------------------------------
+        self._property_container = QWidget()
+        prop_layout = QHBoxLayout(self._property_container)
+        prop_layout.setContentsMargins(0, 0, 0, 0)
+        prop_layout.setSpacing(Spacing.SM)
+        prop_layout.addWidget(QLabel("Property:"))
+        self._property_combo = QComboBox()
+        self._property_combo.setMinimumHeight(UISizes.COMBO_BOX_MIN_HEIGHT)
+        self._property_combo.addItem("length", "length")
+        self._property_combo.addItem("duration", "duration")
+        self._property_combo.addItem("log_frequency", "log_frequency")
+        self._property_combo.currentIndexChanged.connect(self._on_property_changed)
+        prop_layout.addWidget(self._property_combo)
+        prop_layout.addWidget(QLabel("Order:"))
+        self._property_order_combo = QComboBox()
+        self._property_order_combo.setMinimumHeight(UISizes.COMBO_BOX_MIN_HEIGHT)
+        self._property_order_combo.addItem("ascending", "ascending")
+        self._property_order_combo.addItem("descending", "descending")
+        prop_layout.addWidget(self._property_order_combo)
+        prop_layout.addStretch()
+        layout.addWidget(self._property_container)
+
+        # --- Frequency order container -----------------------------------
+        self._frequency_container = QWidget()
+        freq_layout = QHBoxLayout(self._frequency_container)
+        freq_layout.setContentsMargins(0, 0, 0, 0)
+        freq_layout.setSpacing(Spacing.SM)
+        freq_layout.addWidget(QLabel("Order:"))
+        self._frequency_order_combo = QComboBox()
+        self._frequency_order_combo.setMinimumHeight(UISizes.COMBO_BOX_MIN_HEIGHT)
+        self._frequency_order_combo.addItem("descending", "descending")
+        self._frequency_order_combo.addItem("ascending", "ascending")
+        freq_layout.addWidget(self._frequency_order_combo)
+        freq_layout.addStretch()
+        layout.addWidget(self._frequency_container)
+
+        # --- User-curated word list container ----------------------------
+        self._userlist_container = QWidget()
+        ul_layout = QVBoxLayout(self._userlist_container)
+        ul_layout.setContentsMargins(0, 0, 0, 0)
+        ul_layout.setSpacing(Spacing.SM)
+        ul_label = QLabel(
+            "Word sequence (repeats allowed; one slot per entry):"
+        )
+        ul_label.setStyleSheet(
+            f"color: {theme().text_secondary}; font-size: {TypeScale.SM}px;"
+        )
+        ul_layout.addWidget(ul_label)
+        self._userlist_input = QPlainTextEdit()
+        self._userlist_input.setPlaceholderText("the the the sky")
+        self._userlist_input.setMinimumHeight(80)
+        self._userlist_input.textChanged.connect(self._refresh_validation)
+        ul_layout.addWidget(self._userlist_input)
+        self._userlist_match_label = QLabel("")
+        self._userlist_match_label.setStyleSheet(
+            f"color: {theme().text_muted}; font-size: {TypeScale.XS}px;"
+        )
+        ul_layout.addWidget(self._userlist_match_label)
+        layout.addWidget(self._userlist_container)
+
+        # --- Handle-frames -----------------------------------------------
+        handle_row = QHBoxLayout()
+        handle_label = QLabel("Handle frames")
+        handle_label.setMinimumWidth(UISizes.FORM_LABEL_WIDTH)
+        handle_row.addWidget(handle_label)
+        self._handle_spin = QSpinBox()
+        self._handle_spin.setRange(0, 10)
+        self._handle_spin.setValue(0)
+        self._handle_spin.setMinimumHeight(UISizes.LINE_EDIT_MIN_HEIGHT)
+        handle_row.addWidget(self._handle_spin)
+        handle_row.addStretch()
+        layout.addLayout(handle_row)
+
+        # --- Inline error label ------------------------------------------
+        self._error_label = QLabel("")
+        self._error_label.setWordWrap(True)
+        self._error_label.setStyleSheet(
+            f"color: {theme().accent_red}; font-size: {TypeScale.SM}px;"
+        )
+        self._error_label.setVisible(False)
+        layout.addWidget(self._error_label)
+
+        layout.addStretch()
+
+        # --- Buttons ------------------------------------------------------
+        btn_row = QHBoxLayout()
+        btn_row.addStretch()
+        self._cancel_btn = QPushButton("Cancel")
+        self._cancel_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        self._cancel_btn.clicked.connect(self.reject)
+        btn_row.addWidget(self._cancel_btn)
+        self._accept_btn = QPushButton("Generate")
+        self._accept_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        self._accept_btn.setStyleSheet("font-weight: bold;")
+        self._accept_btn.clicked.connect(self._on_accept)
+        btn_row.addWidget(self._accept_btn)
+        layout.addLayout(btn_row)
+
+        scroll.setWidget(page)
+        return scroll
+
+    def _build_progress_page(self) -> QWidget:
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(Spacing.MD)
+
+        self._progress_title = QLabel("Aligning words...")
+        self._progress_title.setStyleSheet(
+            f"font-size: {TypeScale.LG}px; font-weight: bold;"
+        )
+        layout.addWidget(self._progress_title)
+
+        self._progress_label = QLabel("")
+        self._progress_label.setStyleSheet(f"color: {theme().text_secondary};")
+        layout.addWidget(self._progress_label)
+
+        self._progress_bar = QProgressBar()
+        self._progress_bar.setMinimum(0)
+        self._progress_bar.setMaximum(100)
+        layout.addWidget(self._progress_bar)
+
+        layout.addStretch()
+
+        btns = QHBoxLayout()
+        btns.addStretch()
+        self._progress_cancel_btn = QPushButton("Cancel")
+        self._progress_cancel_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        self._progress_cancel_btn.clicked.connect(self._on_cancel_alignment)
+        btns.addWidget(self._progress_cancel_btn)
+        btns.addStretch()
+        layout.addLayout(btns)
+        return page
+
+    # ----------------------------------------------------------- Helpers
+
+    def _populate_source_picker(self) -> None:
+        self._source_list.blockSignals(True)
+        self._source_list.clear()
+        for source_id, src_clips in self._clips_by_source_id.items():
+            source = self._sources_by_id.get(source_id)
+            badge_key, language = self._source_status.get(
+                source_id, (_BADGE_ALIGNED, None)
+            )
+            label = self._format_source_row(source, src_clips, badge_key, language)
+            item = QListWidgetItem(label)
+            item.setData(Qt.UserRole, source_id)
+            disabled = badge_key in (_BADGE_UNSUPPORTED_LANGUAGE, _BADGE_MISSING_FPS)
+            if disabled:
+                item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
+                item.setCheckState(Qt.Unchecked)
+                if badge_key == _BADGE_UNSUPPORTED_LANGUAGE:
+                    item.setToolTip(
+                        f"alignment model does not support {language!r}; "
+                        "source unavailable for word-level sequencing"
+                    )
+                else:
+                    item.setToolTip("source missing fps metadata")
+            else:
+                item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+                item.setCheckState(Qt.Checked)
+            self._source_list.addItem(item)
+        self._source_list.blockSignals(False)
+
+    def _format_source_row(
+        self,
+        source: Any,
+        src_clips: list[tuple[Any, Any]],
+        badge_key: str,
+        language: Optional[str],
+    ) -> str:
+        filename = (
+            getattr(source, "filename", None)
+            or str(getattr(source, "file_path", "")) or "unknown"
+        )
+        duration = getattr(source, "duration_seconds", None)
+        if duration is None:
+            # Try a derived duration_str if present.
+            duration_str = getattr(source, "duration_str", "?")
+        else:
+            duration_str = f"{float(duration):.1f}s"
+
+        if badge_key == _BADGE_ALIGNED:
+            badge = "✓ aligned"
+        elif badge_key == _BADGE_NEEDS_ALIGNMENT:
+            badge = "… needs alignment"
+        elif badge_key == _BADGE_UNSUPPORTED_LANGUAGE:
+            badge = f"⚠ unsupported language ({language})"
+        else:  # missing fps
+            badge = "⚠ missing fps"
+        return f"{filename}  ·  {duration_str}  ·  {badge}  ·  {len(src_clips)} clip(s)"
+
+    def _checked_clips(self) -> list[tuple[Any, Any]]:
+        out: list[tuple[Any, Any]] = []
+        for i in range(self._source_list.count()):
+            item = self._source_list.item(i)
+            if item.checkState() != Qt.Checked:
+                continue
+            source_id = item.data(Qt.UserRole)
+            out.extend(self._clips_by_source_id.get(source_id, []))
+        return out
+
+    def _alignable_pending_clips(self) -> list:
+        """Return ``Clip`` objects from checked sources missing word data."""
+        pending: list = []
+        for clip, _source in self._checked_clips():
+            transcript = getattr(clip, "transcript", None) or []
+            if any(getattr(seg, "words", None) is None for seg in transcript):
+                pending.append(clip)
+        return pending
+
+    def _selected_mode_key(self) -> str:
+        return _MODE_OPTIONS[self._mode_combo.currentIndex()][0]
+
+    # ----------------------------------------------------------- Slots
+
+    @Slot(int)
+    def _on_mode_changed(self, _index: int) -> None:
+        mode = self._selected_mode_key()
+        self._chosen_container.setVisible(mode == "by_chosen_words")
+        self._property_container.setVisible(mode == "by_property")
+        self._frequency_container.setVisible(mode == "by_frequency")
+        self._userlist_container.setVisible(mode == "from_word_list")
+        self._refresh_validation()
+
+    @Slot(int)
+    def _on_property_changed(self, _index: int) -> None:
+        # Plan default: ascending for length, descending for log_frequency.
+        key = self._property_combo.currentData()
+        if key == "log_frequency":
+            self._property_order_combo.setCurrentIndex(1)  # descending
+        elif key == "length":
+            self._property_order_combo.setCurrentIndex(0)  # ascending
+
+    @Slot()
+    def _on_source_checked_changed(self, _item) -> None:
+        self._refresh_validation()
+
+    def _refresh_validation(self) -> None:
+        """Re-evaluate Accept enablement and update the inline error label."""
+        checked_clips = self._checked_clips()
+        mode = self._selected_mode_key()
+
+        if not checked_clips:
+            self._set_error("Select at least one source to continue.")
+            self._accept_btn.setEnabled(False)
+            return
+
+        # Mode-specific corpus / list checks. These are cheap and only run
+        # over the current selection's already-aligned words; clips pending
+        # alignment are conservatively counted as "potentially in corpus".
+        try:
+            from core.spine.words import build_inventory
+            inv = build_inventory(checked_clips)
+            corpus = inv.by_word
+        except Exception:
+            corpus = {}
+
+        # If every clip is missing words and the corpus is empty, the dialog
+        # will fall back to triggering alignment. That's fine — we let
+        # Accept stay enabled in that case so the user can opt into the run.
+        any_needs_alignment = any(
+            self._source_status.get(item_source_id, (_BADGE_ALIGNED, None))[0]
+            == _BADGE_NEEDS_ALIGNMENT
+            for item_source_id in self._checked_source_ids()
+        )
+
+        if not corpus and not any_needs_alignment:
+            self._set_error(
+                "no words in selected sources — adjust your selection or include list"
+            )
+            self._accept_btn.setEnabled(False)
+            return
+
+        if mode == "by_chosen_words":
+            entries = _parse_word_list(self._chosen_words_input.toPlainText())
+            normalized = [_normalize_for_lookup(w) for w in entries]
+            normalized = [w for w in normalized if w]
+            found = [w for w in normalized if w in corpus]
+            if normalized:
+                self._chosen_match_label.setText(
+                    f"in corpus: {len(found)} / {len(normalized)}"
+                )
+            else:
+                self._chosen_match_label.setText("")
+            if normalized and not found and not any_needs_alignment:
+                self._set_error(
+                    f"0 of {len(normalized)} include-list words found in corpus"
+                )
+                self._accept_btn.setEnabled(False)
+                return
+            if not normalized:
+                self._set_error("Enter at least one word to include.")
+                self._accept_btn.setEnabled(False)
+                return
+
+        if mode == "from_word_list":
+            entries = _parse_word_list(self._userlist_input.toPlainText())
+            normalized = [_normalize_for_lookup(w) for w in entries]
+            normalized = [w for w in normalized if w]
+            unrecognized = [w for w in normalized if w not in corpus]
+            if normalized:
+                self._userlist_match_label.setText(
+                    f"{len(normalized)} slots; {len(unrecognized)} unrecognized"
+                )
+            else:
+                self._userlist_match_label.setText("")
+            if not normalized:
+                self._set_error("Enter at least one word.")
+                self._accept_btn.setEnabled(False)
+                return
+
+        self._set_error(None)
+        self._accept_btn.setEnabled(True)
+
+    def _checked_source_ids(self) -> list[str]:
+        out: list[str] = []
+        for i in range(self._source_list.count()):
+            item = self._source_list.item(i)
+            if item.checkState() == Qt.Checked:
+                src_id = item.data(Qt.UserRole)
+                if src_id:
+                    out.append(src_id)
+        return out
+
+    def _set_error(self, text: Optional[str]) -> None:
+        if text:
+            self._error_label.setText(text)
+            self._error_label.setVisible(True)
+        else:
+            self._error_label.clear()
+            self._error_label.setVisible(False)
+
+    # ----------------------------------------------------------- Accept
+
+    @Slot()
+    def _on_accept(self) -> None:
+        """Build the sequence; auto-run alignment if needed."""
+        checked_clips = self._checked_clips()
+        if not checked_clips:
+            return
+
+        pending = self._alignable_pending_clips()
+        if pending:
+            # Auto-run alignment over the pending clips. Once the worker
+            # completes, re-enter accept logic via _pending_after_alignment.
+            self._start_alignment(pending)
+            return
+
+        self._try_generate()
+
+    def _try_generate(self) -> None:
+        try:
+            sequence_clips = generate_word_sequence(
+                self._checked_clips(),
+                mode=self._selected_mode_key(),
+                mode_params=self._collect_mode_params(),
+                handle_frames=self._handle_spin.value(),
+            )
+        except MissingWordDataError as exc:
+            # Alignment must have failed for some clips; fall through to
+            # surfacing the message without dismissing the dialog.
+            self._set_error(str(exc))
+            self._stack.setCurrentIndex(0)
+            return
+        except ValueError as exc:
+            self._set_error(str(exc))
+            self._stack.setCurrentIndex(0)
+            return
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Word Sequencer generation failed")
+            self._set_error(f"Sequencer error: {exc}")
+            self._stack.setCurrentIndex(0)
+            return
+
+        if not sequence_clips:
+            self._set_error(
+                "Sequencer produced no clips — check your word list / corpus."
+            )
+            self._stack.setCurrentIndex(0)
+            return
+
+        self.sequence_ready.emit(sequence_clips)
+        self.accept()
+
+    def _collect_mode_params(self) -> dict:
+        mode = self._selected_mode_key()
+        if mode == "by_chosen_words":
+            return {"include": _parse_word_list(self._chosen_words_input.toPlainText())}
+        if mode == "by_frequency":
+            return {"order": self._frequency_order_combo.currentData()}
+        if mode == "by_property":
+            return {
+                "key": self._property_combo.currentData(),
+                "order": self._property_order_combo.currentData(),
+            }
+        if mode == "from_word_list":
+            return {
+                "sequence": _parse_word_list(self._userlist_input.toPlainText()),
+                "on_missing": "skip",
+            }
+        return {}
+
+    # --------------------------------------------------------- Alignment
+
+    def _start_alignment(self, pending_clips: list) -> None:
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        self._alignment_finished_handled = False
+        self._pending_after_alignment = True
+
+        sources_by_id = {
+            src.id: src for src in self._sources_by_id.values() if src is not None
+        }
+
+        self._stack.setCurrentIndex(1)
+        self._progress_title.setText("Aligning words")
+        self._progress_label.setText(
+            f"Running word-level alignment on {len(pending_clips)} clip(s)..."
+        )
+        self._progress_bar.setValue(0)
+
+        worker = ForcedAlignmentWorker(
+            clips=pending_clips,
+            sources_by_id=sources_by_id,
+            skip_existing=True,
+            parent=self,
+        )
+        worker.progress.connect(self._on_alignment_progress, Qt.UniqueConnection)
+        worker.clip_aligned.connect(self._on_clip_aligned, Qt.UniqueConnection)
+        worker.alignment_completed.connect(
+            self._on_alignment_completed, Qt.UniqueConnection,
+        )
+        worker.error.connect(self._on_alignment_error, Qt.UniqueConnection)
+        self._alignment_worker = worker
+        worker.start()
+
+    @Slot(int, int)
+    def _on_alignment_progress(self, current: int, total: int) -> None:
+        if total > 0:
+            self._progress_bar.setValue(int(current / total * 100))
+        self._progress_label.setText(f"Aligning clip {current} of {total}...")
+
+    @Slot(str, list)
+    def _on_clip_aligned(self, clip_id: str, words: list) -> None:
+        """Distribute words back onto the matching clip's transcript."""
+        # Find the clip object across the dialog's selection.
+        clip = None
+        for c, _ in self._clips:
+            if getattr(c, "id", None) == clip_id:
+                clip = c
+                break
+        if clip is None or not getattr(clip, "transcript", None):
+            logger.warning(
+                "WordSequencerDialog: clip %s no longer present; dropping payload",
+                clip_id,
+            )
+            return
+
+        segments = list(clip.transcript)
+        per_segment: list[list] = [[] for _ in segments]
+        for word in words:
+            midpoint = (float(word.start) + float(word.end)) / 2.0
+            chosen_idx: Optional[int] = None
+            for i, seg in enumerate(segments):
+                if seg.start_time <= midpoint <= seg.end_time:
+                    chosen_idx = i
+                    break
+            if chosen_idx is None:
+                chosen_idx = min(
+                    range(len(segments)),
+                    key=lambda i: min(
+                        abs(midpoint - segments[i].start_time),
+                        abs(midpoint - segments[i].end_time),
+                    ),
+                )
+            per_segment[chosen_idx].append(word)
+        for seg, seg_words in zip(segments, per_segment):
+            seg.words = seg_words
+
+    @Slot(str)
+    def _on_alignment_error(self, message: str) -> None:
+        logger.warning("WordSequencerDialog alignment error: %s", message)
+        self._set_error(f"Alignment failed: {message}")
+
+    @Slot()
+    def _on_alignment_completed(self) -> None:
+        if self._alignment_finished_handled:
+            return
+        self._alignment_finished_handled = True
+
+        # Refresh per-source status caches so the picker would render
+        # correctly if the user backs out and re-opens the dialog.
+        for source_id, src_clips in self._clips_by_source_id.items():
+            self._source_status[source_id] = _classify_source(src_clips)
+
+        worker = self._alignment_worker
+        self._alignment_worker = None
+        if worker is not None:
+            try:
+                worker.wait(50)
+            except Exception:
+                pass
+
+        if not self._pending_after_alignment:
+            # User cancelled — bounce back to form.
+            self._stack.setCurrentIndex(0)
+            return
+
+        self._pending_after_alignment = False
+        # Re-attempt generation after alignment.
+        self._try_generate()
+
+    @Slot()
+    def _on_cancel_alignment(self) -> None:
+        worker = self._alignment_worker
+        if worker is not None and worker.isRunning():
+            self._pending_after_alignment = False
+            worker.cancel()
+            # The worker's alignment_completed signal will bounce the stack
+            # back to the form page.
+        else:
+            self._stack.setCurrentIndex(0)
+
+    # --------------------------------------------------------- Lifecycle
+
+    def closeEvent(self, event) -> None:  # noqa: D401 - Qt override
+        worker = self._alignment_worker
+        if worker is not None and worker.isRunning():
+            worker.cancel()
+            worker.wait(2000)
+        super().closeEvent(event)

--- a/ui/dialogs/word_sequencer_dialog.py
+++ b/ui/dialogs/word_sequencer_dialog.py
@@ -46,6 +46,14 @@ from core.remix.word_sequencer import (
     MissingWordDataError,
     generate_word_sequence,
 )
+from ui.dialogs._word_source_picker import (
+    BADGE_ALIGNED,
+    BADGE_MISSING_FPS,
+    BADGE_NEEDS_ALIGNMENT,
+    BADGE_UNSUPPORTED_LANGUAGE,
+    WordAlignmentController,
+    classify_source_alignment,
+)
 from ui.theme import theme, Spacing, TypeScale, UISizes
 
 logger = logging.getLogger(__name__)
@@ -65,11 +73,18 @@ _MODE_OPTIONS: list[tuple[str, str]] = [
 ]
 
 
-# Per-source alignment status flags surfaced in the source picker.
-_BADGE_ALIGNED = "aligned"
-_BADGE_NEEDS_ALIGNMENT = "needs_alignment"
-_BADGE_UNSUPPORTED_LANGUAGE = "unsupported_language"
-_BADGE_MISSING_FPS = "missing_fps"
+# Backward-compatible private aliases for the per-source badge constants.
+# The canonical names live in ``ui.dialogs._word_source_picker``; these
+# aliases keep existing tests / imports working.
+_BADGE_ALIGNED = BADGE_ALIGNED
+_BADGE_NEEDS_ALIGNMENT = BADGE_NEEDS_ALIGNMENT
+_BADGE_UNSUPPORTED_LANGUAGE = BADGE_UNSUPPORTED_LANGUAGE
+_BADGE_MISSING_FPS = BADGE_MISSING_FPS
+
+# Backward-compatible alias for ``_classify_source`` (the previous
+# underscore-private name). New code should use
+# ``classify_source_alignment`` directly.
+_classify_source = classify_source_alignment
 
 
 def _parse_word_list(text: str) -> list[str]:
@@ -91,47 +106,6 @@ def _normalize_for_lookup(word: str) -> str:
     return normalize_word(word)
 
 
-def _classify_source(clips_for_source: list[tuple[Any, Any]]) -> tuple[str, Optional[str]]:
-    """Return (badge_key, language) for a source's clips.
-
-    The badge key is one of ``_BADGE_*``. The language string is the first
-    transcript language found across the source's clips, or ``None``.
-    """
-    language: Optional[str] = None
-    needs_alignment = False
-    for clip, source in clips_for_source:
-        if getattr(source, "fps", None) in (None, 0):
-            return _BADGE_MISSING_FPS, language
-        transcript = getattr(clip, "transcript", None) or []
-        for seg in transcript:
-            seg_lang = getattr(seg, "language", None)
-            if seg_lang and language is None:
-                language = seg_lang
-            if getattr(seg, "words", None) is None:
-                needs_alignment = True
-
-    if language:
-        try:
-            # Reuse the runtime / fallback gate from U2. Private name, but
-            # the only path that combines runtime introspection with the
-            # static fallback list.
-            from core.analysis.alignment import (
-                UnsupportedLanguageError,
-                _check_language_supported,
-            )
-            _check_language_supported(language)
-        except UnsupportedLanguageError:
-            return _BADGE_UNSUPPORTED_LANGUAGE, language
-        except Exception:
-            # Fail open — if the gate itself errored we don't want to lock
-            # users out of every source.
-            pass
-
-    if needs_alignment:
-        return _BADGE_NEEDS_ALIGNMENT, language
-    return _BADGE_ALIGNED, language
-
-
 class WordSequencerDialog(QDialog):
     """Modal dialog for the Word Sequencer (preset modes)."""
 
@@ -148,11 +122,9 @@ class WordSequencerDialog(QDialog):
         self._clips = list(clips or [])
         self._project = project
 
-        # Worker state. The guard flag prevents the alignment-finished slot
-        # firing twice for a single run (qthread-destroyed-duplicate-signal
-        # learning).
-        self._alignment_worker = None
-        self._alignment_finished_handled = False
+        # Worker state. The controller owns the worker lifetime; the
+        # dialog only needs to know whether an alignment is currently in
+        # flight (via ``self._alignment_ctrl is not None``).
         self._pending_after_alignment = False
 
         # Per-source classification cache, keyed by Source.id.
@@ -170,7 +142,20 @@ class WordSequencerDialog(QDialog):
             self._clips_by_source_id.setdefault(source_id, []).append((clip, source))
 
         for source_id, src_clips in self._clips_by_source_id.items():
-            self._source_status[source_id] = _classify_source(src_clips)
+            self._source_status[source_id] = classify_source_alignment(src_clips)
+
+        # Shared alignment controller — wraps the ``ForcedAlignmentWorker``
+        # lifecycle and the per-clip "distribute words back" mutation. The
+        # dialog reacts to the controller's ``completed`` / ``error``
+        # signals (see :meth:`_start_alignment`).
+        self._alignment_ctrl: Optional[WordAlignmentController] = None
+
+        # Validation-time inventory cache. Keyed by frozenset of checked
+        # source ids; invalidated on source-picker toggles and after
+        # alignment runs. Without this, every keystroke in the chosen-words
+        # or user-list inputs rebuilds the full inventory.
+        self._inventory_cache_key: Optional[frozenset] = None
+        self._inventory_cache: Optional[Any] = None
 
         self.setWindowTitle("Word Sequencer")
         self.setMinimumWidth(560)
@@ -501,7 +486,34 @@ class WordSequencerDialog(QDialog):
 
     @Slot()
     def _on_source_checked_changed(self, _item) -> None:
+        # The set of checked sources changed → corpus changed.
+        self._invalidate_inventory_cache()
         self._refresh_validation()
+
+    def _invalidate_inventory_cache(self) -> None:
+        """Drop the cached ``WordInventory`` so the next access rebuilds it."""
+        self._inventory_cache_key = None
+        self._inventory_cache = None
+
+    def _get_cached_inventory(self, checked_clips: list[tuple[Any, Any]]):
+        """Build (or return cached) ``WordInventory`` for the checked set.
+
+        Cache key is the frozenset of checked source ids — the only thing
+        that affects which clips are included in the inventory. Text
+        inputs (chosen-words / user-list) do NOT change the corpus, so
+        their textChanged signals never trigger a rebuild.
+        """
+        key = frozenset(self._checked_source_ids())
+        if self._inventory_cache_key == key and self._inventory_cache is not None:
+            return self._inventory_cache
+        try:
+            from core.spine.words import build_inventory
+            inv = build_inventory(checked_clips)
+        except Exception:
+            inv = None
+        self._inventory_cache_key = key
+        self._inventory_cache = inv
+        return inv
 
     def _refresh_validation(self) -> None:
         """Re-evaluate Accept enablement and update the inline error label."""
@@ -516,12 +528,12 @@ class WordSequencerDialog(QDialog):
         # Mode-specific corpus / list checks. These are cheap and only run
         # over the current selection's already-aligned words; clips pending
         # alignment are conservatively counted as "potentially in corpus".
-        try:
-            from core.spine.words import build_inventory
-            inv = build_inventory(checked_clips)
-            corpus = inv.by_word
-        except Exception:
-            corpus = {}
+        #
+        # The inventory is cached by checked-source-id set so that typing
+        # in the chosen-words / user-list inputs doesn't rebuild it on
+        # every keystroke (textChanged fires very frequently).
+        inv = self._get_cached_inventory(checked_clips)
+        corpus = inv.by_word if inv is not None else {}
 
         # If every clip is missing words and the corpus is empty, the dialog
         # will fall back to triggering alignment. That's fine — we let
@@ -671,9 +683,7 @@ class WordSequencerDialog(QDialog):
     # --------------------------------------------------------- Alignment
 
     def _start_alignment(self, pending_clips: list) -> None:
-        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
-
-        self._alignment_finished_handled = False
+        """Spawn a ``WordAlignmentController`` over the pending clips."""
         self._pending_after_alignment = True
 
         sources_by_id = {
@@ -687,63 +697,18 @@ class WordSequencerDialog(QDialog):
         )
         self._progress_bar.setValue(0)
 
-        worker = ForcedAlignmentWorker(
-            clips=pending_clips,
-            sources_by_id=sources_by_id,
-            skip_existing=True,
-            parent=self,
-        )
-        worker.progress.connect(self._on_alignment_progress, Qt.UniqueConnection)
-        worker.clip_aligned.connect(self._on_clip_aligned, Qt.UniqueConnection)
-        worker.alignment_completed.connect(
-            self._on_alignment_completed, Qt.UniqueConnection,
-        )
-        worker.error.connect(self._on_alignment_error, Qt.UniqueConnection)
-        self._alignment_worker = worker
-        worker.start()
+        ctrl = WordAlignmentController(self._clips, parent=self)
+        ctrl.progress.connect(self._on_alignment_progress, Qt.UniqueConnection)
+        ctrl.completed.connect(self._on_alignment_completed, Qt.UniqueConnection)
+        ctrl.error.connect(self._on_alignment_error, Qt.UniqueConnection)
+        self._alignment_ctrl = ctrl
+        ctrl.start(pending_clips, sources_by_id)
 
     @Slot(int, int)
     def _on_alignment_progress(self, current: int, total: int) -> None:
         if total > 0:
             self._progress_bar.setValue(int(current / total * 100))
         self._progress_label.setText(f"Aligning clip {current} of {total}...")
-
-    @Slot(str, list)
-    def _on_clip_aligned(self, clip_id: str, words: list) -> None:
-        """Distribute words back onto the matching clip's transcript."""
-        # Find the clip object across the dialog's selection.
-        clip = None
-        for c, _ in self._clips:
-            if getattr(c, "id", None) == clip_id:
-                clip = c
-                break
-        if clip is None or not getattr(clip, "transcript", None):
-            logger.warning(
-                "WordSequencerDialog: clip %s no longer present; dropping payload",
-                clip_id,
-            )
-            return
-
-        segments = list(clip.transcript)
-        per_segment: list[list] = [[] for _ in segments]
-        for word in words:
-            midpoint = (float(word.start) + float(word.end)) / 2.0
-            chosen_idx: Optional[int] = None
-            for i, seg in enumerate(segments):
-                if seg.start_time <= midpoint <= seg.end_time:
-                    chosen_idx = i
-                    break
-            if chosen_idx is None:
-                chosen_idx = min(
-                    range(len(segments)),
-                    key=lambda i: min(
-                        abs(midpoint - segments[i].start_time),
-                        abs(midpoint - segments[i].end_time),
-                    ),
-                )
-            per_segment[chosen_idx].append(word)
-        for seg, seg_words in zip(segments, per_segment):
-            seg.words = seg_words
 
     @Slot(str)
     def _on_alignment_error(self, message: str) -> None:
@@ -752,22 +717,15 @@ class WordSequencerDialog(QDialog):
 
     @Slot()
     def _on_alignment_completed(self) -> None:
-        if self._alignment_finished_handled:
-            return
-        self._alignment_finished_handled = True
-
         # Refresh per-source status caches so the picker would render
         # correctly if the user backs out and re-opens the dialog.
         for source_id, src_clips in self._clips_by_source_id.items():
-            self._source_status[source_id] = _classify_source(src_clips)
+            self._source_status[source_id] = classify_source_alignment(src_clips)
 
-        worker = self._alignment_worker
-        self._alignment_worker = None
-        if worker is not None:
-            try:
-                worker.wait(50)
-            except Exception:
-                pass
+        self._alignment_ctrl = None
+        # The clips' word data has changed — invalidate the inventory
+        # cache so the next ``_refresh_validation`` rebuilds.
+        self._invalidate_inventory_cache()
 
         if not self._pending_after_alignment:
             # User cancelled — bounce back to form.
@@ -780,11 +738,11 @@ class WordSequencerDialog(QDialog):
 
     @Slot()
     def _on_cancel_alignment(self) -> None:
-        worker = self._alignment_worker
-        if worker is not None and worker.isRunning():
+        ctrl = self._alignment_ctrl
+        if ctrl is not None and ctrl.is_running():
             self._pending_after_alignment = False
-            worker.cancel()
-            # The worker's alignment_completed signal will bounce the stack
+            ctrl.cancel()
+            # The controller's ``completed`` signal will bounce the stack
             # back to the form page.
         else:
             self._stack.setCurrentIndex(0)
@@ -792,8 +750,8 @@ class WordSequencerDialog(QDialog):
     # --------------------------------------------------------- Lifecycle
 
     def closeEvent(self, event) -> None:  # noqa: D401 - Qt override
-        worker = self._alignment_worker
-        if worker is not None and worker.isRunning():
-            worker.cancel()
-            worker.wait(2000)
+        ctrl = self._alignment_ctrl
+        if ctrl is not None and ctrl.is_running():
+            ctrl.cancel()
+            ctrl.wait(2000)
         super().closeEvent(event)

--- a/ui/dialogs/word_sequencer_dialog.py
+++ b/ui/dialogs/word_sequencer_dialog.py
@@ -723,6 +723,10 @@ class WordSequencerDialog(QDialog):
             self._source_status[source_id] = classify_source_alignment(src_clips)
 
         self._alignment_ctrl = None
+        # The controller mutated Clip.transcript[*].words in place; mark the
+        # project dirty so the new alignment data survives save.
+        if self._project is not None:
+            self._project.mark_dirty()
         # The clips' word data has changed — invalidate the inventory
         # cache so the next ``_refresh_validation`` rebuilds.
         self._invalidate_inventory_cache()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1730,6 +1730,10 @@ class MainWindow(QMainWindow):
         self.analyze_tab.clip_browser.view_details_requested.connect(self.show_clip_details)
         self.analyze_tab.clip_browser.export_requested.connect(self._on_clip_export_requested)
         self.analyze_tab.clip_browser.disabled_clips_changed.connect(self._on_disabled_clips_changed)
+        # distribute_words_to_segments mutates Clip.transcript[*].words in place;
+        # this signal makes the mutation observable to the dirty flag so the
+        # alignment data persists on save.
+        self.analyze_tab.clip_alignment_applied.connect(lambda _clip_id: self._mark_dirty())
 
         # Sequence tab signals
         self.sequence_tab.playback_requested.connect(self._on_playback_requested)

--- a/ui/tabs/analyze_tab.py
+++ b/ui/tabs/analyze_tab.py
@@ -1,6 +1,7 @@
 """Analyze tab for clip analysis features."""
 
 import logging
+from typing import Optional
 
 from PySide6.QtWidgets import (
     QVBoxLayout,
@@ -12,7 +13,7 @@ from PySide6.QtWidgets import (
     QComboBox,
     QSplitter,
 )
-from PySide6.QtCore import Signal, Qt, QTimer
+from PySide6.QtCore import Signal, Qt, QTimer, Slot
 
 from .base_tab import BaseTab
 from ui.clip_browser import ClipBrowser, VIRTUALIZATION_THRESHOLD
@@ -47,6 +48,14 @@ class AnalyzeTab(BaseTab):
     clips_cleared = Signal()
     selection_changed = Signal(list)  # list[str] selected clip IDs
     clips_changed = Signal(list)  # list[str] current clip IDs in tab
+    # Emitted when the forced-alignment handler writes word data back onto a
+    # clip's transcript segments, so the main window can mark the project
+    # dirty and propagate to other tabs. Payload: clip_id.
+    clip_alignment_applied = Signal(str)
+    # Emitted when the forced-alignment worker run finishes (success,
+    # cancellation, or error). Lets the main window clear any global
+    # progress-bar / status-bar state it was showing for this run.
+    forced_alignment_finished = Signal()
 
     # State constants for stacked widget
     STATE_NO_CLIPS = 0
@@ -61,6 +70,13 @@ class AnalyzeTab(BaseTab):
         self._pending_browser_clip_ids: list[str] = []
         self._is_analyzing = False
         self._disabled_quick_ops: set[str] = set()
+        # Forced-alignment worker state. The guard flag (per
+        # docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md
+        # and the pyside6-duplicate-signal-guard skill) prevents the
+        # alignment-finished handler firing twice for a single run; it
+        # resets at click-start so subsequent runs work.
+        self._forced_alignment_worker = None
+        self._alignment_finished_handled = False
         if filter_state is None:
             from core.filter_state import FilterState
             filter_state = FilterState()
@@ -126,6 +142,21 @@ class AnalyzeTab(BaseTab):
         self.analyze_btn.setEnabled(False)
         self.analyze_btn.clicked.connect(self._on_analyze_click)
         controls.addWidget(self.analyze_btn)
+
+        # Run Word-Level Alignment button — sits in the same controls row as
+        # the Transcribe quick-run dropdown and the Analyze... picker, since
+        # alignment is a transcription post-step. Disabled until at least one
+        # selected clip has a transcript (which is the gating prerequisite
+        # for forced alignment).
+        self.alignment_btn = QPushButton("Run Word-Level Alignment")
+        self.alignment_btn.setMinimumHeight(UISizes.BUTTON_MIN_HEIGHT)
+        self.alignment_btn.setToolTip(
+            "Produce per-word timestamps for selected clips that have a "
+            "transcript. Required for the Word Sequencer."
+        )
+        self.alignment_btn.setEnabled(False)
+        self.alignment_btn.clicked.connect(self._on_alignment_click)
+        controls.addWidget(self.alignment_btn)
 
         # Filter sidebar toggle
         self.filter_toggle_btn = QPushButton("Filters")
@@ -282,6 +313,179 @@ class AnalyzeTab(BaseTab):
         dialog = GlossaryDialog(self)
         dialog.exec()
 
+    # ------------------------------------------------------------------ #
+    # Forced-alignment dispatch                                          #
+    # ------------------------------------------------------------------ #
+
+    def _select_clips_for_alignment(self) -> list:
+        """Return clips eligible for alignment from the current selection.
+
+        Falls back to all clips currently in the Analyze tab when nothing is
+        selected (matching the button-enablement rule in
+        ``_refresh_alignment_button_enablement``). Clips without a transcript
+        are filtered out — the worker filters again, but we surface a clean
+        set so the status messages are accurate.
+        """
+        selected = self.clip_browser.get_selected_clips()
+        candidates = selected if selected else self.get_clips()
+        return [c for c in candidates if getattr(c, "transcript", None)]
+
+    def _on_alignment_click(self):
+        """Dispatch the forced-alignment worker over the eligible clips."""
+        if self._forced_alignment_worker is not None:
+            # A previous run is still active — ignore double-clicks.
+            logger.info(
+                "Forced alignment ignored: a previous run is still in progress"
+            )
+            return
+
+        clips = self._select_clips_for_alignment()
+        if not clips:
+            logger.info(
+                "Forced alignment requested but no eligible clips were found"
+            )
+            return
+
+        # Reset the guard flag at click-start so re-runs work (per the
+        # qthread-destroyed-duplicate-signal-delivery learning).
+        self._alignment_finished_handled = False
+
+        from ui.workers.forced_alignment_worker import ForcedAlignmentWorker
+
+        worker = ForcedAlignmentWorker(
+            clips=clips,
+            sources_by_id=self._sources_by_id,
+        )
+        # Qt.UniqueConnection prevents duplicate slot registration on
+        # repeated runs (the worker object is fresh, but defensive in depth
+        # against future refactors that share workers).
+        worker.progress.connect(
+            self._on_alignment_progress, Qt.UniqueConnection
+        )
+        worker.clip_aligned.connect(
+            self._on_clip_aligned, Qt.UniqueConnection
+        )
+        worker.error.connect(
+            self._on_alignment_error, Qt.UniqueConnection
+        )
+        worker.alignment_completed.connect(
+            self._on_alignment_completed, Qt.UniqueConnection
+        )
+        worker.finished.connect(worker.deleteLater)
+        worker.finished.connect(self._on_alignment_thread_finished)
+
+        self._forced_alignment_worker = worker
+
+        # Surface "alignment running" in the same row the Transcribe quick
+        # run uses by repurposing the analyze button's text — there is no
+        # dedicated analyze-tab progress widget today, and the plan
+        # explicitly says "do not create a new one".
+        self.alignment_btn.setEnabled(False)
+        self.alignment_btn.setText("Aligning...")
+
+        logger.info(
+            "Starting ForcedAlignmentWorker for %d clip(s)", len(clips)
+        )
+        worker.start()
+
+    @Slot(int, int)
+    def _on_alignment_progress(self, current: int, total: int) -> None:
+        """Surface forced-alignment progress in the analyze button label."""
+        if total <= 0:
+            return
+        self.alignment_btn.setText(f"Aligning... ({current}/{total})")
+
+    @Slot(str, list)
+    def _on_clip_aligned(self, clip_id: str, words: list) -> None:
+        """Write per-word timestamps back onto the clip's transcript.
+
+        The worker emits a flat ``list[WordTimestamp]`` across all segments
+        of the clip (alignment runs over the concatenated text). We
+        distribute words back to segments using each word's midpoint: a word
+        whose midpoint falls within ``[seg.start_time, seg.end_time]`` is
+        assigned to that segment. Any words that fall outside every segment
+        (rare — typically a tiny boundary slop) attach to the nearest
+        segment by midpoint distance. Segments that end up with no words
+        are set to ``[]`` so the skip predicate treats the clip as aligned
+        on the next run (per U3's idempotency contract).
+        """
+        clip = self._clips_by_id.get(clip_id)
+        if clip is None or not getattr(clip, "transcript", None):
+            logger.warning(
+                "Forced alignment: clip %s no longer present; dropping payload",
+                clip_id,
+            )
+            return
+
+        segments = list(clip.transcript)
+        per_segment: list[list] = [[] for _ in segments]
+
+        for word in words:
+            midpoint = (float(word.start) + float(word.end)) / 2.0
+            chosen_idx: Optional[int] = None
+            for i, seg in enumerate(segments):
+                if seg.start_time <= midpoint <= seg.end_time:
+                    chosen_idx = i
+                    break
+            if chosen_idx is None:
+                # Fall back to nearest segment by midpoint distance.
+                chosen_idx = min(
+                    range(len(segments)),
+                    key=lambda i: min(
+                        abs(midpoint - segments[i].start_time),
+                        abs(midpoint - segments[i].end_time),
+                    ),
+                )
+            per_segment[chosen_idx].append(word)
+
+        for seg, seg_words in zip(segments, per_segment):
+            # Always assign — even an empty list means "alignment ran for
+            # this segment", which is what the skip predicate checks.
+            seg.words = seg_words
+
+        if self.clip_browser.is_clip_realized(clip_id):
+            self.clip_browser.update_clip_transcript(clip_id, segments)
+
+        self._refresh_alignment_button_enablement()
+        # Notify the main window so it can mark the project dirty without
+        # the analyze tab itself reaching into Project state.
+        self.clip_alignment_applied.emit(clip_id)
+
+    @Slot(str)
+    def _on_alignment_error(self, message: str) -> None:
+        """Log alignment errors. Surfaced to the user via the main window
+        when wired (the analyze tab keeps its own status quiet so the same
+        widget the Transcribe path uses is the canonical surface)."""
+        logger.warning("Forced alignment reported errors: %s", message)
+
+    @Slot()
+    def _on_alignment_completed(self) -> None:
+        """Handle ``alignment_completed`` — the worker's main-thread signal
+        that emits exactly once at the end of each run, success or otherwise.
+
+        Guarded by ``_alignment_finished_handled`` per the
+        qthread-destroyed-duplicate-signal-delivery learning. The
+        ``finished`` QThread signal (separate, fired by Qt itself when the
+        thread terminates) clears the worker reference in
+        ``_on_alignment_thread_finished``.
+        """
+        if self._alignment_finished_handled:
+            logger.debug(
+                "_on_alignment_completed already handled; ignoring duplicate"
+            )
+            return
+        self._alignment_finished_handled = True
+        # Restore the button label; enablement is recomputed by the
+        # thread-finished handler once the worker reference is cleared.
+        self.alignment_btn.setText("Run Word-Level Alignment")
+        self.forced_alignment_finished.emit()
+
+    @Slot()
+    def _on_alignment_thread_finished(self) -> None:
+        """Drop the worker reference once Qt has finished the thread."""
+        self._forced_alignment_worker = None
+        self._refresh_alignment_button_enablement()
+
     def _on_clip_selected(self, clip):
         """Handle clip selection."""
         self.clip_selected.emit(clip)
@@ -289,6 +493,7 @@ class AnalyzeTab(BaseTab):
     def _on_browser_selection_changed(self, _clip_ids: list[str]):
         """Handle selection changes from the clip browser."""
         self._update_selection_ui()
+        self._refresh_alignment_button_enablement()
 
     def _update_selection_ui(self):
         """Update selection count label and notify parent."""
@@ -299,6 +504,25 @@ class AnalyzeTab(BaseTab):
         else:
             self.selection_label.setText("")
         self.selection_changed.emit([c.id for c in selected])
+
+    def _refresh_alignment_button_enablement(self) -> None:
+        """Enable the alignment button only when at least one selected clip
+        has a transcript. Falls back to enabling when ANY tab clip has a
+        transcript (so the user has an affordance even before selecting),
+        but disables while a worker is already running."""
+        if self._is_analyzing or self._forced_alignment_worker is not None:
+            self.alignment_btn.setEnabled(False)
+            return
+
+        selected_clips = self.clip_browser.get_selected_clips()
+        # Per the plan: "Disabled when no selected clip has a transcript;
+        # enabled otherwise." When nothing is selected, fall back to "any
+        # clip in the tab" so the button is discoverable.
+        candidate_clips = selected_clips or self.get_clips()
+        has_transcript = any(
+            getattr(c, "transcript", None) for c in candidate_clips
+        )
+        self.alignment_btn.setEnabled(bool(has_transcript))
 
     def _on_clip_double_clicked(self, clip):
         """Handle clip double-click."""
@@ -329,6 +553,7 @@ class AnalyzeTab(BaseTab):
 
         self._refresh_quick_run_availability()
         self.analyze_btn.setEnabled(controls_enabled)
+        self._refresh_alignment_button_enablement()
 
         if has_clips:
             self.clip_count_label.setText(f"{count} clips")
@@ -567,6 +792,7 @@ class AnalyzeTab(BaseTab):
             if self.clip_browser.is_clip_realized(clip_id):
                 self.clip_browser.update_clip_transcript(clip_id, segments)
             self._refresh_quick_run_availability()
+            self._refresh_alignment_button_enablement()
 
     def update_clip_extracted_text(self, clip_id: str, texts: list):
         """Update extracted text for a clip."""

--- a/ui/tabs/analyze_tab.py
+++ b/ui/tabs/analyze_tab.py
@@ -418,30 +418,11 @@ class AnalyzeTab(BaseTab):
             return
 
         segments = list(clip.transcript)
-        per_segment: list[list] = [[] for _ in segments]
-
-        for word in words:
-            midpoint = (float(word.start) + float(word.end)) / 2.0
-            chosen_idx: Optional[int] = None
-            for i, seg in enumerate(segments):
-                if seg.start_time <= midpoint <= seg.end_time:
-                    chosen_idx = i
-                    break
-            if chosen_idx is None:
-                # Fall back to nearest segment by midpoint distance.
-                chosen_idx = min(
-                    range(len(segments)),
-                    key=lambda i: min(
-                        abs(midpoint - segments[i].start_time),
-                        abs(midpoint - segments[i].end_time),
-                    ),
-                )
-            per_segment[chosen_idx].append(word)
-
-        for seg, seg_words in zip(segments, per_segment):
-            # Always assign — even an empty list means "alignment ran for
-            # this segment", which is what the skip predicate checks.
-            seg.words = seg_words
+        # Distribute the flat word list back onto segments. See
+        # ``core.analysis.alignment.distribute_words_to_segments`` for the
+        # midpoint-containment + nearest-boundary fallback.
+        from core.analysis.alignment import distribute_words_to_segments
+        distribute_words_to_segments(segments, words)
 
         if self.clip_browser.is_clip_realized(clip_id):
             self.clip_browser.update_clip_transcript(clip_id, segments)

--- a/ui/tabs/sequence_tab.py
+++ b/ui/tabs/sequence_tab.py
@@ -1608,6 +1608,9 @@ class SequenceTab(BaseTab):
                 source = sources_by_clip_id.get(clip_id)
                 if clip is None or source is None:
                     continue
+                duration = seq_clip.out_point - seq_clip.in_point
+                if duration <= 0:
+                    continue
                 self.timeline.add_clip(
                     clip,
                     source,
@@ -1616,9 +1619,6 @@ class SequenceTab(BaseTab):
                     in_point=clip.start_frame + seq_clip.in_point,
                     out_point=clip.start_frame + seq_clip.out_point,
                 )
-                duration = seq_clip.out_point - seq_clip.in_point
-                if duration <= 0:
-                    continue
                 current_frame += duration
                 self.clip_added.emit(clip, source)
                 preview_clips.append((clip, source))

--- a/ui/tabs/sequence_tab.py
+++ b/ui/tabs/sequence_tab.py
@@ -662,6 +662,14 @@ class SequenceTab(BaseTab):
             self._apply_chromatic_bar_to_sequence("staccato")
             self._show_staccato_dialog(clips)
             return
+        if algorithm == "word_sequencer":
+            self._apply_chromatic_bar_to_sequence("word_sequencer")
+            self._show_word_sequencer_dialog(clips)
+            return
+        if algorithm == "word_llm_composer":
+            self._apply_chromatic_bar_to_sequence("word_llm_composer")
+            self._show_word_llm_composer_dialog(clips)
+            return
 
         self._apply_algorithm(algorithm, clips, no_color_handling=no_color_handling)
 
@@ -804,6 +812,12 @@ class SequenceTab(BaseTab):
                 return
             if algorithm == "cassette_tape":
                 self._show_cassette_tape_dialog(clips)
+                return
+            if algorithm == "word_sequencer":
+                self._show_word_sequencer_dialog(clips)
+                return
+            if algorithm == "word_llm_composer":
+                self._show_word_llm_composer_dialog(clips)
                 return
 
         # Compute cost estimates for this algorithm
@@ -1508,6 +1522,134 @@ class SequenceTab(BaseTab):
             logger.error(f"Failed to apply Staccato sequence: {e}")
             QMessageBox.critical(self, "Error", f"Failed to apply sequence:\n{e}")
 
+        finally:
+            self._algorithm_running = False
+
+    def _show_word_sequencer_dialog(self, clips: list):
+        """Show the Word Sequencer dialog for preset-mode word sequencing.
+
+        Args:
+            clips: List of (Clip, Source) tuples to process.
+        """
+        from ui.dialogs.word_sequencer_dialog import WordSequencerDialog
+
+        dialog = WordSequencerDialog(clips=clips, project=self.project, parent=self)
+        dialog.sequence_ready.connect(
+            lambda seq_clips: self._apply_word_sequence(
+                seq_clips, clips, "word_sequencer", "Word Sequencer"
+            )
+        )
+        dialog.exec()
+
+    def _show_word_llm_composer_dialog(self, clips: list):
+        """Show the LLM Word Composer dialog for prompt-driven word sequencing.
+
+        Args:
+            clips: List of (Clip, Source) tuples to process.
+        """
+        from ui.dialogs.word_llm_composer_dialog import WordLLMComposerDialog
+
+        dialog = WordLLMComposerDialog(clips=clips, project=self.project, parent=self)
+        dialog.sequence_ready.connect(
+            lambda seq_clips: self._apply_word_sequence(
+                seq_clips, clips, "word_llm_composer", "LLM Word Composer"
+            )
+        )
+        dialog.exec()
+
+    def _apply_word_sequence(
+        self,
+        sequence_clips: list,
+        clips: list,
+        algorithm_key: str,
+        display_label: str,
+    ):
+        """Apply a sequence emitted by a word-based dialog.
+
+        Both word dialogs emit ``list[SequenceClip]`` (in-points / out-points
+        already set by ``instances_to_sequence_clips``) — this helper places
+        each entry on track 0 at sequential ``start_frame`` positions and
+        wraps everything in a fresh ``Sequence`` on the project.
+        """
+        if not sequence_clips:
+            logger.warning("No clips in %s sequence", display_label)
+            return
+
+        try:
+            sources_by_clip_id = {
+                getattr(clip, "id", ""): source for clip, source in clips
+            }
+
+            self._create_and_activate_sequence(algorithm_key)
+            self.timeline.clear_timeline()
+
+            # Pick the fps from the first source so the timeline has a
+            # canonical frame rate. Word sequences may mix sources but the
+            # SequenceClip frame coords are clip-relative; the timeline
+            # frame rate is decorative for word films.
+            first_clip = sequence_clips[0]
+            first_source = sources_by_clip_id.get(first_clip.source_clip_id)
+            if first_source is None:
+                # Fall back to the first clip's source from the dialog input.
+                first_source = clips[0][1] if clips else None
+            if first_source is not None:
+                fps = float(getattr(first_source, "fps", 30.0) or 30.0)
+                self.timeline.set_fps(fps)
+                self.video_player.load_video(first_source.file_path)
+
+            current_frame = 0
+            preview_clips: list[tuple] = []
+            clip_lookup = {
+                getattr(clip, "id", ""): clip for clip, _ in clips
+            }
+            for seq_clip in sequence_clips:
+                clip_id = seq_clip.source_clip_id
+                clip = clip_lookup.get(clip_id)
+                source = sources_by_clip_id.get(clip_id)
+                if clip is None or source is None:
+                    continue
+                self.timeline.add_clip(
+                    clip,
+                    source,
+                    track_index=0,
+                    start_frame=current_frame,
+                    in_point=clip.start_frame + seq_clip.in_point,
+                    out_point=clip.start_frame + seq_clip.out_point,
+                )
+                duration = seq_clip.out_point - seq_clip.in_point
+                if duration <= 0:
+                    continue
+                current_frame += duration
+                self.clip_added.emit(clip, source)
+                preview_clips.append((clip, source))
+
+            self.timeline_preview.set_clips(preview_clips, self._sources)
+            self.timeline._on_zoom_fit()
+
+            self.algorithm_dropdown.blockSignals(True)
+            if self.algorithm_dropdown.findText(display_label) == -1:
+                self.algorithm_dropdown.addItem(display_label)
+            self.algorithm_dropdown.setCurrentText(display_label)
+            self.algorithm_dropdown.blockSignals(False)
+
+            self._current_algorithm = algorithm_key
+
+            sequence = self.timeline.get_sequence()
+            sequence.algorithm = algorithm_key
+            self._apply_chromatic_bar_to_sequence(algorithm_key)
+            self._update_chromatic_bar_controls(algorithm_key)
+            self._emit_chromatic_bar_setting_changed()
+
+            self._set_state(self.STATE_TIMELINE)
+
+            logger.info(
+                "Applied %d clips from %s", len(preview_clips), display_label,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to apply %s sequence: %s", display_label, exc)
+            QMessageBox.critical(
+                self, "Error", f"Failed to apply sequence:\n{exc}",
+            )
         finally:
             self._algorithm_running = False
 

--- a/ui/widgets/sorting_card_grid.py
+++ b/ui/widgets/sorting_card_grid.py
@@ -1,6 +1,6 @@
 """Grid of sorting algorithm cards for the Sequence tab.
 
-Displays 19 sorting algorithms as clickable cards, filterable by category
+Displays sorting algorithms as clickable cards, filterable by category
 via a pill bar.
 """
 
@@ -75,6 +75,7 @@ class SortingCardGrid(QWidget):
             "free_association", "cassette_tape", "reference_guided", "signature_style",
             "rose_hobart", "staccato",
             "gaze_sort", "gaze_consistency", "eyes_without_a_face",
+            "word_sequencer", "word_llm_composer",
         ]
 
         # Create all cards (but don't add to layout yet)

--- a/ui/workers/__init__.py
+++ b/ui/workers/__init__.py
@@ -6,6 +6,7 @@ from .classification_worker import ClassificationWorker
 from .color_worker import ColorAnalysisWorker
 from .description_worker import DescriptionWorker
 from .embedding_worker import EmbeddingAnalysisWorker
+from .forced_alignment_worker import ForcedAlignmentWorker
 from .frame_extraction_worker import FrameExtractionWorker
 from .gaze_worker import GazeAnalysisWorker
 from .object_detection_worker import ObjectDetectionWorker
@@ -22,6 +23,7 @@ __all__ = [
     "ColorAnalysisWorker",
     "DescriptionWorker",
     "EmbeddingAnalysisWorker",
+    "ForcedAlignmentWorker",
     "FrameExtractionWorker",
     "GazeAnalysisWorker",
     "ObjectDetectionWorker",

--- a/ui/workers/forced_alignment_worker.py
+++ b/ui/workers/forced_alignment_worker.py
@@ -27,8 +27,6 @@ The temp file is cleaned up after alignment runs (success or failure).
 from __future__ import annotations
 
 import logging
-import subprocess
-import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -40,89 +38,6 @@ if TYPE_CHECKING:
     from models.clip import Clip, Source
 
 logger = logging.getLogger(__name__)
-
-
-def _extract_clip_audio_wav(
-    source_path: Path,
-    start_time: float,
-    end_time: float,
-) -> Path:
-    """Extract a clip's audio range to a temporary 16 kHz mono PCM WAV.
-
-    Mirrors the pattern in ``core.transcription.transcribe_clip``. The temp
-    file is created here; the caller is responsible for cleanup via the
-    ``try/finally`` around the alignment call.
-
-    Raises:
-        RuntimeError: FFmpeg is missing, fails to extract, or produces an
-            empty output (e.g. source has no audio track).
-    """
-    from core.binary_resolver import (
-        find_binary,
-        get_subprocess_env,
-        get_subprocess_kwargs,
-    )
-
-    ffmpeg = find_binary("ffmpeg")
-    if ffmpeg is None:
-        raise RuntimeError(
-            "FFmpeg is required for word-level alignment but was not found. "
-            "Install FFmpeg from Settings > Dependencies and try again."
-        )
-
-    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
-        tmp_path = Path(tmp.name)
-
-    cmd = [
-        ffmpeg, "-y",
-        "-ss", str(float(start_time)),
-        "-to", str(float(end_time)),
-        "-i", str(source_path),
-        "-vn",
-        "-acodec", "pcm_s16le",
-        "-ar", "16000",
-        "-ac", "1",
-        str(tmp_path),
-    ]
-
-    try:
-        subprocess.run(
-            cmd,
-            capture_output=True,
-            check=True,
-            env=get_subprocess_env(),
-            **get_subprocess_kwargs(),
-        )
-    except subprocess.CalledProcessError as exc:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        stderr = (
-            exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""
-        )
-        raise RuntimeError(
-            f"FFmpeg failed to extract clip audio from {source_path}: "
-            f"{stderr.strip() or exc}"
-        ) from exc
-    except FileNotFoundError as exc:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        raise RuntimeError(f"FFmpeg binary not found: {exc}") from exc
-
-    if tmp_path.stat().st_size == 0:
-        try:
-            tmp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        raise RuntimeError(
-            f"FFmpeg produced an empty audio file for {source_path} "
-            "(source may have no audio stream)."
-        )
-
-    return tmp_path
 
 
 def _clip_needs_alignment(clip) -> bool:
@@ -307,10 +222,10 @@ class ForcedAlignmentWorker(CancellableWorker):
             source = self._sources_by_id[clip.source_id]
             wav_path: Optional[Path] = None
             try:
-                wav_path = _extract_clip_audio_wav(
+                wav_path = alignment_mod.extract_audio_to_wav(
                     Path(source.file_path),
-                    clip.start_time(source.fps),
-                    clip.end_time(source.fps),
+                    start_time=clip.start_time(source.fps),
+                    end_time=clip.end_time(source.fps),
                 )
 
                 if self.is_cancelled():

--- a/ui/workers/forced_alignment_worker.py
+++ b/ui/workers/forced_alignment_worker.py
@@ -1,0 +1,348 @@
+"""Background worker for word-level forced alignment.
+
+Given a list of clips that already have transcripts (from U1's transcription
+pass), this worker runs ``ctc-forced-aligner`` per clip to produce per-word
+timestamps. Output is emitted to the main thread via ``clip_aligned``; the
+*handler* on the main thread is responsible for writing the words back into
+the project (per Scene Ripper's worker discipline — workers never mutate the
+``Project`` or ``Clip`` model directly).
+
+Why serial-per-clip? ``ctc-forced-aligner`` is CPU-bound on Apple Silicon
+(MPS wav2vec2 is unreliable in 2026; the alignment runtime forces CPU + fp32
+— see ``core/analysis/alignment.py``) and not thread-safe. Mirroring the
+``TranscriptionWorker`` MLX backend constraint, this worker runs one clip at a
+time.
+
+Lazy imports: the heavy alignment dependencies (``torch``,
+``ctc_forced_aligner``) are imported only inside ``core.analysis.alignment``,
+and that module itself defers them to function bodies. This module is
+importable on a clean Python environment without those deps installed, which
+keeps the test path light.
+
+Audio strategy: each clip's audio range is extracted to a temporary WAV via
+FFmpeg (mirroring ``core.transcription.transcribe_clip`` at lines 663–685).
+The temp file is cleaned up after alignment runs (success or failure).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from PySide6.QtCore import Signal, Slot
+
+from ui.workers.base import CancellableWorker, summarize_clip_errors
+
+if TYPE_CHECKING:
+    from models.clip import Clip, Source
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_clip_audio_wav(
+    source_path: Path,
+    start_time: float,
+    end_time: float,
+) -> Path:
+    """Extract a clip's audio range to a temporary 16 kHz mono PCM WAV.
+
+    Mirrors the pattern in ``core.transcription.transcribe_clip``. The temp
+    file is created here; the caller is responsible for cleanup via the
+    ``try/finally`` around the alignment call.
+
+    Raises:
+        RuntimeError: FFmpeg is missing, fails to extract, or produces an
+            empty output (e.g. source has no audio track).
+    """
+    from core.binary_resolver import (
+        find_binary,
+        get_subprocess_env,
+        get_subprocess_kwargs,
+    )
+
+    ffmpeg = find_binary("ffmpeg")
+    if ffmpeg is None:
+        raise RuntimeError(
+            "FFmpeg is required for word-level alignment but was not found. "
+            "Install FFmpeg from Settings > Dependencies and try again."
+        )
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    cmd = [
+        ffmpeg, "-y",
+        "-ss", str(float(start_time)),
+        "-to", str(float(end_time)),
+        "-i", str(source_path),
+        "-vn",
+        "-acodec", "pcm_s16le",
+        "-ar", "16000",
+        "-ac", "1",
+        str(tmp_path),
+    ]
+
+    try:
+        subprocess.run(
+            cmd,
+            capture_output=True,
+            check=True,
+            env=get_subprocess_env(),
+            **get_subprocess_kwargs(),
+        )
+    except subprocess.CalledProcessError as exc:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        stderr = (
+            exc.stderr.decode("utf-8", errors="replace") if exc.stderr else ""
+        )
+        raise RuntimeError(
+            f"FFmpeg failed to extract clip audio from {source_path}: "
+            f"{stderr.strip() or exc}"
+        ) from exc
+    except FileNotFoundError as exc:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise RuntimeError(f"FFmpeg binary not found: {exc}") from exc
+
+    if tmp_path.stat().st_size == 0:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise RuntimeError(
+            f"FFmpeg produced an empty audio file for {source_path} "
+            "(source may have no audio stream)."
+        )
+
+    return tmp_path
+
+
+def _clip_needs_alignment(clip) -> bool:
+    """True when any of the clip's transcript segments lacks word data.
+
+    Per the plan's per-clip skip predicate: re-align the whole clip when any
+    ``TranscriptSegment.words is None``. ``words == []`` (alignment ran and
+    produced no words) is treated as "already aligned" — we deliberately
+    don't conflate ``None`` with ``[]``.
+    """
+    transcript = getattr(clip, "transcript", None)
+    if not transcript:
+        # No transcript at all → cannot align; the worker skips this clip.
+        return False
+    for seg in transcript:
+        if seg.words is None:
+            return True
+    return False
+
+
+class ForcedAlignmentWorker(CancellableWorker):
+    """Background worker for word-level forced alignment.
+
+    Runs ``ctc-forced-aligner`` over a list of clips that already have
+    transcripts. Each clip's audio is extracted to a temp WAV, alignment runs,
+    and the resulting ``list[WordTimestamp]`` is emitted to the main thread.
+
+    The worker does NOT mutate the ``Project`` or ``Clip`` model — the main
+    thread's ``clip_aligned`` handler is responsible for writing the words
+    back through the project (matching the ``TranscriptionWorker`` /
+    ``transcript_ready`` pattern in ``ui/main_window.py``).
+
+    Signals:
+        progress: ``(current, total)`` after each clip is processed (and once
+            before the loop with ``(0, total)`` so progress UIs can render
+            their initial state, mirroring ``TranscriptionWorker``).
+        clip_aligned: ``(clip_id, words)`` where ``words`` is a flat
+            ``list[WordTimestamp]`` produced by ``align_words``. Segment
+            boundaries are not preserved in the payload — the receiver
+            distributes them across segments on the main thread.
+        alignment_completed: Emitted exactly once when the worker finishes
+            (success, cancellation, or fatal error — the pipeline can always
+            advance on this signal).
+        error: Inherited from ``CancellableWorker``. Emitted at most once at
+            the end of the run with a summarized per-clip error message when
+            one or more clips failed.
+
+    Notes:
+        - Serial per-clip; ``ctc-forced-aligner`` is not thread-safe.
+        - Pre-loads the alignment model with progress reporting BEFORE the
+          per-clip loop (pattern from ``TranscriptionWorker.run`` lines
+          162-174). On Apple Silicon this front-loads any required model
+          download/import cost.
+        - Calls ``core.feature_registry.check_feature_ready('word_alignment')``
+          and ``install_for_feature`` from inside ``run()``, never from the
+          dialog/tab — this matches the staccato pattern.
+    """
+
+    progress = Signal(int, int)  # current, total
+    clip_aligned = Signal(str, list)  # clip_id, list[WordTimestamp]
+    alignment_completed = Signal()
+
+    def __init__(
+        self,
+        clips: list["Clip"],
+        sources_by_id: dict[str, "Source"],
+        skip_existing: bool = True,
+        parent=None,
+    ) -> None:
+        """
+        Args:
+            clips: Clips to align. Clips without transcripts, or whose every
+                segment already has populated ``words`` (per the skip
+                predicate), are filtered out before processing.
+            sources_by_id: Lookup of ``Source.id`` → ``Source`` so the worker
+                can resolve each clip's source media path and frame rate.
+                Required; clips whose source is missing are skipped with a
+                warning.
+            skip_existing: When True (default), clips whose every transcript
+                segment already has ``.words`` populated are skipped. When
+                False, every clip with a transcript is re-aligned (the data
+                is idempotent — alignment produces the same boundaries on
+                repeated runs).
+            parent: Qt parent.
+        """
+        super().__init__(parent)
+        self._clips = list(clips or [])
+        self._sources_by_id = sources_by_id or {}
+        self._skip_existing = skip_existing
+
+    @Slot()
+    def run(self) -> None:
+        """Execute alignment over the (filtered) clip set."""
+        self._log_start()
+
+        # Filter the input set: drop clips that have nothing to align, are
+        # missing a source, or already have full word data (when
+        # skip_existing).
+        clips_to_process: list["Clip"] = []
+        for clip in self._clips:
+            if not getattr(clip, "transcript", None):
+                continue
+            if self._skip_existing and not _clip_needs_alignment(clip):
+                continue
+            source = self._sources_by_id.get(clip.source_id)
+            if source is None:
+                logger.warning(
+                    "ForcedAlignmentWorker: clip %s has no source in sources_by_id; skipping",
+                    clip.id,
+                )
+                continue
+            clips_to_process.append(clip)
+
+        total = len(clips_to_process)
+        if total == 0:
+            logger.info(
+                "ForcedAlignmentWorker: no clips require alignment (input %d, after filtering 0)",
+                len(self._clips),
+            )
+            self.alignment_completed.emit()
+            self._log_complete()
+            return
+
+        # Feature-registry preflight INSIDE the worker (per staccato pattern).
+        try:
+            from core import feature_registry
+
+            ready, missing = feature_registry.check_feature_ready("word_alignment")
+            if not ready:
+                logger.info(
+                    "ForcedAlignmentWorker: word_alignment not ready (missing %s); "
+                    "calling install_for_feature",
+                    missing,
+                )
+                installed = feature_registry.install_for_feature("word_alignment")
+                if not installed:
+                    self.error.emit(
+                        "Could not install word-level alignment dependencies. "
+                        "Check Settings > Dependencies and try again."
+                    )
+                    self.alignment_completed.emit()
+                    self._log_complete()
+                    return
+        except Exception as exc:  # noqa: BLE001 — feature_registry errors are user-facing
+            logger.exception("ForcedAlignmentWorker: feature_registry preflight raised")
+            self.error.emit(f"Word alignment dependencies unavailable: {exc}")
+            self.alignment_completed.emit()
+            self._log_complete()
+            return
+
+        # Pre-loop progress emission so progress UIs can show 0/total before
+        # any per-clip work happens (mirrors TranscriptionWorker). The
+        # alignment runtime itself was validated by
+        # ``check_feature_ready('word_alignment')`` above — it internally
+        # calls ``ensure_word_alignment_runtime_available()``. The model
+        # checkpoints lazy-load on the first ``align_words`` call.
+        self.progress.emit(0, total)
+
+        if self.is_cancelled():
+            self._log_cancelled()
+            self.alignment_completed.emit()
+            self._log_complete()
+            return
+
+        # Import the alignment entry point once. Module load is cheap; the
+        # heavy imports live inside ``align_words`` itself.
+        from core.analysis import alignment as alignment_mod
+
+        errors: list[tuple[str, str]] = []
+        completed = 0
+        for clip in clips_to_process:
+            # Cancellation gate at the TOP of each iteration — the moment
+            # cancel() fires (from any thread, including the main thread via
+            # a Cancel button), we stop emitting further clip_aligned signals
+            # and exit cleanly. Already-aligned clips persist (partial
+            # progress is real progress; the handler has already written
+            # them back to the project).
+            if self.is_cancelled():
+                self._log_cancelled()
+                break
+
+            source = self._sources_by_id[clip.source_id]
+            wav_path: Optional[Path] = None
+            try:
+                wav_path = _extract_clip_audio_wav(
+                    Path(source.file_path),
+                    clip.start_time(source.fps),
+                    clip.end_time(source.fps),
+                )
+
+                if self.is_cancelled():
+                    self._log_cancelled()
+                    break
+
+                words = alignment_mod.align_words(str(wav_path), clip.transcript)
+                self.clip_aligned.emit(clip.id, list(words))
+            except Exception as exc:  # noqa: BLE001 — surface per-clip errors
+                self._log_error(str(exc), clip.id)
+                errors.append((clip.id, str(exc)))
+            finally:
+                if wav_path is not None:
+                    try:
+                        wav_path.unlink(missing_ok=True)
+                    except OSError as cleanup_exc:
+                        logger.warning(
+                            "Failed to remove temp alignment WAV %s: %s",
+                            wav_path,
+                            cleanup_exc,
+                        )
+
+            completed += 1
+            self.progress.emit(completed, total)
+
+        if errors:
+            self.error.emit(
+                summarize_clip_errors(errors, operation_label="Word alignment")
+            )
+
+        self.alignment_completed.emit()
+        self._log_complete()
+
+
+__all__ = ["ForcedAlignmentWorker"]

--- a/ui/workers/llm_composer_worker.py
+++ b/ui/workers/llm_composer_worker.py
@@ -1,0 +1,126 @@
+"""Background worker for the LLM Word Composer.
+
+Runs ``core.remix.word_llm_composer.generate_llm_word_sequence`` off the GUI
+thread. The composer makes a single HTTP call to a local Ollama server (via
+the ``compose_with_llm`` helper) which can take many seconds at corpus scale,
+so a worker is required to keep the dialog responsive.
+
+Cancellation contract: ``httpx``'s blocking client does not expose a cancel
+token to non-cooperative callers. We approximate cancellation by checking
+``self.is_cancelled()`` immediately before and after the spine call and
+silently dropping the emitted ``SequenceClip`` payload if the user has asked
+to stop. The in-flight HTTP request itself runs to completion (or to its
+configured timeout); we trade a small amount of wasted compute for a simple,
+reliable cancellation semantic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from PySide6.QtCore import Signal, Slot
+
+from ui.workers.base import CancellableWorker
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["LLMComposerWorker"]
+
+
+class LLMComposerWorker(CancellableWorker):
+    """Background worker for LLM-composed word sequencing.
+
+    Signals:
+        progress: ``(current, total)``. Emits ``(0, 1)`` before the call and
+            ``(1, 1)`` immediately after a successful call. Cancellation
+            paths skip the final tick.
+        sequence_ready: Emits ``list[SequenceClip]`` produced by
+            ``generate_llm_word_sequence``. Suppressed when cancelled.
+        error: Inherited from ``CancellableWorker``. Emits a single
+            human-readable message for any of: ``MissingWordDataError``,
+            ``OllamaUnreachableError``, ``LLMEmptyResponseError``, plain
+            ``ValueError`` (empty corpus / OOV / bad fps), or any other
+            unexpected failure.
+    """
+
+    progress = Signal(int, int)
+    sequence_ready = Signal(list)
+
+    def __init__(
+        self,
+        clips: list[tuple[Any, Any]],
+        prompt: str,
+        target_length: int,
+        repeat_policy: str = "round-robin",
+        seed: Optional[int] = None,
+        handle_frames: int = 0,
+        *,
+        model: Optional[str] = None,
+        api_base: Optional[str] = None,
+        temperature: float = 0.7,
+        timeout: float = 120.0,
+        system_prompt: Optional[str] = None,
+        think: bool = False,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self._clips = list(clips or [])
+        self._prompt = prompt
+        self._target_length = int(target_length)
+        self._repeat_policy = repeat_policy
+        self._seed = seed
+        self._handle_frames = int(handle_frames)
+        self._model = model
+        self._api_base = api_base
+        self._temperature = float(temperature)
+        self._timeout = float(timeout)
+        self._system_prompt = system_prompt
+        self._think = think
+
+    @Slot()
+    def run(self) -> None:
+        self._log_start()
+        try:
+            if self.is_cancelled():
+                self._log_cancelled()
+                return
+
+            # Coarse progress: a single tick before and after the call. The
+            # underlying composer doesn't expose intermediate progress.
+            self.progress.emit(0, 1)
+
+            from core.remix.word_llm_composer import generate_llm_word_sequence
+
+            sequence_clips = generate_llm_word_sequence(
+                self._clips,
+                prompt=self._prompt,
+                target_length=self._target_length,
+                repeat_policy=self._repeat_policy,
+                seed=self._seed,
+                handle_frames=self._handle_frames,
+                model=self._model,
+                api_base=self._api_base,
+                temperature=self._temperature,
+                timeout=self._timeout,
+                system_prompt=self._system_prompt,
+                think=self._think,
+            )
+
+            if self.is_cancelled():
+                self._log_cancelled()
+                return
+
+            self.progress.emit(1, 1)
+            # PySide6 marshals ``list`` over queued connections by value;
+            # the receiver gets its own copy.
+            self.sequence_ready.emit(list(sequence_clips))
+        except Exception as exc:  # noqa: BLE001
+            if self.is_cancelled():
+                self._log_cancelled()
+                return
+            logger.exception("LLMComposerWorker run failed")
+            self.error.emit(str(exc))
+        finally:
+            self._log_complete()


### PR DESCRIPTION
## Summary

Adds the **Word Sequencer** feature: word-level film editing built on `faster-whisper`'s already-computed (but previously discarded) word timestamps, plus `ctc-forced-aligner` as the opt-in accuracy upgrade and the required path for MLX-transcribed sources.

Two new sequencer algorithms appear in the Sequence tab:

- **Word Sequencer** — 5 preset modes: alphabetical, chosen-words filter, by-frequency, by-property (length / duration / log-frequency), and user-curated ordered list
- **LLM Word Composer** — type a prompt, a local Ollama model composes a sentence using only your corpus vocabulary (JSON-schema-enum constraint)

Both materialize into `SequenceClip[]` with word-aligned in/out frames, run through the existing render pipeline unchanged.

Plan: `docs/plans/2026-05-11-001-feat-word-sequencer-plan.md` (now `status: completed`).

## What changed

- **`core/transcription.py`** — `WordTimestamp` dataclass + `TranscriptSegment.words` / `.language` (round-trip back-compat). `faster-whisper`'s per-word data and detected language are now captured at both call sites; MLX's `result["language"]` is captured too (previously discarded). _(U1)_
- **`core/analysis/alignment.py`** — new module: `align_words(audio_path, transcript_segments) -> list[WordTimestamp]` via `ctc-forced-aligner`. CPU-only on Apple Silicon, fp32. Per-clip WAV extraction mirrors the existing `transcribe_clip` pattern. Raises `LanguageUnknownError` / `UnsupportedLanguageError`. Registered through `core/feature_registry.py` as `word_alignment`. _(U2)_
- **`ui/workers/forced_alignment_worker.py`** — new `CancellableWorker`: per-clip serial alignment, guard-flag + `Qt.UniqueConnection`, partial-progress persistence, idempotent re-run. Wired into the Analyze tab as "Run Word-Level Alignment". _(U3)_
- **`core/spine/words.py`** — `WordInstance`, `WordInventory`, `build_inventory(clips)`, plus the 5 ordering modes and `compose_with_llm()`. `core/remix/word_sequencer.py` materializes mode output into `SequenceClip[]` with floor/ceil frame conversion + handle padding. `core/remix/word_llm_composer.py` is the LLM equivalent. Both algorithms registered authoritatively in `ui/algorithm_config.py`; `core/cost_estimates.py` gains a `transcription_with_words` METADATA_CHECK. _(U4, U5)_
- **`core/llm_client.py`** — `complete_with_enum_constraint` calls Ollama's `/api/generate` directly (LiteLLM does forward `format`, but the new helper bypasses it for the most correctness-sensitive call so the constraint cannot be silently stripped). Plus `LLMEmptyResponseError`, `OllamaUnreachableError`, and `check_ollama_health_sync`. _(U5)_
- **`ui/dialogs/word_sequencer_dialog.py` + `ui/dialogs/word_llm_composer_dialog.py`** — two new `QDialog` subclasses with source-picker badges (✓ aligned / … needs alignment / ⚠ unsupported language / ⚠ missing fps), auto-run alignment on accept, inline error label, Ollama-absent state. Wired into `ui/tabs/sequence_tab.py` algorithm dispatch. Shared scaffolding in `ui/dialogs/_word_source_picker.py` (`WordAlignmentController`, badge constants, `classify_source_alignment`). _(U6)_

## Test plan

- [x] `pytest tests/ -q` (excluding the 3 pre-existing `test_sorting_card_grid.py::TestCategoryFiltering` failures that exist on `main`): **2469 passed, 2 skipped**
- [x] Spine boundary enforced: `tests/test_spine_imports.py` registers `core.spine.words`; passes
- [x] U5 real-Ollama integration test (gated by `SCENE_RIPPER_OLLAMA_INTEGRATION=1`) runs against `qwen3:8b`; recorded latency 101–169s for vocab=1000 + target=20 (over the plan's 30s threshold — Tier 2 GBNF deferred per plan, tracked as #102)
- [x] End-to-end smoke: 30s synthetic clip → 50 aligned words → alphabetical sequencer → 50 SequenceClips → renderable timeline (`tests/test_word_sequencer_e2e.py`; render-to-mp4 leg gated by `SCENE_RIPPER_E2E_RENDER=1`)
- [ ] Manual GUI test: open Sequence tab → "Word Sequencer" → select an aligned source → alphabetical mode → render
- [ ] Manual GUI test: open Sequence tab → "LLM Word Composer" → enter a prompt → cancel mid-generation → confirm timeline is NOT overwritten (cancel-race fix at `64ec13a`)
- [ ] Manual GUI test: open Analyze tab → "Run Word-Level Alignment" on an MLX-transcribed source → save project → reopen → confirm alignment data persists (mark_dirty fix at `134f815`)

## Code review

Tier 2 multi-persona review run: `/tmp/compound-engineering/ce-code-review/20260511-161347-6c78487c/`.

**Applied fixes (8 across 3 commits):**

- `77e7603` — safe_auto: `cost_estimates` predicate `is not None`; NaN fps guarded; `out_seconds` lower-bounded; `check_ollama_health_sync` only swallows the loop-running RuntimeError; zero-duration guard before `timeline.add_clip`
- `134f815` — **P1**: alignment mutations now flow through `project.mark_dirty()` so word data survives save (previously the signal was emitted but no slot was connected)
- `64ec13a` — **P1**: LLM-composer cancel race closed; `_compose_finished_handled = True` set before `worker.cancel()`

## Known Residuals (filed as follow-up issues)

Tier 2 review surfaced additional P2/P3 items deferred to follow-up:

- #98 — **P1 architectural**: generic `generate_sequence(...)` ladder silently degrades dialog-only algorithms (affects all 11, not just word ones)
- #99 — **P2**: alignment reliability (double FFmpeg extraction, temp-WAV leak on `KeyboardInterrupt`, LLM-composer 120s timeout outlives 2s closeEvent wait)
- #100 — **P2**: source-picker UX (clip with `transcript=None` classified as ALIGNED; `normalize_word` doesn't strip non-ASCII control chars)
- #101 — **P3**: cleanup (dead backward-compat aliases, `_validate_word_data`/`validate_word_data` double-spelling, false `noqa: F401`, `_check_language_supported` cross-layer private reach)
- #102 — **P2**: MCP/agent-tool parity pre-conditions (`list_clips.has_word_alignment`, Tier 2 GBNF follow-up)
- #103 — **P3**: test coverage gaps (closeEvent mid-alignment, `_try_generate` error paths, install-failed worker, `words=[]` cost-gate, NaN fps error path, `extract_audio_to_wav` range kwargs, `by_property` tiebreak)

## Post-Deploy Monitoring & Validation

This is a desktop-app feature, not a server deployment, so the monitoring shape is "first-user-run":

- **Healthy signals**: New algorithms appear in the Sequence tab picker under "Word" / "Experimental" / "LLM" categories. Alignment runs on MLX-transcribed sources without manual language argument. Save/reload preserves word data.
- **Failure signals**: User reports "I clicked Run Word-Level Alignment but my project didn't save the words" (would indicate `134f815` regression); reports "the LLM Composer cancelled but my timeline got overwritten" (would indicate `64ec13a` regression); reports "Word Sequencer says 0 words on a source I never transcribed" (covered by issue #100).
- **Rollback trigger**: any user-visible regression on existing sequencer algorithms (Staccato, Free Association, etc.) — these were not touched but share `sequence_tab.py` dispatch wiring.
- **Validation window**: first 7 days of use after merging.
- **Owner**: @dvschultz

🤖 Generated with [Claude Code](https://claude.com/claude-code)