### PR TITLE
feat: ChatGPT subscription auth foundation (U1-U10 scaffolding)

### DIFF
--- a/core/analysis/cinematography.py
+++ b/core/analysis/cinematography.py
@@ -556,9 +556,9 @@ def analyze_cinematography_frame(
     ]
 
     try:
-        import litellm
+        from core.llm_client import complete_routed
 
-        response = litellm.completion(
+        response = complete_routed(
             model=llm_model,
             messages=messages,
             api_key=api_key,
@@ -689,9 +689,9 @@ def analyze_cinematography_video(
             }
         ]
 
-        import litellm
+        from core.llm_client import complete_routed
 
-        response = litellm.completion(
+        response = complete_routed(
             model=llm_model,
             messages=messages,
             api_key=api_key,

--- a/core/analysis/custom_query.py
+++ b/core/analysis/custom_query.py
@@ -155,9 +155,9 @@ def evaluate_custom_query_cloud(
     ]
 
     try:
-        import litellm
+        from core.llm_client import complete_routed
 
-        response = litellm.completion(
+        response = complete_routed(
             model=model,
             messages=messages,
             api_key=api_key,

--- a/core/analysis/description.py
+++ b/core/analysis/description.py
@@ -319,10 +319,10 @@ def describe_video_cloud(
     ]
 
     try:
-        import litellm
+        from core.llm_client import complete_routed
 
         logger.info(f"Calling LiteLLM with video, model={model}")
-        response = litellm.completion(
+        response = complete_routed(
             model=model,
             messages=messages,
             api_key=api_key,
@@ -677,10 +677,10 @@ def describe_frame_cloud(image_path: Path, prompt: str = "Describe this image.")
     ]
 
     try:
-        import litellm
+        from core.llm_client import complete_routed
 
         logger.info(f"Calling LiteLLM with model={model}")
-        response = litellm.completion(
+        response = complete_routed(
             model=model,
             messages=messages,
             api_key=api_key,

--- a/core/analysis/ocr.py
+++ b/core/analysis/ocr.py
@@ -211,7 +211,7 @@ def _vlm_text_extraction(
     Returns:
         Tuple of (text, confidence) where confidence is estimated.
     """
-    import litellm
+    from core.llm_client import complete_routed
     from core.analysis.description import encode_image_base64
     from core.settings import load_settings, get_gemini_api_key, get_openai_api_key, get_anthropic_api_key
 
@@ -262,7 +262,7 @@ Do not add any commentary or descriptions."""
     ]
 
     logger.debug(f"Calling VLM for text extraction with model={model}")
-    response = litellm.completion(
+    response = complete_routed(
         model=model,
         messages=messages,
         api_key=api_key,

--- a/core/analysis/shots_cloud.py
+++ b/core/analysis/shots_cloud.py
@@ -96,7 +96,7 @@ def classify_shot_cloud(
         ValueError: If no API key is configured for the model's provider
         RuntimeError: If classification fails
     """
-    import litellm
+    from core.llm_client import complete_routed
 
     from core.analysis.shots import SHOT_TYPES
     from core.settings import get_gemini_api_key, load_settings
@@ -149,7 +149,7 @@ def classify_shot_cloud(
     ]
 
     try:
-        response = litellm.completion(
+        response = complete_routed(
             model=model,
             messages=messages,
             api_key=api_key,

--- a/core/auth_errors.py
+++ b/core/auth_errors.py
@@ -1,0 +1,118 @@
+"""Shared classifier for subscription-mode auth errors.
+
+U8's scope is "translate the new exception types from U6 into user-visible
+UX." The hard part — defining the types and raising them from the right
+places — lives in :mod:`core.codex_client`. This module provides the
+one-line bridge workers and the chat UI use to decide which dialog to show.
+
+The classifier returns a stable string category so callers can branch
+in a switch-style block without importing every error type. Stable
+across the codebase:
+
+  - ``"token_required"`` — user needs to sign in (no token, or token
+    cannot be refreshed); show the re-auth prompt
+  - ``"token_expired"`` — same UX as token_required, but distinguishes
+    the case where a refresh attempt was made and failed
+  - ``"quota_exceeded"`` — show the Plus-quota message with the
+    "wait or switch to API key" action
+  - ``"codex_backend"`` — generic backend failure; show a transient
+    "OpenAI's Codex service had a hiccup" message
+  - ``"none"`` — not a subscription-auth error; the caller surfaces
+    it via its existing error path
+
+The re-auth prompt entry point (R-E1) is the settings dialog focused
+on the subscription panel — workers emit the category and the main
+window opens settings rather than spawning a separate OAuthWorker.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Re-export the error types so callers have a single import point.
+from core.codex_client import (
+    CodexBackendError,
+    CodexError,
+    MalformedCodexResponseError,
+    QuotaExceededError,
+    TokenExpiredError,
+    TokenMissingError,
+)
+
+
+# Stable category strings — U5's re-auth dialog branches on these.
+CATEGORY_TOKEN_REQUIRED = "token_required"
+CATEGORY_TOKEN_EXPIRED = "token_expired"
+CATEGORY_QUOTA_EXCEEDED = "quota_exceeded"
+CATEGORY_CODEX_BACKEND = "codex_backend"
+CATEGORY_NONE = "none"
+
+
+def classify_subscription_error(exc: BaseException) -> str:
+    """Map a caught exception to a stable UX category string.
+
+    Returns ``"none"`` for anything that isn't a subscription-auth error,
+    so workers can fall through to their existing error-handling path.
+    """
+    if isinstance(exc, TokenMissingError):
+        return CATEGORY_TOKEN_REQUIRED
+    if isinstance(exc, TokenExpiredError):
+        return CATEGORY_TOKEN_EXPIRED
+    if isinstance(exc, QuotaExceededError):
+        return CATEGORY_QUOTA_EXCEEDED
+    if isinstance(exc, CodexBackendError):
+        return CATEGORY_CODEX_BACKEND
+    if isinstance(exc, MalformedCodexResponseError):
+        return CATEGORY_CODEX_BACKEND
+    return CATEGORY_NONE
+
+
+def user_message_for_category(category: str, raw_message: Optional[str] = None) -> str:
+    """Friendly user-facing string for each category.
+
+    ``raw_message`` is the exception's own message; we use it as a hint
+    in the codex_backend case but never display it raw for the auth
+    categories (those have purpose-built strings the user sees often
+    enough that hand-tuning matters).
+
+    Exact wording is intentionally short and actionable. Workers pass
+    this string to whatever toast / dialog they own; the main window's
+    re-auth dialog uses category branching for actions, not wording.
+    """
+    if category == CATEGORY_TOKEN_REQUIRED:
+        return (
+            "ChatGPT sign-in required. Open Settings → API Keys to sign in, "
+            "or switch to API-key mode."
+        )
+    if category == CATEGORY_TOKEN_EXPIRED:
+        return (
+            "Your ChatGPT sign-in has expired. Sign in again from Settings, "
+            "or switch to API-key mode."
+        )
+    if category == CATEGORY_QUOTA_EXCEEDED:
+        return (
+            "You've hit your ChatGPT Plus quota for this 3-hour window. "
+            "Wait, or switch to API-key mode to keep working."
+        )
+    if category == CATEGORY_CODEX_BACKEND:
+        if raw_message:
+            return f"OpenAI's Codex service returned an error: {raw_message}"
+        return "OpenAI's Codex service had a hiccup. Try again, or switch to API-key mode."
+    return ""
+
+
+__all__ = [
+    "CATEGORY_TOKEN_REQUIRED",
+    "CATEGORY_TOKEN_EXPIRED",
+    "CATEGORY_QUOTA_EXCEEDED",
+    "CATEGORY_CODEX_BACKEND",
+    "CATEGORY_NONE",
+    "CodexBackendError",
+    "CodexError",
+    "MalformedCodexResponseError",
+    "QuotaExceededError",
+    "TokenExpiredError",
+    "TokenMissingError",
+    "classify_subscription_error",
+    "user_message_for_category",
+]

--- a/core/auth_errors.py
+++ b/core/auth_errors.py
@@ -27,6 +27,7 @@ window opens settings rather than spawning a separate OAuthWorker.
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Optional
 
 # Re-export the error types so callers have a single import point.
@@ -40,12 +41,29 @@ from core.codex_client import (
 )
 
 
-# Stable category strings — U5's re-auth dialog branches on these.
-CATEGORY_TOKEN_REQUIRED = "token_required"
-CATEGORY_TOKEN_EXPIRED = "token_expired"
-CATEGORY_QUOTA_EXCEEDED = "quota_exceeded"
-CATEGORY_CODEX_BACKEND = "codex_backend"
-CATEGORY_NONE = "none"
+class AuthErrorCategory(StrEnum):
+    """Stable category strings U5's re-auth dialog branches on.
+
+    StrEnum (Python 3.11+) means ``AuthErrorCategory.TOKEN_REQUIRED ==
+    "token_required"`` is True, so any existing string-comparison
+    callers keep working unchanged. Matches the precedent set by
+    ``core.update_models.UpdateChannel``.
+    """
+
+    TOKEN_REQUIRED = "token_required"
+    TOKEN_EXPIRED = "token_expired"
+    QUOTA_EXCEEDED = "quota_exceeded"
+    CODEX_BACKEND = "codex_backend"
+    NONE = "none"
+
+
+# Backwards-compatible module-level constant aliases. Callers that
+# import the bare names keep working; new code prefers the enum.
+CATEGORY_TOKEN_REQUIRED = AuthErrorCategory.TOKEN_REQUIRED
+CATEGORY_TOKEN_EXPIRED = AuthErrorCategory.TOKEN_EXPIRED
+CATEGORY_QUOTA_EXCEEDED = AuthErrorCategory.QUOTA_EXCEEDED
+CATEGORY_CODEX_BACKEND = AuthErrorCategory.CODEX_BACKEND
+CATEGORY_NONE = AuthErrorCategory.NONE
 
 
 def classify_subscription_error(exc: BaseException) -> str:
@@ -102,6 +120,7 @@ def user_message_for_category(category: str, raw_message: Optional[str] = None) 
 
 
 __all__ = [
+    "AuthErrorCategory",
     "CATEGORY_TOKEN_REQUIRED",
     "CATEGORY_TOKEN_EXPIRED",
     "CATEGORY_QUOTA_EXCEEDED",

--- a/core/codex_client.py
+++ b/core/codex_client.py
@@ -40,14 +40,29 @@ Codex endpoint differs.
 from __future__ import annotations
 
 import logging
-import re
 from typing import Optional, Tuple
 
 import httpx
 
 from core.spine.chatgpt_auth import CODEX_COMPLETION_ENDPOINT
+from core.spine.log_redaction import redact_bearer_tokens as _sanitize_for_log
 
 logger = logging.getLogger(__name__)
+
+
+# Module-level httpx client reused across calls so a batch of N analyses
+# in subscription mode shares one TLS handshake + one HTTP/1.1 keepalive
+# connection instead of paying ~100-300ms per clip on cold TLS. Lazily
+# created on first call; closed by Python's atexit cleanup.
+_shared_client: Optional[httpx.Client] = None
+
+
+def _get_shared_client() -> httpx.Client:
+    """Return the module-level httpx.Client, creating it on first use."""
+    global _shared_client
+    if _shared_client is None:
+        _shared_client = httpx.Client()
+    return _shared_client
 
 
 # --- Errors -----------------------------------------------------------------
@@ -144,28 +159,6 @@ def coerce_model_for_codex(model: str) -> str:
             return target
     # Non-prefixed gpt-* models pass through.
     return model
-
-
-# --- Bearer-token redaction -------------------------------------------------
-
-
-_AUTHORIZATION_PATTERN = re.compile(
-    r"(?i)(authorization\s*[:=]\s*bearer\s+)\S+"
-)
-
-
-def _sanitize_for_log(text: str) -> str:
-    """Redact bearer-token values from any free-form text.
-
-    Best-effort: matches the common ``Authorization: Bearer <token>``
-    pattern (case insensitive). Always run on any string that might
-    transit through a logger or an Exception message — httpx error
-    strings, in particular, can include the full request representation
-    with headers.
-    """
-    if not text:
-        return text
-    return _AUTHORIZATION_PATTERN.sub(r"\1[REDACTED]", text)
 
 
 # --- Low-level HTTP helper --------------------------------------------------
@@ -290,11 +283,8 @@ def complete(
     """
     coerced_model = coerce_model_for_codex(model)
     payload = {"model": coerced_model, "messages": messages, **kwargs}
-    if client is None:
-        with httpx.Client() as owned:
-            raw = _post_completion(owned, token_blob=token_blob, payload=payload)
-    else:
-        raw = _post_completion(client, token_blob=token_blob, payload=payload)
+    active_client = client if client is not None else _get_shared_client()
+    raw = _post_completion(active_client, token_blob=token_blob, payload=payload)
     return _wrap_response(raw)
 
 

--- a/core/codex_client.py
+++ b/core/codex_client.py
@@ -1,0 +1,347 @@
+"""Thin HTTP client for the OpenAI Codex inference backend.
+
+This module is what ``core.llm_client.complete_routed`` / ``stream_chat_routed``
+delegate to when ``auth_mode == "subscription"``. LiteLLM doesn't speak the
+Codex backend's wire shape, so we maintain a small focused client rather
+than registering a custom LiteLLM provider (that path is more invasive
+and harder to evolve as Codex's API changes).
+
+Three responsibilities:
+
+1. **Model coercion**: the analysis features in ``core/analysis/*`` pass
+   model names like ``gemini/gemini-2.5-flash`` or ``anthropic/claude-...``
+   from their per-feature settings. The Codex backend serves only OpenAI
+   models, so we map every configured model to its OpenAI substitute
+   when subscription mode is active. The substitution map lives in
+   ``CODEX_MODEL_SUBSTITUTIONS`` and is mechanically tunable. Per R-A2,
+   features whose only usable shape is Gemini-specific (e.g., video-file
+   content blocks) fall back to ``frame mode`` semantics; the per-feature
+   sites are aware of this and pass already-frame-shaped content.
+
+2. **Bearer-token redaction**: ``_sanitize_for_log`` scrubs the
+   Authorization header from any error message we propagate, so callers
+   can safely ``logger.error(str(exc))`` without leaking tokens to log
+   files. Mirrors the R-S4 pattern from
+   ``core/spine/chatgpt_oauth_flow._redact_authorization``.
+
+3. **Specific error taxonomy**: ``TokenMissingError``,
+   ``TokenExpiredError``, ``QuotaExceededError``, ``CodexBackendError``,
+   ``MalformedCodexResponseError`` — each error is what the routing
+   helper raises so U8's UX layer can branch cleanly.
+
+Placeholder values: ``CODEX_COMPLETION_ENDPOINT`` lives in
+``core/spine/chatgpt_auth.py`` from U2 and is a placeholder until a
+follow-up session reads Codex CLI's source. The request/response shape
+implemented here matches the OpenAI Chat Completions API (the broadest
+common ground); a future session refines the exact wire shape if the
+Codex endpoint differs.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional, Tuple
+
+import httpx
+
+from core.spine.chatgpt_auth import CODEX_COMPLETION_ENDPOINT
+
+logger = logging.getLogger(__name__)
+
+
+# --- Errors -----------------------------------------------------------------
+
+
+class CodexError(Exception):
+    """Base class for every error raised by this client."""
+
+
+class TokenMissingError(CodexError):
+    """auth_mode is subscription but no token is in keyring.
+
+    Surfaced before any HTTP call — the routing helper recognizes the
+    "subscription mode + no blob" state from ``load_active_auth`` and
+    raises this directly so callers don't waste a round trip.
+    """
+
+
+class TokenExpiredError(CodexError):
+    """The Codex backend returned 401 — token expired or revoked.
+
+    The routing helper catches this once, attempts a refresh through
+    ``core/spine/chatgpt_oauth_flow.refresh_token_blob``, and retries
+    the call. If refresh also returns 401, this is re-raised to the
+    UI layer (U8) which prompts the user to sign in again.
+    """
+
+
+class QuotaExceededError(CodexError):
+    """The Codex backend returned 429 — Plus quota window exhausted."""
+
+
+class CodexBackendError(CodexError):
+    """Non-2xx, non-401, non-429 response from the Codex backend.
+
+    Carries the status code so callers can branch on 5xx (transient,
+    worth retrying) vs 4xx (permanent, surface to user). ``body``
+    contains the response text with bearer tokens redacted.
+    """
+
+    def __init__(self, status: int, message: str, body: str = ""):
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+class MalformedCodexResponseError(CodexError):
+    """Codex response shape was 2xx but missing expected fields."""
+
+
+# --- Model coercion ---------------------------------------------------------
+
+
+# Per-feature OpenAI model substitutions applied when auth_mode is
+# subscription. The keys are the lower-cased substring patterns of the
+# configured model name; the values are OpenAI models the Codex backend
+# is expected to serve.
+#
+# Calibration is tunable in one place — a follow-up session adjusts
+# these based on actual Codex availability and quality observations.
+# Per R-A2: video-input features (cinematography_video, description_video)
+# fall back to frame mode upstream so we don't send Gemini-specific
+# content blocks the Codex endpoint won't accept.
+CODEX_MODEL_SUBSTITUTIONS: Tuple[Tuple[str, str], ...] = (
+    # (substring-match, openai_model_substitute)
+    ("gemini-3.1-flash-lite-preview", "gpt-4o-mini"),
+    ("gemini-2.5-flash", "gpt-4o-mini"),
+    ("gemini-2.5-pro", "gpt-4o"),
+    ("gemini", "gpt-4o-mini"),  # any other gemini -> small OpenAI
+    ("claude-sonnet", "gpt-4o"),
+    ("claude-opus", "gpt-4o"),
+    ("claude", "gpt-4o-mini"),  # any other claude -> small OpenAI
+    ("vertex_ai/", "gpt-4o"),
+    ("anthropic/", "gpt-4o-mini"),
+    ("openrouter/", "gpt-4o-mini"),
+)
+
+
+def coerce_model_for_codex(model: str) -> str:
+    """Map a configured model name to a Codex-supported OpenAI model.
+
+    Looks the model up in the substitution table; if no rule matches,
+    falls through to the model as-is — useful when the configured model
+    is already an OpenAI name (``gpt-4o``, ``gpt-5.2``, ``openai/...``).
+    """
+    if not model:
+        return "gpt-4o-mini"
+    lowered = model.lower()
+    # Strip provider prefix for the OpenAI passthrough case.
+    if lowered.startswith("openai/"):
+        return model.split("/", 1)[1]
+    for pattern, target in CODEX_MODEL_SUBSTITUTIONS:
+        if pattern in lowered:
+            return target
+    # Non-prefixed gpt-* models pass through.
+    return model
+
+
+# --- Bearer-token redaction -------------------------------------------------
+
+
+_AUTHORIZATION_PATTERN = re.compile(
+    r"(?i)(authorization\s*[:=]\s*bearer\s+)\S+"
+)
+
+
+def _sanitize_for_log(text: str) -> str:
+    """Redact bearer-token values from any free-form text.
+
+    Best-effort: matches the common ``Authorization: Bearer <token>``
+    pattern (case insensitive). Always run on any string that might
+    transit through a logger or an Exception message — httpx error
+    strings, in particular, can include the full request representation
+    with headers.
+    """
+    if not text:
+        return text
+    return _AUTHORIZATION_PATTERN.sub(r"\1[REDACTED]", text)
+
+
+# --- Low-level HTTP helper --------------------------------------------------
+
+
+def _post_completion(
+    client: httpx.Client,
+    *,
+    token_blob: dict,
+    payload: dict,
+) -> dict:
+    """POST a chat-completion request to the Codex backend; return JSON."""
+    access_token = token_blob.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise TokenMissingError("ChatGPT OAuth token blob is missing access_token")
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+    try:
+        response = client.post(
+            CODEX_COMPLETION_ENDPOINT,
+            json=payload,
+            headers=headers,
+            timeout=60.0,
+        )
+    except httpx.HTTPError as exc:
+        raise CodexBackendError(
+            status=0,
+            message=_sanitize_for_log(
+                f"Network error contacting Codex backend: {exc}"
+            ),
+        ) from exc
+
+    status = response.status_code
+    if status == 401:
+        raise TokenExpiredError("Codex backend rejected the bearer token (401)")
+    if status == 429:
+        try:
+            body_text = _sanitize_for_log(response.text)
+        except Exception:
+            body_text = ""
+        raise QuotaExceededError(
+            f"Codex backend returned 429 (quota exhausted): {body_text}"
+        )
+    if status >= 400:
+        try:
+            body_text = _sanitize_for_log(response.text)
+        except Exception:
+            body_text = ""
+        raise CodexBackendError(
+            status=status,
+            message=f"Codex backend returned {status}",
+            body=body_text,
+        )
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise MalformedCodexResponseError(
+            f"Codex response was non-JSON: {exc}"
+        ) from exc
+
+
+# --- Public API -------------------------------------------------------------
+
+
+def complete(
+    token_blob: dict,
+    *,
+    model: str,
+    messages: list,
+    client: Optional[httpx.Client] = None,
+    **kwargs,
+) -> dict:
+    """Run a chat completion against the Codex backend.
+
+    Returns the response dict in OpenAI Chat Completions format
+    (``choices[].message.content``, ``usage.*``). Callers that want
+    streaming use ``stream_complete`` instead.
+
+    ``kwargs`` is passed through to the backend as additional fields in
+    the JSON payload. Sites that previously passed ``response_format``,
+    ``tools``, ``tool_choice``, ``temperature``, ``max_tokens``, etc. to
+    ``litellm.completion`` flow through unchanged; the Codex backend's
+    support for any individual field is what the kwargs-compatibility
+    matrix (deferred to a follow-up session) verifies.
+    """
+    coerced_model = coerce_model_for_codex(model)
+    payload = {"model": coerced_model, "messages": messages, **kwargs}
+    if client is None:
+        with httpx.Client() as owned:
+            return _post_completion(owned, token_blob=token_blob, payload=payload)
+    return _post_completion(client, token_blob=token_blob, payload=payload)
+
+
+async def stream_complete(
+    token_blob: dict,
+    *,
+    model: str,
+    messages: list,
+    client: Optional[httpx.AsyncClient] = None,
+    **kwargs,
+):
+    """Async generator that yields streaming delta chunks from the Codex backend.
+
+    Emits dicts shaped like OpenAI streaming chunks
+    (``choices[].delta.content``, optional ``choices[].delta.tool_calls``).
+    The caller assembles a final response from the deltas exactly as
+    they do for ``litellm.acompletion`` streaming today.
+
+    The exact wire format for Codex streaming is verified during the
+    live-smoke-test step (deferred to a follow-up session). For now,
+    this implements the OpenAI Server-Sent-Events streaming convention
+    — ``data: {json}\\n`` lines terminated by ``data: [DONE]\\n``.
+    """
+    coerced_model = coerce_model_for_codex(model)
+    payload = {"model": coerced_model, "messages": messages, "stream": True, **kwargs}
+    access_token = token_blob.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise TokenMissingError("ChatGPT OAuth token blob is missing access_token")
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+    }
+
+    owns_client = client is None
+    if owns_client:
+        client = httpx.AsyncClient()
+
+    try:
+        async with client.stream(
+            "POST",
+            CODEX_COMPLETION_ENDPOINT,
+            json=payload,
+            headers=headers,
+            timeout=120.0,
+        ) as response:
+            status = response.status_code
+            if status == 401:
+                raise TokenExpiredError("Codex stream rejected the bearer token (401)")
+            if status == 429:
+                raise QuotaExceededError("Codex stream returned 429 (quota exhausted)")
+            if status >= 400:
+                try:
+                    body_text = _sanitize_for_log(await response.aread())
+                    body_text = body_text.decode("utf-8", errors="replace")
+                except Exception:
+                    body_text = ""
+                raise CodexBackendError(
+                    status=status,
+                    message=f"Codex stream returned {status}",
+                    body=body_text,
+                )
+            async for line in response.aiter_lines():
+                if not line:
+                    continue
+                if line.startswith(":"):
+                    # SSE comment line
+                    continue
+                if line.startswith("data: "):
+                    payload_str = line[len("data: "):]
+                    if payload_str.strip() == "[DONE]":
+                        return
+                    try:
+                        import json as _json
+
+                        yield _json.loads(payload_str)
+                    except ValueError:
+                        # Malformed chunk — log redacted, skip
+                        logger.warning(
+                            _sanitize_for_log(
+                                f"Codex stream emitted non-JSON chunk: {payload_str[:200]}"
+                            )
+                        )
+                        continue
+    finally:
+        if owns_client:
+            await client.aclose()

--- a/core/codex_client.py
+++ b/core/codex_client.py
@@ -232,6 +232,41 @@ def _post_completion(
 # --- Public API -------------------------------------------------------------
 
 
+class _NamespaceDict(dict):
+    """Dict that also supports attribute access for OpenAI-shape responses.
+
+    Call sites today do ``response.choices[0].message.content`` against
+    litellm's ModelResponse (a pydantic object). Subscription-mode responses
+    come from us as plain JSON dicts; wrapping them in this class keeps the
+    call sites unchanged. ``getattr(response.choices[0], 'finish_reason',
+    default)`` continues to work because attribute access falls back to
+    dict lookup with the same default semantics as a missing key.
+
+    Nested dicts and list elements are wrapped on the way in so the whole
+    response tree is uniformly accessible.
+    """
+
+    def __getattr__(self, name):
+        try:
+            return self[name]
+        except KeyError as exc:
+            raise AttributeError(name) from exc
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+
+def _wrap_response(obj):
+    """Recursively wrap dicts/lists so attribute access works downstream."""
+    if isinstance(obj, dict):
+        return _NamespaceDict(
+            {k: _wrap_response(v) for k, v in obj.items()}
+        )
+    if isinstance(obj, list):
+        return [_wrap_response(item) for item in obj]
+    return obj
+
+
 def complete(
     token_blob: dict,
     *,
@@ -257,8 +292,10 @@ def complete(
     payload = {"model": coerced_model, "messages": messages, **kwargs}
     if client is None:
         with httpx.Client() as owned:
-            return _post_completion(owned, token_blob=token_blob, payload=payload)
-    return _post_completion(client, token_blob=token_blob, payload=payload)
+            raw = _post_completion(owned, token_blob=token_blob, payload=payload)
+    else:
+        raw = _post_completion(client, token_blob=token_blob, payload=payload)
+    return _wrap_response(raw)
 
 
 async def stream_complete(

--- a/core/llm_client.py
+++ b/core/llm_client.py
@@ -904,3 +904,121 @@ def create_provider_config_from_settings() -> ProviderConfig:
         api_base=settings.llm_api_base or None,
         temperature=settings.llm_temperature,
     )
+
+
+def complete_routed(
+    *,
+    model: str,
+    messages: list,
+    api_key: Optional[str] = None,
+    **kwargs,
+):
+    """LLM-routing chokepoint — branches on the active auth mode at call time.
+
+    This is the single seam every LLM-backed feature should call instead of
+    ``litellm.completion`` directly. When ``auth_mode == "api_key"`` (the
+    default), behavior is bit-identical to today's call sites — the
+    function calls ``litellm.completion`` with the same signature and
+    returns the same response shape (R8 unchanged invariant).
+
+    When ``auth_mode == "subscription"``, the call routes through
+    :func:`core.codex_client.complete` against OpenAI's Codex backend using
+    the user's stored OAuth token. Non-OpenAI model names are coerced to
+    Codex-supported OpenAI substitutes by
+    :func:`core.codex_client.coerce_model_for_codex` (R-A2).
+
+    Token refresh: a 401 from the Codex backend triggers one transparent
+    refresh attempt (via :func:`core.spine.chatgpt_oauth_flow.refresh_token_blob`)
+    serialized through the module-level lock from
+    :mod:`core.spine.chatgpt_auth` (R-S5). On successful refresh, the call
+    is retried once. A second 401 propagates as ``TokenExpiredError`` for
+    U8's UI layer to surface.
+
+    Args:
+        model: model identifier as the caller already knows it; coerced
+            internally in subscription mode.
+        messages: chat messages list, same shape as ``litellm.completion``.
+        api_key: explicit API key override (API-key mode only; ignored in
+            subscription mode).
+        **kwargs: passed through to the underlying backend.
+
+    Returns:
+        Response dict in OpenAI Chat Completions shape.
+
+    Raises:
+        :class:`core.codex_client.TokenMissingError` when subscription
+        mode is active but no token blob is stored.
+
+        :class:`core.codex_client.TokenExpiredError` when the Codex
+        backend rejects the token and a refresh also fails.
+
+        :class:`core.codex_client.QuotaExceededError` when the Codex
+        backend returns 429.
+
+        :class:`core.codex_client.CodexBackendError` on other Codex
+        backend failures.
+    """
+    # Lazy imports keep startup cost flat and avoid pulling core/spine
+    # into module-init order when nobody calls this helper.
+    from core.spine.chatgpt_auth import (
+        AuthMode,
+        REFRESH_LOCK,
+        load_active_auth,
+    )
+
+    mode, _identity = load_active_auth()
+    if mode == AuthMode.API_KEY:
+        import litellm
+
+        # Preserve the existing api_key resolution behavior — callers
+        # that pass api_key=... still win; otherwise it stays None and
+        # litellm reads from env/keyring as before.
+        return litellm.completion(
+            model=model, messages=messages, api_key=api_key, **kwargs
+        )
+
+    # auth_mode == "subscription"
+    from core import codex_client
+    from core.settings import (
+        get_chatgpt_oauth_token,
+        set_chatgpt_oauth_token,
+    )
+
+    blob = get_chatgpt_oauth_token()
+    if not blob:
+        raise codex_client.TokenMissingError(
+            "Subscription auth mode is active but no token is stored. "
+            "Sign in again from Settings."
+        )
+
+    try:
+        return codex_client.complete(blob, model=model, messages=messages, **kwargs)
+    except codex_client.TokenExpiredError:
+        # Single refresh-and-retry attempt serialized across this process.
+        refresh_token_value = blob.get("refresh_token") or ""
+        if not refresh_token_value:
+            raise
+        # Lock is shared with any other in-flight LLM call in this process.
+        # The "check after acquire" idiom skips the actual refresh when a
+        # parallel caller already refreshed (R-S5).
+        with REFRESH_LOCK:
+            current_blob = get_chatgpt_oauth_token()
+            if (
+                current_blob
+                and current_blob.get("access_token") != blob.get("access_token")
+            ):
+                # Another caller already refreshed.
+                fresh_blob = current_blob
+            else:
+                from core.spine.chatgpt_oauth_flow import refresh_token_blob
+
+                refreshed = refresh_token_blob(refresh_token_value)
+                fresh_blob = refreshed.as_dict()
+                # Persist the refreshed blob. If keyring write fails, the
+                # current call still uses the in-memory blob; the next
+                # call will see the failure and surface re-auth.
+                set_chatgpt_oauth_token(fresh_blob)
+        # Retry once with the fresh blob — a second 401 propagates.
+        return codex_client.complete(
+            fresh_blob, model=model, messages=messages, **kwargs
+        )

--- a/core/quota_estimator.py
+++ b/core/quota_estimator.py
@@ -1,0 +1,133 @@
+"""Heuristic ChatGPT Plus quota estimator for pre-flight batch warnings.
+
+R12 requires Scene Ripper to warn a subscription-mode user *before*
+starting a batch operation that's likely to exhaust the ChatGPT Plus
+quota for the current 3-hour window. The Codex backend doesn't (today)
+expose remaining quota in any header, so this is heuristic-only.
+
+R-Q3 from the doc-review: default to **wide tolerance** for v1 so we
+don't train users to dismiss the warning before the estimator is
+calibrated. Calibration is a follow-up step — once a week of
+subscription-mode usage data exists, the per-operation thresholds in
+``_OPERATION_HEURISTICS`` get tightened in-place.
+
+Each operation key maps to a small set of numeric heuristics:
+
+  - ``messages_per_unit``  — roughly how many backend round-trips one
+    "unit" of work consumes (1 message per clip for describe; 1 per
+    clip per query for custom_query)
+  - ``tokens_per_unit``    — input + expected output tokens per unit
+  - ``warn_threshold_units`` — soft cap, wide for v1, units above this
+    trigger a pre-flight warning
+
+The exact warning UX (R-Q1 — "Switch to API key" is current-operation-only,
+not a persisted mode change) lives in the worker that consumes this
+estimator. The estimator itself returns a small dict; callers branch
+on ``should_warn`` to decide whether to show the dialog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+# Per-operation heuristic constants. Tunable as a single module-level
+# dict so calibration changes are a one-line edit. Wide v1 thresholds:
+# values intentionally high to avoid false-positive fatigue before real
+# Plus-quota data is collected (R-Q3).
+_OPERATION_HEURISTICS: dict[str, dict[str, int]] = {
+    "describe": {
+        "messages_per_unit": 1,
+        "tokens_per_unit": 500,
+        "warn_threshold_units": 300,
+    },
+    "classify": {
+        "messages_per_unit": 1,
+        "tokens_per_unit": 200,
+        "warn_threshold_units": 500,
+    },
+    "cinematography": {
+        "messages_per_unit": 1,
+        "tokens_per_unit": 800,
+        "warn_threshold_units": 200,
+    },
+    "custom_query": {
+        "messages_per_unit": 1,
+        "tokens_per_unit": 300,
+        "warn_threshold_units": 250,
+    },
+    "ocr": {
+        "messages_per_unit": 1,
+        "tokens_per_unit": 200,
+        "warn_threshold_units": 500,
+    },
+}
+
+
+@dataclass(frozen=True)
+class BatchLoadEstimate:
+    """Estimate returned by :func:`estimate_batch_load`.
+
+    ``should_warn`` is the simple boolean callers branch on. The
+    individual fields are exposed for debugging / log output but are
+    not load-bearing — they're heuristic until calibration lands.
+    """
+
+    operation: str
+    count: int
+    estimated_messages: int
+    estimated_tokens: int
+    warn_threshold_units: int
+    should_warn: bool
+
+
+def estimate_batch_load(operation: str, count: int) -> BatchLoadEstimate:
+    """Return a heuristic estimate for an N-unit batch of ``operation``.
+
+    Unknown operations return a zero-everywhere estimate with
+    ``should_warn=False`` so the caller's warning path is silent rather
+    than firing on every operation it doesn't recognize.
+    """
+    heuristics = _OPERATION_HEURISTICS.get(operation)
+    if heuristics is None or count <= 0:
+        return BatchLoadEstimate(
+            operation=operation,
+            count=max(0, count),
+            estimated_messages=0,
+            estimated_tokens=0,
+            warn_threshold_units=0,
+            should_warn=False,
+        )
+
+    messages = heuristics["messages_per_unit"] * count
+    tokens = heuristics["tokens_per_unit"] * count
+    threshold = heuristics["warn_threshold_units"]
+    return BatchLoadEstimate(
+        operation=operation,
+        count=count,
+        estimated_messages=messages,
+        estimated_tokens=tokens,
+        warn_threshold_units=threshold,
+        should_warn=count > threshold,
+    )
+
+
+def adjust_threshold(operation: str, new_threshold_units: int) -> None:
+    """Tunable threshold update — used by calibration follow-up.
+
+    Mutates the module-level dict in place; subsequent calls to
+    :func:`estimate_batch_load` pick up the new value. Pre-existing
+    BatchLoadEstimate instances are immutable so they're unaffected.
+    """
+    if operation in _OPERATION_HEURISTICS:
+        _OPERATION_HEURISTICS[operation]["warn_threshold_units"] = int(
+            new_threshold_units
+        )
+
+
+__all__ = [
+    "BatchLoadEstimate",
+    "adjust_threshold",
+    "estimate_batch_load",
+]

--- a/core/settings.py
+++ b/core/settings.py
@@ -36,6 +36,9 @@ KEYRING_OPENROUTER_API_KEY = "openrouter_api_key"
 KEYRING_REPLICATE_API_KEY = "replicate_api_key"
 KEYRING_GROQ_API_KEY = "groq_api_key"
 
+# ChatGPT subscription auth (Sign in with ChatGPT) — OAuth token blob
+KEYRING_CHATGPT_OAUTH_TOKEN = "chatgpt_oauth_token"
+
 # Config schema version
 CONFIG_VERSION = "1.0"
 
@@ -227,6 +230,98 @@ def get_groq_api_key() -> str:
 def set_groq_api_key(api_key: str) -> bool:
     """Store Groq API key in system keyring."""
     return _set_provider_api_key_in_keyring(KEYRING_GROQ_API_KEY, api_key)
+
+
+# ChatGPT subscription OAuth token helpers
+#
+# Stored as a single JSON-serialized blob under one keyring key. The blob shape
+# is opaque to settings.py; core/spine/chatgpt_auth.py owns the schema. Writing
+# the full blob atomically avoids the partial-update race that separate fields
+# would create during a refresh.
+#
+# Intentionally NOT exposed via env var: OAuth tokens are short-lived secrets
+# with refresh semantics. API keys have env-var overrides for power users;
+# subscription tokens are keyring-only.
+
+def _is_plaintext_keyring_backend(keyring_module) -> bool:
+    """True when the active keyring backend stores credentials in plaintext.
+
+    Linux systems without a Secret Service provider fall back to
+    `keyrings.alt.file.PlaintextKeyring`, which writes credentials in
+    base64-encoded plaintext to disk. OAuth refresh tokens are higher-value
+    than API keys and warrant fail-closed behavior here — API-key mode
+    remains available as the alternative path.
+    """
+    try:
+        backend_cls = keyring_module.get_keyring().__class__
+    except Exception:
+        return False
+    backend_name = backend_cls.__name__
+    backend_module = (backend_cls.__module__ or "")
+    return backend_name == "PlaintextKeyring" or backend_module.startswith("keyrings.alt")
+
+
+def get_chatgpt_oauth_token() -> Optional[dict]:
+    """Retrieve the stored ChatGPT OAuth token blob.
+
+    Returns None when no token is stored, the keyring is unreadable, or the
+    stored value is malformed JSON. Malformed blobs are self-cleared to break
+    the perpetual `TokenMissingError` loop a partial-write crash could cause.
+    """
+    try:
+        import keyring
+        blob_json = _get_password_from_keyring_services(keyring, KEYRING_CHATGPT_OAUTH_TOKEN)
+        if not blob_json:
+            return None
+        return json.loads(blob_json)
+    except json.JSONDecodeError as e:
+        logger.warning(f"Stored ChatGPT OAuth token is malformed JSON; clearing: {e}")
+        clear_chatgpt_oauth_token()
+        return None
+    except Exception as e:
+        logger.debug(f"Could not read ChatGPT OAuth token from keyring: {e}")
+        return None
+
+
+def set_chatgpt_oauth_token(token_blob: Optional[dict]) -> bool:
+    """Store the ChatGPT OAuth token blob in secure OS storage.
+
+    Refuses the write (returns False, logs error, no entry created) when the
+    active keyring backend is a plaintext fallback. Passing None deletes the
+    stored entry.
+    """
+    try:
+        import keyring
+        if token_blob is None:
+            _delete_password_from_keyring_services(keyring, KEYRING_CHATGPT_OAUTH_TOKEN)
+            return True
+        if _is_plaintext_keyring_backend(keyring):
+            backend_cls = keyring.get_keyring().__class__
+            logger.error(
+                "Refusing to store ChatGPT OAuth token: active keyring backend "
+                f"({backend_cls.__module__}.{backend_cls.__name__}) writes "
+                "credentials in plaintext. Install a system keychain "
+                "(GNOME Keyring, KWallet, Windows Credential Manager) or use "
+                "API-key mode."
+            )
+            return False
+        blob_json = json.dumps(token_blob)
+        keyring.set_password(KEYRING_SERVICE, KEYRING_CHATGPT_OAUTH_TOKEN, blob_json)
+        return True
+    except Exception as e:
+        logger.warning(f"Could not write ChatGPT OAuth token to keyring: {e}")
+        return False
+
+
+def clear_chatgpt_oauth_token() -> bool:
+    """Remove the ChatGPT OAuth token blob from secure storage."""
+    try:
+        import keyring
+        _delete_password_from_keyring_services(keyring, KEYRING_CHATGPT_OAUTH_TOKEN)
+        return True
+    except Exception as e:
+        logger.warning(f"Could not clear ChatGPT OAuth token from keyring: {e}")
+        return False
 
 
 def is_api_key_from_env(provider: str) -> bool:
@@ -481,6 +576,14 @@ class Settings:
     anthropic_model: str = "claude-sonnet-4-5-20250929"
     gemini_model: str = "gemini-2.5-flash"
     openrouter_model: str = "anthropic/claude-sonnet-4"
+
+    # ChatGPT subscription auth (Sign in with ChatGPT)
+    # auth_mode = "api_key" preserves existing behavior; "subscription" routes
+    # LLM calls through the user's ChatGPT Plus/Pro quota. The OAuth token
+    # itself lives in keyring (KEYRING_CHATGPT_OAUTH_TOKEN); only the mode
+    # selection and the display-only account identity persist here.
+    auth_mode: str = "api_key"  # api_key, subscription
+    chatgpt_account_email: str = ""  # display-only identity, non-secret
 
     # Vision Description Settings
     description_model_tier: str = "local"  # local, cloud (legacy: cpu, gpu)
@@ -766,6 +869,15 @@ def _load_from_json(config_path: Path, settings: Settings) -> Settings:
         if "parallel_downloads" in youtube:
             settings.youtube_parallel_downloads = int(youtube["parallel_downloads"])
 
+    # Auth section (ChatGPT OAuth token comes from keyring, not JSON)
+    if auth := data.get("auth"):
+        mode = auth.get("mode")
+        if isinstance(mode, str) and mode in ("api_key", "subscription"):
+            settings.auth_mode = mode
+        email = auth.get("chatgpt_account_email")
+        if isinstance(email, str):
+            settings.chatgpt_account_email = email
+
     # LLM section (API key comes from keyring, not JSON)
     if llm := data.get("llm"):
         if val := llm.get("provider"):
@@ -960,6 +1072,11 @@ def _settings_to_json(settings: Settings) -> dict:
             "gemini_model": settings.gemini_model,
             "openrouter_model": settings.openrouter_model,
             # Note: API key is NOT stored here - it goes to keyring
+        },
+        "auth": {
+            "mode": settings.auth_mode,
+            "chatgpt_account_email": settings.chatgpt_account_email,
+            # Note: OAuth token blob is NOT stored here - it goes to keyring
         },
         "description": {
             "model_tier": settings.description_model_tier,

--- a/core/spine/chatgpt_auth.py
+++ b/core/spine/chatgpt_auth.py
@@ -42,7 +42,7 @@ import asyncio
 import threading
 import time
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from typing import Optional, Tuple
 
 
@@ -69,12 +69,16 @@ REFRESH_LOCK: threading.Lock = threading.Lock()
 REFRESH_LOCK_ASYNC: asyncio.Lock = asyncio.Lock()
 
 
-class AuthMode(str, Enum):
+class AuthMode(StrEnum):
     """User's selected authentication mode for LLM features.
 
-    Inherits from ``str`` so callers can compare directly with the JSON
-    string values stored in ``Settings.auth_mode`` without explicit
-    conversion (``AuthMode.API_KEY == "api_key"`` is True).
+    ``StrEnum`` (Python 3.11+) makes member values plain strings — so
+    ``AuthMode.API_KEY == "api_key"`` and ``str(AuthMode.API_KEY) ==
+    "api_key"`` are both True. This lets callers compare directly with
+    the JSON string values stored in ``Settings.auth_mode`` without
+    explicit conversion. Matches the repo precedent in
+    ``core.update_models`` (UpdateChannel, UpdateAvailability,
+    UpdateCapability).
     """
 
     API_KEY = "api_key"

--- a/core/spine/chatgpt_auth.py
+++ b/core/spine/chatgpt_auth.py
@@ -1,0 +1,174 @@
+"""ChatGPT subscription auth — spine-safe state layer.
+
+This module owns the in-memory shape of the "Sign in with ChatGPT" feature.
+It reads ``Settings.auth_mode`` and the keyring-backed OAuth token blob, and
+exposes a tiny pure-function API every consumer reads through at call time.
+
+Spine boundary discipline:
+
+- Imports at module top level are stdlib only. No ``PySide6``, ``litellm``,
+  ``httpx``, ``av``, ``mpv``, ``faster_whisper``, ``paddleocr``, ``mlx_vlm``.
+  This module must be safely importable from headless processes (MCP server,
+  CLI). The boundary is enforced by ``tests/test_spine_imports.py``.
+- The OAuth flow itself (HTTP, PKCE, loopback listener) lives in a sibling
+  ``core/spine/chatgpt_oauth_flow.py`` module that this module does NOT
+  import — keeping the active-state read path free of any network-library
+  dependency. ``chatgpt_oauth_flow`` is added in U3.
+
+Why a single shared module instead of caching auth state in each consumer:
+the chat worker is recreated per message, analysis workers re-resolve
+credentials per call, and the MCP server reloads on each tool invocation —
+all consumers re-read this module at call time. AE5 (mid-conversation auth
+switch without app restart) holds because nothing caches mode at
+construction time.
+
+Refresh-contention locks (``REFRESH_LOCK`` / ``REFRESH_LOCK_ASYNC``) are
+declared here so concurrent LLM calls coordinate on a single refresh
+attempt per process. The cross-process contract is GUI-only-refresh
+(documented in the plan): the GUI process holds the writer role; the MCP
+server treats keyring as read-only and surfaces ``TokenExpiredError`` to
+its callers rather than refreshing.
+
+The OAuth client_id, endpoints, and scopes below are placeholder strings
+until U3 fills them in from the open-source Codex CLI flow. They are
+exposed at module scope so ``tests/test_chatgpt_auth.py`` can assert
+HTTPS-only schemes — catching ``http://`` transcription mistakes at
+merge time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+
+# OAuth endpoint constants
+#
+# Placeholder HTTPS URLs — U3 replaces these with the real values borrowed
+# from Codex CLI's open-source flow. The HTTPS-prefix assertion in
+# tests/test_chatgpt_auth.py runs against whatever value is here, so a
+# regression to http:// will fail at merge time regardless of U3's order.
+CLIENT_ID: str = "PLACEHOLDER_UNTIL_U3"
+AUTHORIZATION_ENDPOINT: str = "https://auth.openai.com/oauth/authorize"
+TOKEN_ENDPOINT: str = "https://auth.openai.com/oauth/token"
+CODEX_COMPLETION_ENDPOINT: str = "https://chatgpt.com/backend-api/codex/responses"
+REDIRECT_URI_HOST: str = "127.0.0.1"
+SCOPES: Tuple[str, ...] = ("openid", "profile", "email", "offline_access")
+
+
+# Refresh-coordination locks (one per event loop / thread group within this
+# process). Acquired before calling the refresh endpoint; the holder
+# re-reads the token blob after acquiring to detect a parallel caller that
+# already refreshed. Cross-process coordination is documented in the plan
+# as GUI-only-refresh; the MCP process does not hold either of these locks.
+REFRESH_LOCK: threading.Lock = threading.Lock()
+REFRESH_LOCK_ASYNC: asyncio.Lock = asyncio.Lock()
+
+
+class AuthMode(str, Enum):
+    """User's selected authentication mode for LLM features.
+
+    Inherits from ``str`` so callers can compare directly with the JSON
+    string values stored in ``Settings.auth_mode`` without explicit
+    conversion (``AuthMode.API_KEY == "api_key"`` is True).
+    """
+
+    API_KEY = "api_key"
+    SUBSCRIPTION = "subscription"
+
+
+@dataclass(frozen=True)
+class AuthIdentity:
+    """Immutable snapshot of the active sign-in identity.
+
+    Returned by ``load_active_auth()`` when the user is signed in with
+    ChatGPT subscription mode and a valid token blob is in keyring.
+    Carries display-only identity plus the expiry timestamp the routing
+    layer uses to decide whether to refresh before an LLM call.
+    """
+
+    account_email: str
+    expires_at_unix: int
+
+    @property
+    def seconds_until_expiry(self) -> int:
+        """Remaining lifetime of the access token in seconds.
+
+        Can be negative when the token is already expired; callers should
+        prefer ``is_token_expired(identity, leeway_seconds=...)`` for the
+        boolean decision instead of comparing this to zero directly.
+        """
+        return int(self.expires_at_unix - time.time())
+
+
+def is_token_expired(identity: AuthIdentity, leeway_seconds: int = 60) -> bool:
+    """True when the access token is at-or-past its expiry, allowing leeway.
+
+    A small positive ``leeway_seconds`` (default 60s) treats "about to
+    expire" as expired so callers refresh before launching a long-running
+    LLM call rather than mid-call. Set ``leeway_seconds=0`` to test the
+    strict boundary.
+    """
+    return time.time() + leeway_seconds >= identity.expires_at_unix
+
+
+def load_active_auth() -> Tuple[AuthMode, Optional[AuthIdentity]]:
+    """Read the user's current auth mode and identity at call time.
+
+    Returns:
+        ``(AuthMode.API_KEY, None)`` when the user has selected API-key mode.
+
+        ``(AuthMode.SUBSCRIPTION, AuthIdentity(...))`` when subscription mode
+        is active and a valid token blob is in keyring.
+
+        ``(AuthMode.SUBSCRIPTION, None)`` when subscription mode is selected
+        but no token blob exists — the "re-auth needed" state. The routing
+        layer (U6) translates this into ``TokenMissingError`` so the UI
+        (U8) can prompt for sign-in.
+
+    Reads ``Settings.auth_mode`` and the keyring blob fresh on every call —
+    no caching. This is what makes AE5 (mid-conversation mode switch
+    without restart) structurally easy: every consumer naturally picks up
+    the latest state without dedicated propagation code.
+    """
+    # Lazy imports keep the spine boundary intact: settings.py is already
+    # spine-safe but importing it at module scope here would couple our
+    # import order to settings' module init. Function-scope keeps both
+    # modules independently importable in any order.
+    from core.settings import (
+        get_chatgpt_oauth_token,
+        load_settings,
+    )
+
+    settings = load_settings()
+    if settings.auth_mode != AuthMode.SUBSCRIPTION.value:
+        return AuthMode.API_KEY, None
+
+    blob = get_chatgpt_oauth_token()
+    if not blob:
+        return AuthMode.SUBSCRIPTION, None
+
+    # Extract identity fields with defensive defaults. The blob schema is
+    # documented in core/settings.py:set_chatgpt_oauth_token and produced
+    # by U3 (OAuth flow). We tolerate missing fields here rather than
+    # crashing — a malformed-but-parseable blob still surfaces as
+    # "subscription mode, no identity" rather than raising on every call.
+    account_email = ""
+    raw_email = blob.get("account_email")
+    if isinstance(raw_email, str):
+        account_email = raw_email
+
+    expires_at_unix = 0
+    raw_expiry = blob.get("expires_at_unix")
+    if isinstance(raw_expiry, (int, float)):
+        expires_at_unix = int(raw_expiry)
+
+    identity = AuthIdentity(
+        account_email=account_email,
+        expires_at_unix=expires_at_unix,
+    )
+    return AuthMode.SUBSCRIPTION, identity

--- a/core/spine/chatgpt_oauth_flow.py
+++ b/core/spine/chatgpt_oauth_flow.py
@@ -65,6 +65,7 @@ from core.spine.chatgpt_auth import (
     SCOPES,
     TOKEN_ENDPOINT,
 )
+from core.spine.log_redaction import redact_bearer_tokens as _redact_authorization
 
 logger = logging.getLogger(__name__)
 
@@ -312,6 +313,13 @@ class _LoopbackHandler(http.server.BaseHTTPRequestHandler):
 class _LoopbackServer(http.server.HTTPServer):
     """HTTPServer subclass that holds the single captured result."""
 
+    # ``OAuthWorker._run_listener_with_cancellation`` (U4) wraps the
+    # listener in short slices to make user cancellation observable, so
+    # the server is bound and torn down repeatedly during one flow.
+    # ``SO_REUSEADDR`` lets the rebind succeed inside the kernel's
+    # TIME_WAIT window instead of failing spuriously a few seconds in.
+    allow_reuse_address = True
+
     def __init__(self, server_address, RequestHandlerClass):
         super().__init__(server_address, RequestHandlerClass)
         self.result_code: Optional[str] = None
@@ -373,18 +381,6 @@ def run_loopback_listener(
 
 
 # --- Token exchange ----------------------------------------------------------
-
-
-def _redact_authorization(message: str) -> str:
-    """Best-effort redaction of bearer tokens in error messages."""
-    # Match common Authorization header patterns; replace value half.
-    import re
-
-    return re.sub(
-        r"(?i)(authorization\s*[:=]\s*bearer\s+)\S+",
-        r"\1[REDACTED]",
-        message,
-    )
 
 
 def _post_token_endpoint(

--- a/core/spine/chatgpt_oauth_flow.py
+++ b/core/spine/chatgpt_oauth_flow.py
@@ -1,0 +1,547 @@
+"""PKCE + loopback OAuth flow against OpenAI's Codex auth endpoint.
+
+Pure-Python, GUI-free implementation of the authorization-code-with-PKCE
+flow Codex CLI uses. The flow:
+
+  1. ``generate_pkce_pair()`` → (verifier, challenge)
+  2. ``build_authorization_url(challenge)`` → (url, redirect_uri, state, port)
+       — state is generated internally via secrets.token_urlsafe per R-S1
+       — redirect_uri binds to 127.0.0.1:<port>
+  3. caller opens ``url`` in the user's browser
+  4. ``run_loopback_listener(port, expected_state, timeout)`` → AuthorizationCode
+       — explicit 127.0.0.1 bind, Host header validation, path allowlist (R-S2)
+       — single-shot: handler terminates after one redirect
+  5. ``exchange_code_for_token(code, verifier, redirect_uri)`` → TokenBlob
+  6. ``refresh_token_blob(refresh_token)`` → TokenBlob (later, on 401)
+
+All HTTP traffic flows through ``httpx.Client``. Tests inject
+``httpx.MockTransport`` to assert request shape without live calls.
+
+Error surface — all OAuth flow exceptions inherit from ``OAuthError`` so
+callers can catch broadly when they need to:
+
+  - ``OAuthCancelledError``   — user closed the browser / app cancelled
+  - ``OAuthTimeoutError``     — loopback waited longer than the timeout
+  - ``OAuthHTTPError``        — non-2xx from OpenAI; carries status code
+  - ``OAuthMalformedResponseError`` — 2xx but expected fields missing
+  - ``OAuthHostMismatchError`` — request to loopback had a bad Host header
+
+Bearer-token redaction (R-S4): any ``httpx`` request error caught here is
+re-raised as ``OAuthHTTPError`` with the ``Authorization`` header value
+scrubbed from the message. Callers can safely ``logger.error(str(exc))``
+without leaking tokens to log files.
+
+Spine boundary: ``httpx`` is allowed in spine per
+``tests/test_spine_imports.py``. This module does NOT import PySide6, mpv,
+or any heavy ML lib. The OAuth-worker Qt wrapper lives in
+``ui/workers/oauth_worker.py`` (U4) and consumes this module.
+
+Placeholders: the actual ``client_id`` and exact token-endpoint request
+shape come from Codex CLI's open-source repo. The functions below build
+the standard OAuth 2.0 + PKCE flow; ``CLIENT_ID`` is read from
+``core/spine/chatgpt_auth.py``'s constants (currently a placeholder). A
+follow-up session replaces those constants with the real values and
+verifies end-to-end against the real endpoint.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import http.server
+import logging
+import secrets
+import socket
+import urllib.parse
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import httpx
+
+from core.spine.chatgpt_auth import (
+    AUTHORIZATION_ENDPOINT,
+    CLIENT_ID,
+    REDIRECT_URI_HOST,
+    SCOPES,
+    TOKEN_ENDPOINT,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# --- Exceptions --------------------------------------------------------------
+
+
+class OAuthError(Exception):
+    """Base class for all OAuth-flow errors raised by this module."""
+
+
+class OAuthCancelledError(OAuthError):
+    """User cancelled the flow (closed browser, app-side cancel)."""
+
+
+class OAuthTimeoutError(OAuthError):
+    """Loopback receiver did not get a redirect within the timeout window."""
+
+
+class OAuthHTTPError(OAuthError):
+    """OpenAI endpoint returned a non-success status (or httpx errored).
+
+    ``status`` is None when the failure happened before a response was
+    received (e.g., DNS, connect, TLS). ``body`` is best-effort — empty
+    when no response body was readable. The ``__str__`` of this exception
+    has bearer tokens redacted via ``_redact_authorization`` so callers
+    can safely log it.
+    """
+
+    def __init__(self, status: Optional[int], message: str, body: str = ""):
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+class OAuthMalformedResponseError(OAuthError):
+    """Token endpoint returned 2xx but a required field is missing."""
+
+
+class OAuthHostMismatchError(OAuthError):
+    """Loopback handler received a request with an unexpected Host header."""
+
+
+# --- Data shapes -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PKCEPair:
+    """Code verifier + S256-derived challenge for the PKCE flow."""
+
+    verifier: str
+    challenge: str
+
+
+@dataclass(frozen=True)
+class AuthorizationRequest:
+    """Materials the caller needs to drive the rest of the flow.
+
+    The url is what the GUI opens in the user's browser. The redirect_uri
+    must match exactly between the authorization request and the token
+    exchange. The state must match what the loopback listener observes.
+    The port lets the caller pass it to ``run_loopback_listener``.
+    """
+
+    url: str
+    redirect_uri: str
+    state: str
+    port: int
+
+
+@dataclass(frozen=True)
+class AuthorizationCode:
+    """Result of a successful loopback redirect."""
+
+    code: str
+    state: str
+
+
+@dataclass(frozen=True)
+class TokenBlob:
+    """Shape of what we persist to keyring after a successful exchange.
+
+    Matches the schema documented in ``core/settings.py:set_chatgpt_oauth_token``.
+    ``expires_at_unix`` is computed at exchange time from the endpoint's
+    ``expires_in`` field so consumers don't have to know the issuance time.
+    """
+
+    access_token: str
+    refresh_token: str
+    id_token: str
+    expires_at_unix: int
+    account_email: str
+
+    def as_dict(self) -> dict:
+        return {
+            "access_token": self.access_token,
+            "refresh_token": self.refresh_token,
+            "id_token": self.id_token,
+            "expires_at_unix": self.expires_at_unix,
+            "account_email": self.account_email,
+        }
+
+
+# --- PKCE primitives ---------------------------------------------------------
+
+
+def generate_pkce_pair() -> PKCEPair:
+    """Generate a code_verifier (43-128 random chars) + S256 challenge.
+
+    Per RFC 7636: verifier is a URL-safe random string of 43-128 chars;
+    challenge is BASE64URL(SHA256(verifier)) with padding stripped.
+    """
+    # 32 random bytes encodes to 43 url-safe base64 chars (no padding),
+    # which is the minimum-allowed verifier length under RFC 7636.
+    verifier = secrets.token_urlsafe(32)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return PKCEPair(verifier=verifier, challenge=challenge)
+
+
+# --- Authorization URL -------------------------------------------------------
+
+
+def _pick_free_loopback_port() -> int:
+    """Bind a transient socket on 127.0.0.1:0 to discover a free port.
+
+    Returns immediately after closing the probe socket. There's a small
+    TOCTOU window before the listener re-binds, but the worst-case
+    failure (port now occupied) surfaces as a clean ``OSError`` from
+    ``HTTPServer`` rather than silent breakage.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind((REDIRECT_URI_HOST, 0))
+        return probe.getsockname()[1]
+
+
+def build_authorization_url(challenge: str) -> AuthorizationRequest:
+    """Construct the URL the user's browser opens to start the OAuth flow.
+
+    Generates ``state`` internally via ``secrets.token_urlsafe(32)`` so
+    callers can't accidentally pass a low-entropy value (R-S1). Picks a
+    free localhost port for the loopback redirect URI; the caller passes
+    that port to ``run_loopback_listener``.
+    """
+    state = secrets.token_urlsafe(32)
+    port = _pick_free_loopback_port()
+    redirect_uri = f"http://{REDIRECT_URI_HOST}:{port}/callback"
+
+    params = {
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "scope": " ".join(SCOPES),
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    query = urllib.parse.urlencode(params)
+    url = f"{AUTHORIZATION_ENDPOINT}?{query}"
+    return AuthorizationRequest(
+        url=url, redirect_uri=redirect_uri, state=state, port=port
+    )
+
+
+# --- Loopback listener -------------------------------------------------------
+
+
+# Successful and error response bodies served back to the browser. Static
+# HTML so the user sees something coherent after authorizing.
+_SUCCESS_PAGE = (
+    b"<!DOCTYPE html><html><head><title>Signed in</title></head>"
+    b"<body style='font-family: -apple-system, sans-serif; padding: 40px;'>"
+    b"<h2>Sign-in complete.</h2>"
+    b"<p>You can close this window and return to Scene Ripper.</p>"
+    b"</body></html>"
+)
+_ERROR_PAGE = (
+    b"<!DOCTYPE html><html><head><title>Sign-in failed</title></head>"
+    b"<body style='font-family: -apple-system, sans-serif; padding: 40px;'>"
+    b"<h2>Sign-in did not complete.</h2>"
+    b"<p>Return to Scene Ripper for details, then try again.</p>"
+    b"</body></html>"
+)
+
+
+class _LoopbackHandler(http.server.BaseHTTPRequestHandler):
+    """Single-shot handler that captures one ``?code=&state=`` redirect.
+
+    Captures the result on the server instance so the calling code can
+    read it after the server stops. Validates Host header and path
+    before parsing query parameters (R-S2).
+    """
+
+    server: "_LoopbackServer"  # narrower type than http.server.HTTPServer
+
+    # Silence the default access log — we have our own logging.
+    def log_message(self, format: str, *args) -> None:  # noqa: A002
+        return
+
+    def do_GET(self) -> None:  # noqa: N802 (BaseHTTPRequestHandler API)
+        # Validate Host header — defense in depth against a local process
+        # sending a request to the listener with a spoofed Host.
+        host_header = self.headers.get("Host", "")
+        host_only = host_header.split(":", 1)[0]
+        if host_only not in ("localhost", "127.0.0.1"):
+            self.server.host_mismatch = host_header
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        parsed = urllib.parse.urlsplit(self.path)
+        if parsed.path != "/callback":
+            # Anything other than the expected callback path is ignored;
+            # the loop continues to wait for the real redirect.
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        params = urllib.parse.parse_qs(parsed.query)
+        code = params.get("code", [""])[0]
+        state = params.get("state", [""])[0]
+        error = params.get("error", [""])[0]
+
+        if error:
+            self.server.error_param = error
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(_ERROR_PAGE)
+            return
+
+        if not code or not state:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        self.server.result_code = code
+        self.server.result_state = state
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(_SUCCESS_PAGE)
+
+
+class _LoopbackServer(http.server.HTTPServer):
+    """HTTPServer subclass that holds the single captured result."""
+
+    def __init__(self, server_address, RequestHandlerClass):
+        super().__init__(server_address, RequestHandlerClass)
+        self.result_code: Optional[str] = None
+        self.result_state: Optional[str] = None
+        self.error_param: Optional[str] = None
+        self.host_mismatch: Optional[str] = None
+
+
+def run_loopback_listener(
+    port: int, expected_state: str, timeout_seconds: float = 300.0
+) -> AuthorizationCode:
+    """Run a single-shot HTTPS-callback receiver on 127.0.0.1:port.
+
+    Returns when one valid callback is received (matching state) or
+    raises an OAuth* exception on error / timeout. The server is closed
+    on every exit path including exceptions.
+    """
+    server = _LoopbackServer((REDIRECT_URI_HOST, port), _LoopbackHandler)
+    server.timeout = max(1.0, timeout_seconds)
+
+    try:
+        # handle_request() returns when one request has been handled or
+        # the timeout fires. Loop because the handler may have served
+        # a 404 (unknown path) and we should keep waiting.
+        import time
+
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            remaining = deadline - time.time()
+            server.timeout = max(0.1, remaining)
+            server.handle_request()
+            if server.host_mismatch:
+                raise OAuthHostMismatchError(
+                    f"Loopback received request with unexpected Host: "
+                    f"{server.host_mismatch!r}"
+                )
+            if server.error_param:
+                raise OAuthHTTPError(
+                    status=None,
+                    message=f"Authorization server returned error: {server.error_param}",
+                )
+            if server.result_code is not None and server.result_state is not None:
+                if server.result_state != expected_state:
+                    # CSRF guard — state must match what we generated.
+                    logger.warning(
+                        "OAuth state mismatch — possible CSRF or stale flow"
+                    )
+                    raise OAuthCancelledError(
+                        "OAuth state parameter did not match — flow rejected"
+                    )
+                return AuthorizationCode(
+                    code=server.result_code, state=server.result_state
+                )
+        raise OAuthTimeoutError(
+            f"Loopback receiver timed out after {timeout_seconds:.0f}s"
+        )
+    finally:
+        server.server_close()
+
+
+# --- Token exchange ----------------------------------------------------------
+
+
+def _redact_authorization(message: str) -> str:
+    """Best-effort redaction of bearer tokens in error messages."""
+    # Match common Authorization header patterns; replace value half.
+    import re
+
+    return re.sub(
+        r"(?i)(authorization\s*[:=]\s*bearer\s+)\S+",
+        r"\1[REDACTED]",
+        message,
+    )
+
+
+def _post_token_endpoint(
+    client: httpx.Client, data: dict
+) -> dict:
+    """POST to TOKEN_ENDPOINT, return parsed JSON, or raise OAuth*Error."""
+    try:
+        response = client.post(TOKEN_ENDPOINT, data=data, timeout=30.0)
+    except httpx.HTTPError as exc:
+        raise OAuthHTTPError(
+            status=None,
+            message=_redact_authorization(f"Network error contacting token endpoint: {exc}"),
+        ) from exc
+
+    if response.status_code >= 400:
+        try:
+            body_text = response.text
+        except Exception:
+            body_text = ""
+        raise OAuthHTTPError(
+            status=response.status_code,
+            message=f"Token endpoint returned {response.status_code}",
+            body=_redact_authorization(body_text),
+        )
+
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise OAuthMalformedResponseError(
+            f"Token endpoint returned non-JSON response: {exc}"
+        ) from exc
+
+
+def _token_blob_from_response(body: dict) -> TokenBlob:
+    """Validate the token-endpoint response and lift it into a TokenBlob.
+
+    The exact key names (``access_token``, ``refresh_token``, ``id_token``,
+    ``expires_in``) are standard OAuth 2.0; OpenAI's actual response shape
+    is verified during U3's live smoke test (deferred to a follow-up
+    session). ``account_email`` comes from the ``email`` claim in the
+    id_token when present; otherwise empty (U5's identity fallback chain
+    handles display).
+    """
+    import time
+
+    access_token = body.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise OAuthMalformedResponseError(
+            "Token endpoint response missing access_token"
+        )
+    refresh_token = body.get("refresh_token") or ""
+    id_token = body.get("id_token") or ""
+    expires_in = body.get("expires_in", 0)
+    try:
+        expires_in_int = int(expires_in)
+    except (TypeError, ValueError):
+        expires_in_int = 0
+    expires_at_unix = int(time.time()) + max(0, expires_in_int)
+
+    # Best-effort email extraction from id_token (unverified — purely for
+    # display; the keyring blob is the auth source of truth, not the
+    # decoded id_token).
+    account_email = body.get("email", "") or ""
+    if isinstance(id_token, str) and id_token and not account_email:
+        account_email = _try_extract_email_from_id_token(id_token)
+
+    return TokenBlob(
+        access_token=access_token,
+        refresh_token=refresh_token if isinstance(refresh_token, str) else "",
+        id_token=id_token if isinstance(id_token, str) else "",
+        expires_at_unix=expires_at_unix,
+        account_email=account_email if isinstance(account_email, str) else "",
+    )
+
+
+def _try_extract_email_from_id_token(id_token: str) -> str:
+    """Decode the id_token's payload base64 segment and read 'email'.
+
+    No signature verification — purely for display fallback. If anything
+    goes wrong, returns empty string.
+    """
+    try:
+        import json as _json
+
+        segments = id_token.split(".")
+        if len(segments) < 2:
+            return ""
+        # Base64-url-decode the payload segment (middle one).
+        payload_b64 = segments[1]
+        # Add padding back if missing.
+        padding = 4 - (len(payload_b64) % 4)
+        if padding != 4:
+            payload_b64 = payload_b64 + ("=" * padding)
+        payload_json = base64.urlsafe_b64decode(payload_b64).decode("utf-8")
+        payload = _json.loads(payload_json)
+        email = payload.get("email")
+        return email if isinstance(email, str) else ""
+    except Exception:
+        return ""
+
+
+def exchange_code_for_token(
+    code: str,
+    verifier: str,
+    redirect_uri: str,
+    *,
+    client: Optional[httpx.Client] = None,
+) -> TokenBlob:
+    """Exchange the authorization code for a token blob.
+
+    The ``client`` parameter lets tests inject ``httpx.MockTransport``;
+    production callers pass None and let this function manage its own
+    Client.
+    """
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": CLIENT_ID,
+        "code_verifier": verifier,
+    }
+    if client is None:
+        with httpx.Client() as owned:
+            body = _post_token_endpoint(owned, data)
+    else:
+        body = _post_token_endpoint(client, data)
+    return _token_blob_from_response(body)
+
+
+def refresh_token_blob(
+    refresh_token: str,
+    *,
+    client: Optional[httpx.Client] = None,
+) -> TokenBlob:
+    """Use a refresh_token to obtain a fresh access token blob."""
+    if not refresh_token:
+        raise OAuthMalformedResponseError("refresh_token is empty")
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": CLIENT_ID,
+    }
+    if client is None:
+        with httpx.Client() as owned:
+            body = _post_token_endpoint(owned, data)
+    else:
+        body = _post_token_endpoint(client, data)
+    blob = _token_blob_from_response(body)
+    # Some OAuth servers return a new refresh_token; some don't. If the
+    # response didn't carry one, preserve the previous value so the
+    # caller's persisted state stays usable.
+    if not blob.refresh_token:
+        blob = TokenBlob(
+            access_token=blob.access_token,
+            refresh_token=refresh_token,
+            id_token=blob.id_token,
+            expires_at_unix=blob.expires_at_unix,
+            account_email=blob.account_email,
+        )
+    return blob

--- a/core/spine/log_redaction.py
+++ b/core/spine/log_redaction.py
@@ -1,0 +1,41 @@
+"""Shared redaction helpers for credential-bearing log lines.
+
+Both ``core/spine/chatgpt_oauth_flow`` and ``core/codex_client`` need to
+scrub ``Authorization: Bearer <token>`` from exception messages and
+HTTP-error bodies before they propagate into log files or bug-report
+attachments. This module owns the single canonical regex so both
+callers agree on what gets redacted (R-S4 from the doc-review).
+
+Spine-safe: stdlib only (``re``). No PySide6, litellm, or httpx at
+top level — ``tests/test_spine_imports.py`` enforces this.
+
+Add new patterns here as new credential formats arrive (refresh
+tokens with distinguishable prefixes, raw API keys in error bodies,
+etc.). Callers stay one-line.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+# Authorization: Bearer <token>   or   authorization=Bearer <token>
+# Replaces the value half with [REDACTED]; case-insensitive.
+_BEARER_PATTERN = re.compile(
+    r"(?i)(authorization\s*[:=]\s*bearer\s+)\S+"
+)
+
+
+def redact_bearer_tokens(text: str) -> str:
+    """Replace bearer-token values in ``text`` with ``[REDACTED]``.
+
+    Returns ``text`` unchanged when there's nothing to redact, so
+    callers can pass this through unconditionally without paying
+    for a no-op rewrite.
+    """
+    if not text:
+        return text
+    return _BEARER_PATTERN.sub(r"\1[REDACTED]", text)
+
+
+__all__ = ["redact_bearer_tokens"]

--- a/docs/brainstorms/2026-05-12-chatgpt-subscription-auth-requirements.md
+++ b/docs/brainstorms/2026-05-12-chatgpt-subscription-auth-requirements.md
@@ -1,0 +1,161 @@
+---
+date: 2026-05-12
+topic: chatgpt-subscription-auth
+---
+
+# ChatGPT Subscription Auth
+
+## Summary
+
+A "Sign in with ChatGPT" auth option that lets ChatGPT Plus/Pro subscribers use Scene Ripper's LLM features against their existing subscription quota instead of paying for OpenAI API tokens. The existing API-key path remains unchanged as the alternative; users pick one auth mode globally in settings.
+
+---
+
+## Problem Frame
+
+Scene Ripper has a meaningful LLM-backed surface — chat agent, clip description, shot classification, cinematography analysis, custom queries, composer review, gaze analysis. Today, all of those features require the user to supply an OpenAI API key (or another provider's API key) and to top up a separate billing account.
+
+A real segment of Scene Ripper's power users already pay $20–$200/month for ChatGPT Plus or Pro. For those users, configuring and paying for the OpenAI API *in addition* to the subscription they already have feels insulting enough that they simply leave the AI features off. The result: a chunk of the app's differentiating capability is shelf-ware for the segment most likely to value it.
+
+Recent ecosystem precedent (Hermes, OpenCode, Roo Code) demonstrates a viable OAuth pattern against OpenAI's Codex auth endpoint that uses a user's ChatGPT subscription quota for inference. The pattern is gray-zone with respect to OpenAI's Terms of Service — not officially endorsed, not officially prohibited — but it is tolerated in practice and used by multiple production tools today. An OpenAI engineer has loosely characterized the category as "permissive" while disclaiming legal authority.
+
+---
+
+## Actors
+
+- A1. ChatGPT Plus/Pro subscriber (target user): an existing Scene Ripper user who pays for ChatGPT and has been skipping the AI features rather than paying for the OpenAI API on top.
+- A2. Existing API-key user: a Scene Ripper user who has already configured an OpenAI, Anthropic, Gemini, or other API key and uses the AI features today via that path.
+
+---
+
+## Key Flows
+
+- F1. First-time sign-in with ChatGPT
+  - **Trigger:** User opens settings and selects "Use ChatGPT subscription" / "Sign in with ChatGPT."
+  - **Actors:** A1
+  - **Steps:** App opens the user's default browser to OpenAI's sign-in page. User completes sign-in to chatgpt.com. App receives the token from the OAuth callback. App stores the token in secure OS storage. Settings updates to show the signed-in identity and confirms ChatGPT subscription is now the active auth mode.
+  - **Outcome:** All LLM-backed features in the app route inference via the user's ChatGPT subscription quota.
+  - **Covered by:** R1, R2, R6, R9
+
+- F2. Returning user with a valid token
+  - **Trigger:** User launches the app; subscription mode is the previously selected auth mode; stored token is still valid.
+  - **Actors:** A1
+  - **Steps:** App reads the stored token from secure storage on startup and resumes subscription mode without prompting.
+  - **Outcome:** AI features work immediately; user sees no auth interruption.
+  - **Covered by:** R9, R10
+
+- F3. Expired or revoked token
+  - **Trigger:** A previously stored token has expired or been revoked; an LLM-backed feature is invoked.
+  - **Actors:** A1
+  - **Steps:** App attempts a refresh; on failure, surfaces a clear in-app prompt: "Your ChatGPT sign-in has expired — please sign in again." User can re-run sign-in or switch to API-key mode.
+  - **Outcome:** No silent failures; the user understands what happened and what to do.
+  - **Covered by:** R10, R11
+
+- F4. Switching auth modes
+  - **Trigger:** User changes the auth-mode toggle in settings.
+  - **Actors:** A1, A2
+  - **Steps:** User selects the other mode in settings. App applies the change to all subsequent LLM-backed feature calls without requiring a restart.
+  - **Outcome:** The next LLM call uses the newly selected mode.
+  - **Covered by:** R4, R5
+
+- F5. Long batch operation when quota is near the limit
+  - **Trigger:** User in subscription mode initiates a batch LLM operation (e.g., describe across many clips).
+  - **Actors:** A1
+  - **Steps:** App estimates likely quota consumption against the user's remaining subscription quota. If the operation is likely to exceed remaining quota, the app warns *before* starting and gives the user a clear choice (proceed anyway, cancel, or switch to API-key mode). If the user proceeds and hits the quota wall mid-operation, the app surfaces a quota-specific error rather than a generic rate-limit message.
+  - **Outcome:** Users do not get blindsided by quota walls mid-batch; the failure mode is legible and recoverable.
+  - **Covered by:** R12, R13
+
+---
+
+## Requirements
+
+**Authentication and sign-in**
+- R1. The app provides a "Sign in with ChatGPT" action in settings that initiates a device-code OAuth flow against OpenAI's Codex auth endpoint, without requiring Codex CLI or any other external OpenAI tool to be installed.
+- R2. The OAuth flow opens the user's default browser to OpenAI's sign-in page; on successful authorization, the app receives and stores the resulting token without further user action.
+- R3. The app handles auth-failure cases — no internet, user cancels in the browser, OpenAI rejects the request — with clear, specific in-app error messages and does not change the current auth mode on failure.
+
+**Auth-mode selection and settings**
+- R4. Settings exposes a single global auth-mode toggle: "Use ChatGPT subscription" or "Use API key." The choice applies to every LLM-backed feature in the app; routing is not configurable per-operation.
+- R5. Switching auth modes takes effect immediately for subsequent LLM calls; no app restart is required.
+- R6. While ChatGPT subscription mode is active, settings displays the currently signed-in identity (account email or display name from the OAuth response).
+- R14. Settings provides a "Sign out" action that clears stored tokens and reverts the app to a state where the user must pick an auth mode again.
+
+**LLM feature routing**
+- R7. When ChatGPT subscription mode is active, every LLM-backed feature in the app — chat agent, describe, classify-shots, cinematography, custom-query, composer review, gaze — routes inference requests through the ChatGPT subscription token against the Codex backend.
+- R8. When API-key mode is active, every LLM-backed feature behaves exactly as it does today: no observable difference from the current behavior, and no new dependencies on subscription-auth code paths.
+
+**Token storage and lifecycle**
+- R9. Tokens are stored in secure OS storage (macOS Keychain on macOS, platform equivalent elsewhere) — never in plaintext on disk.
+- R10. The app refreshes tokens automatically when they expire and the refresh succeeds, without user interaction.
+- R11. When a token is unrecoverable — refresh fails, account revoked, OpenAI rejects the credential — the app surfaces a clear in-app prompt asking the user to sign in again, rather than failing LLM calls silently or with raw error text.
+
+**Quota awareness**
+- R12. Before initiating a batch operation likely to consume substantial subscription quota (describe / classify / custom-query across many clips), the app estimates expected consumption and warns the user when remaining quota is likely insufficient — before starting the operation.
+- R13. When a quota-related error is returned mid-operation, the app surfaces a quota-specific error message (clearly framed as "you've hit your ChatGPT Plus quota") with explicit next-step options (wait and retry, or switch to API-key mode), rather than a generic rate-limit error.
+
+**Compatibility and preservation**
+- R15. Account switching is supported via Sign out → Sign in; no explicit multi-account UI is provided in v1.
+- R16. No change to non-LLM features (transcription, scene detection, vision/ML, embeddings, OCR, face detection, audio analysis) — they continue using their existing local or external paths regardless of auth mode.
+- R17. Existing user settings for OpenAI, Anthropic, Gemini, and other API keys are preserved and remain fully functional when API-key mode is active.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R3.** Given the user clicks "Sign in with ChatGPT" with no internet connection, when the OAuth flow fails to reach OpenAI, the app shows a specific "Could not reach OpenAI to sign in — check your connection" message and leaves the current auth mode unchanged.
+- AE2. **Covers R8.** Given the user has API-key mode active and has never signed in with ChatGPT, when they invoke any LLM-backed feature, the request routes through the configured API key exactly as today, with no new code path introduced by this feature.
+- AE3. **Covers R11.** Given a previously valid subscription token has been revoked by OpenAI, when the user invokes an LLM-backed feature, the app surfaces a "Your ChatGPT sign-in has expired — please sign in again" prompt and offers the option to re-authenticate or switch to API-key mode, rather than failing the LLM call with a raw error.
+- AE4. **Covers R12, R13.** Given the user is in subscription mode and triggers `describe` across 200 clips, when the estimate suggests the operation is likely to exceed remaining quota, the app warns before starting; if the user proceeds anyway and hits the quota wall mid-operation, the app surfaces a quota-specific error with clear next-step options.
+- AE5. **Covers R5.** Given the user is signed in via subscription mode and is mid-conversation in the chat panel, when they switch to API-key mode in settings, the next chat message routes through the API key without requiring an app restart.
+
+---
+
+## Success Criteria
+
+- Scene Ripper users who already subscribe to ChatGPT Plus or Pro and previously did not use the AI features begin using them. The "paying twice" objection no longer applies for that segment.
+- A user can sign in once, complete a normal Scene Ripper session that uses the AI features, and never see a raw OAuth error, an unexplained rate-limit, or an unauthenticated state they don't know how to recover from.
+- Existing API-key users see no behavioral change in their AI-feature workflows.
+- A downstream planner reading this document can specify the OAuth flow mechanics, settings UI changes, token storage layer, LLM-routing changes, and quota-aware UX without needing to invent any product behavior.
+
+---
+
+## Scope Boundaries
+
+- Per-operation auth routing (selecting subscription auth for one job and API key for another within the same session) — explicitly rejected in favor of the global mode toggle.
+- Importing existing Codex CLI credentials from `~/.codex/auth.json` (Approach 3 in the discussion) — deferred. The target user almost certainly does not have Codex CLI installed; this is a v1.1 polish at most.
+- Claude Max (Anthropic OAuth), Gemini OAuth, GitHub Copilot OAuth, or any other provider's subscription-auth path — separate future brainstorm. The v1 architecture should not foreclose adding these, but v1 itself ships ChatGPT only.
+- Multi-account UI / explicit account switching beyond Sign out → Sign in.
+- Scene Ripper running a hosted inference proxy (subsidizing inference on behalf of users) — a different product entirely.
+- Any change to non-LLM features (transcription, scene detection, vision/ML, embeddings, OCR, etc.).
+- Any change to the existing OpenAI / Anthropic / Gemini API-key paths — they remain fully functional as the alternative.
+
+---
+
+## Key Decisions
+
+- **Approach 1 over Approaches 2 and 3:** Scene Ripper runs the OAuth flow itself rather than depending on Codex CLI being installed or imported. Rationale: the target user is a Plus subscriber who has not installed Codex CLI and likely never will; telling them to install another tool to use this one violates the entire pitch ("remove the paying-twice friction" by adding setup-another-OpenAI-tool friction).
+- **Global auth-mode toggle over per-operation routing:** simpler mental model, simpler UI, simpler implementation. Users who want bulk-on-API-key can switch modes; that case is rare enough to not warrant per-job UI surface.
+- **Keep architecture open for Approach 4 without building it:** separate the concept of "auth provider" from "LLM client" so that Claude Max, Gemini OAuth, etc. can be added later without rework.
+- **API-key path preserved unchanged:** users who prefer it, or who hit Plus quota walls, keep their working setup with zero migration.
+- **Subscription mode applies to *all* LLM-backed features, not only OpenAI-flavored model calls:** when subscription mode is active, the app uses the ChatGPT-subscription-exposed models for everything, including features that today might call Anthropic or Gemini under a user's API-key configuration. Rationale: a user who flipped the toggle is saying "use my Plus," not "use my Plus for OpenAI calls and my Anthropic key for Claude calls."
+
+---
+
+## Dependencies / Assumptions
+
+- OpenAI's Codex auth endpoint and the device-code OAuth flow it supports remain accessible to non-Codex applications. This is currently the case for Hermes, OpenCode, Roo Code, and others; OpenAI could revoke this at any point.
+- ChatGPT Plus/Pro subscriptions continue to expose inference quota to clients authenticated via this flow.
+- Terms of Service posture: this feature aligns with current production-tool practice in the category. OpenAI has neither endorsed nor prohibited the pattern. If OpenAI revokes the OAuth client_id, shuts down third-party use, or otherwise blocks this path, the feature breaks for all users until alternative auth is available. Users in API-key mode are unaffected.
+- The Plus quota model in 2026 still rate-limits chat-style usage in 3-hour windows. Bulk inference operations through Scene Ripper can plausibly exhaust quota faster than chat usage would; quota-aware UX is required, not optional.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- [Affects R1][Technical] Which OAuth `client_id` does Scene Ripper use? Borrowing the public Codex CLI client_id (as Hermes appears to) versus attempting to register a separate one — tradeoffs in fragility, ToS posture, and account-revocation blast radius need to be evaluated during planning.
+- [Affects R7][Technical] What is the exact request and response shape expected by the Codex backend, and how does it map onto the app's current LLM-client abstraction (LiteLLM-based)? Whether this requires a separate non-LiteLLM client path, a custom LiteLLM provider, or a wrapper around the existing client is a planning decision.
+- [Affects R12][Needs research] Does the Codex backend expose remaining-quota information in any header or endpoint that the app can use for pre-flight estimates? If not, the warning in R12 needs a heuristic (estimated tokens per clip × clip count vs. a user-supplied or default budget) rather than a real check.
+- [Affects R9][Technical] Which secure storage library / mechanism is used on each supported platform? `keyring` on Python is a likely candidate but the exact selection is planning territory.
+- [Affects R12, R13] What is the user-facing wording for the quota-warning prompt and quota-exhausted error? Wording can be settled at planning or in implementation review.

--- a/docs/plans/2026-05-12-001-feat-chatgpt-subscription-auth-plan.md
+++ b/docs/plans/2026-05-12-001-feat-chatgpt-subscription-auth-plan.md
@@ -1,0 +1,811 @@
+---
+title: feat: ChatGPT subscription auth (Sign in with ChatGPT)
+type: feat
+status: active
+date: 2026-05-12
+deepened: 2026-05-12
+origin: docs/brainstorms/2026-05-12-chatgpt-subscription-auth-requirements.md
+---
+
+# feat: ChatGPT subscription auth (Sign in with ChatGPT)
+
+## Summary
+
+Add a "Sign in with ChatGPT" auth path so ChatGPT Plus/Pro subscribers can use Scene Ripper's LLM features against their subscription quota. The plan introduces a global auth-mode toggle in settings, a self-contained OAuth flow (PKCE + loopback, the Codex CLI pattern), keyring-backed token storage, a tiny LLM-routing chokepoint that all five direct `litellm.completion()` call sites in `core/analysis/*` migrate through, plus subscription-aware error and quota UX. The existing API-key path remains the alternative and is fully preserved.
+
+---
+
+## Problem Frame
+
+Scene Ripper's AI surface is meaningful but optional — a real segment of power users who already pay for ChatGPT Plus/Pro currently leave the AI features off rather than pay for the OpenAI API on top of their subscription. The product decision to address this unlock (vs. cost-replace) play, the user segment, the scope, and the gray-zone ToS posture are all settled in origin (see `docs/brainstorms/2026-05-12-chatgpt-subscription-auth-requirements.md`). This plan focuses on *how* to deliver R1–R17 cleanly inside the current PySide6 / LiteLLM / spine / MCP architecture without breaking the existing API-key path.
+
+---
+
+## Requirements
+
+This plan implements the requirements from the origin document. Each implementation unit cites the R-IDs it advances.
+
+- R1–R3. OAuth sign-in flow with clear error handling
+- R4–R6, R14. Settings auth-mode toggle, identity display, sign-out
+- R7. Subscription mode applies to every LLM-backed feature (with one correction below)
+- R8. API-key mode unchanged
+- R9–R11. Secure storage, refresh, re-auth UX
+- R12–R13. Quota-aware UX
+- R15–R17. Single-account v1, no impact to non-LLM features, existing API-key configurations preserved
+
+**Origin actors:** A1 (ChatGPT Plus/Pro subscriber), A2 (existing API-key user)
+
+**Origin flows:** F1 (first-time sign-in), F2 (returning user), F3 (expired/revoked token), F4 (switching auth modes), F5 (batch operation near quota)
+
+**Origin acceptance examples:** AE1 (no internet → R3), AE2 (API-key mode unchanged → R8), AE3 (revoked token → R11), AE4 (quota warn + mid-job error → R12, R13), AE5 (mid-conversation mode switch → R5)
+
+---
+
+## Scope Boundaries
+
+- Per-operation auth routing (origin scope boundary — global toggle only)
+- Importing existing Codex CLI credentials from `~/.codex/auth.json` (deferred v1.1 polish)
+- Claude Max, Gemini OAuth, GitHub Copilot OAuth — architecture leaves room; v1 implements neither
+- Multi-account UI / explicit account switching beyond Sign out → Sign in
+- Hosted inference proxy (centrally-paid inference) — different product
+- Any change to non-LLM features (transcription, scene detection, vision/ML, embeddings, OCR-pipeline non-VLM tier, audio)
+- Changing the existing API-key path — it stays functional, untouched
+- `gaze` analysis is treated as out of scope for R7 because `core/analysis/gaze.py` is MediaPipe-only with no LLM call. R7 listed it; this is a requirements correction surfaced during research, not a plan-level exclusion of LLM work that actually exists
+
+### Deferred to Follow-Up Work
+
+- Feature flag / gradual rollout gating: the origin doc did not call for one and the auth path is opt-in by user action (sign-in click), but a settings-level flag could be added later if early-access gating becomes desirable
+- A pre-flight quota probe of the Codex backend (if/when the backend ever exposes remaining-quota in a header) — current plan uses a heuristic estimator
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+**LLM client and routing**
+- `core/llm_client.py` — `ProviderConfig`, `ProviderType`, `LLMClient.stream_chat`/`chat` (async), `complete_with_local_fallback` (sync, with Ollama fallback for 3 remix sequencers: storyteller, exquisite_corpus, free_association), `complete_with_enum_constraint` (Ollama-only, used by word_llm_composer via spine — unaffected), `create_provider_config_from_settings`. Note: `core/remix/drawing_vlm.py` uses `LLMClient.chat` (a separate path covered by U6's `LLMClient` update).
+- Direct `litellm.completion()` call sites (the surface R7 actually requires touching):
+  - `core/analysis/description.py` (lines 325, 683)
+  - `core/analysis/cinematography.py` (lines 561, 694)
+  - `core/analysis/custom_query.py` (line 160)
+  - `core/analysis/ocr.py` (line 265)
+  - `core/analysis/shots_cloud.py` (line 152)
+- Chat surface: `ui/chat_worker.py`, `ui/chat_panel.py`, `ui/main_window.py` (chat-message flow ~L2195, settings flow ~L1706)
+
+**Settings + keyring (the patterns to mirror)**
+- `core/settings.py` — `Settings` dataclass; per-provider keyring constants (`KEYRING_OPENAI_API_KEY`, etc.); symmetric `get_<provider>_api_key()` / `set_<provider>_api_key()` helpers; `_get_password_from_keyring_services()` walks current + legacy service names for migration; service name `com.algorithmic-filmmaking.scene-ripper`
+- `ui/settings_dialog.py` — 6-tab dialog; "API Keys" tab uses `QLineEdit(EchoMode=Password)` + Show toggle; save flow `_on_accept` → `_save_to_settings` → `_save_llm_api_keys`; propagation to running components via `ui/main_window.py:_apply_settings`
+- Existing keyring access already abstracted through `_set_provider_api_key_in_keyring(keyring_key, value)` and `_get_provider_api_key_from_keyring(keyring_key)` — reuse for the OAuth token blob
+
+**Worker pattern**
+- `ui/workers/base.py` — `CancellableWorker(QThread)` with `threading.Event` cancellation; subclasses check `is_cancelled()` between blocking calls (not during)
+- `ui/chat_worker.py` — uses `asyncio.run(self._async_run())` inside `run()`, the pattern to mirror for polling-based work
+- `ui/workers/free_association_worker.py` — documents the constraint that `litellm.completion` cannot be interrupted mid-call; same applies to `httpx.post()` during OAuth code exchange (acceptable since each call is bounded and we check cancellation between iterations)
+- Browser launch convention: `QDesktopServices.openUrl(QUrl(url))` on the main thread (used 10+ places in `ui/main_window.py`)
+
+**Spine layering**
+- `core/spine/` is flat, modules sit at `core/spine/<topic>.py`
+- `tests/test_spine_imports.py` enforces no `PySide6`, `mpv`, `av`, `faster_whisper`, `paddleocr`, `mlx_vlm` at module import; `httpx` and `keyring` are allowed
+- Only `core/spine/words.py` imports from `core/llm_client.py` today, and only lazily inside a function body — the established pattern for cross-layer LLM access from spine
+
+**MCP server**
+- `scene_ripper_mcp/server.py` — `FastMCP` with `lifespan` that calls `load_settings()` once at startup (line ~45); LLM-routed tools live in `scene_ripper_mcp/tools/jobs.py` (`start_describe`, `start_analyze_classify`, `start_analyze_cinematography`, `start_custom_query`, `start_analyze_clips`, `start_extract_text`); the server runs as an independent process — it shares the JSON config and the keyring with the GUI but not in-memory state
+
+### Institutional Learnings
+
+From `docs/solutions/`:
+- `runtime-errors/transcription-mlx-auto-fallback-groq-key-20260512.md` — the keyring-only / read-at-call-time / pre-flight configuration gate pattern. Mirror it for OAuth tokens (storage, gating, configuration-error surfacing)
+- `runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md` — `Qt.UniqueConnection` + per-handler guard flag + `@Slot()` decorator + guard reset on new operation. Mandatory for the OAuth worker (a duplicate `auth_complete` could double-write the token or open two browser tabs)
+- `ui-bugs/pyside6-thumbnail-source-id-mismatch.md` and `ui-bugs/timeline-widget-sequence-mismatch-20260124.md` — single live source of truth; do not cache auth-mode at construction time, read it at call time from `core/settings.py`
+- `logic-errors/circular-import-config-consolidation.md` — auth abstraction lives in a neutral spine-safe module (no PySide6/LiteLLM at top level), not inside `core/llm_client.py` or `core/chat_tools.py`
+- `security-issues/url-scheme-validation-bypass.md` — validate scheme allowlist (`https://` for OpenAI, `http://localhost:*` for the loopback redirect) before any URL is used
+- `reliability-issues/subprocess-cleanup-on-exception.md` — wrap any transient resources (loopback HTTP server, polling timers) in `try/finally` inside the worker's `run()`
+
+### External References
+
+- Codex CLI source (open-source) — reference implementation of the OAuth flow against OpenAI's Codex auth endpoint. Plan-time: borrow the client_id, endpoints, and scopes from Codex CLI's source as the starting point; implementation discovers the exact constants
+- Hermes-agent (Nous Research) — concrete demonstration of the same pattern in a desktop app using device-code phrasing for what is in fact PKCE + loopback. Reference for token storage shape and auth-mode UX
+- Origin doc Dependencies / Assumptions — captures the ToS gray-zone posture and what breaks if OpenAI revokes the client_id
+
+---
+
+## Key Technical Decisions
+
+- **The LLM-routing chokepoint is introduced and the five direct `core/analysis/*` call sites migrate through it.** The alternative ("subscription mode is chat-only in v1") violates R7. Migration is mechanical: one new function in `core/llm_client.py` mirroring the `litellm.completion()` signature, five callsite swaps. (User-confirmed at Phase 5.1.5.)
+- **OAuth flow is PKCE + loopback redirect, not RFC 8628 device-code.** The origin doc said "device-code" loosely; the actual Codex CLI flow OpenAI exposes is authorization-code + PKCE + `http://localhost:<port>` redirect. Plan uses the latter throughout. Same UX from the user's perspective (browser opens, they sign in, app gets a token).
+- **`gaze` is excluded from R7's scope** because `core/analysis/gaze.py` performs no LLM call. Treated as a requirements correction, not a planning decision. (see origin: R7)
+- **The new auth abstraction lives in `core/spine/chatgpt_auth.py`** (spine-safe, no top-level PySide6/LiteLLM imports). This avoids the circular-import risk of putting it in `core/llm_client.py` or `core/chat_tools.py`, and pre-positions Approach 4 (Claude Max, Gemini OAuth) as future drop-in modules behind the same `AuthMode` interface.
+- **Auth-mode state is read at call time from `core/settings.py`**, never cached in worker or client constructors. This is what makes AE5 (mid-conversation switch without restart) structurally easy — workers are already short-lived (chat worker is recreated per message; analysis workers re-resolve `api_key` per-call).
+- **The Codex backend gets its own thin HTTP client at `core/codex_client.py`** (httpx-based). LiteLLM does not speak the Codex backend's request/response shape; trying to force-fit it into LiteLLM as a custom provider is more invasive than a small, focused client.
+- **OAuth tokens are stored as a single JSON-serialized blob under one new keyring key** (`KEYRING_CHATGPT_OAUTH_TOKEN`). Storing `access_token`, `refresh_token`, `expires_at`, `account_email` separately would create atomicity hazards during refresh. The blob is reread on each LLM call (microseconds).
+- **MCP server reloads settings + token on each LLM-routed tool invocation.** Cheap (JSON read + one keyring read); avoids the staleness trap where a GUI sign-in is invisible to a running MCP server.
+- **`complete_with_local_fallback()` skips the Ollama fallback when subscription mode is active.** Falling back from a Plus subscription to a (potentially uninstalled) local Ollama is worse UX than surfacing the auth or quota error; subscription users explicitly chose subscription. The fallback path stays intact for API-key mode (unchanged).
+- **No environment-variable override for the OAuth token.** API keys have env-var overrides for power users; OAuth tokens are short-lived secrets with refresh semantics — keyring-only.
+- **Test posture for OAuth + worker units: test-first.** Security-sensitive, no existing patterns in the repo, high-blast-radius bugs (token persistence, duplicate signals, scheme validation) all benefit from failing tests up front. Other units follow the project's normal test-alongside posture.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- *Should the auth-mode toggle live in a new tab or in API Keys?* — Place in the existing "API Keys" tab. Grouped naturally with other LLM credentials; avoids adding tab surface. (See U5.)
+- *Codex backend or full LiteLLM custom provider?* — Standalone `core/codex_client.py`. (See Key Technical Decisions.)
+- *Token blob format in keyring?* — Single JSON blob under one keyring key. (See Key Technical Decisions.)
+- *MCP server staleness handling?* — Per-call settings reload. (See Key Technical Decisions.)
+- *Ollama fallback behavior in subscription mode?* — Skipped. (See Key Technical Decisions.)
+- *PKCE + loopback or RFC 8628 device-code?* — PKCE + loopback (the actual Codex CLI flow). (See Key Technical Decisions.)
+
+### Deferred to Implementation
+
+- *Exact OAuth `client_id`, authorization endpoint, token endpoint, and scopes.* Pulled from Codex CLI's open-source source at implementation time; constants land in `core/spine/chatgpt_auth.py`. The plan does not lock these in — they may change as OpenAI evolves the endpoint.
+- *Exact request/response shape for the Codex backend.* Discovered by reading Codex CLI's client; encoded in `core/codex_client.py`.
+- *Whether the Codex backend returns a remaining-quota signal in any response header.* If yes, the heuristic estimator in U8 can be replaced with a real check; if no, the heuristic stands.
+- *Specific user-facing wording for the quota warning, the re-auth prompt, the sign-in success toast.* Wording lands during implementation review.
+- *Exact heuristic for the pre-flight quota warning* (tokens per clip × clip count × safety margin). Calibrated against real Codex behavior during implementation.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+**Layered shape:**
+
+```
+                  ┌──────────────────────────────────────────┐
+                  │  ui/settings_dialog.py                    │
+                  │  ui/workers/oauth_worker.py               │
+                  │  ui/chat_worker.py, ui/chat_panel.py      │
+                  └──────────────────┬───────────────────────┘
+                                     │ Qt signals, settings I/O
+                                     ▼
+                  ┌──────────────────────────────────────────┐
+                  │  core/llm_client.py                       │
+                  │   - complete_routed()  ← new chokepoint   │
+                  │   - existing helpers route through it     │
+                  └────┬───────────────────────────┬─────────┘
+                       │ auth_mode == api_key      │ auth_mode == subscription
+                       ▼                            ▼
+              litellm.completion()       core/codex_client.py
+                                                   │
+                                                   ▼
+                                         OpenAI Codex backend
+                                                   ▲
+                                                   │ bearer token (refreshed)
+                  ┌──────────────────────────────────────────┐
+                  │  core/spine/chatgpt_auth.py               │
+                  │   - AuthMode enum                         │
+                  │   - load_active_auth() (reads settings    │
+                  │     + keyring at call time)               │
+                  │   - PKCE/loopback OAuth flow              │
+                  │   - token refresh                         │
+                  └────────────────┬─────────────────────────┘
+                                   │ token blob (JSON) ⇄ keyring
+                                   ▼
+                       core/settings.py keyring helpers
+                       (KEYRING_CHATGPT_OAUTH_TOKEN)
+```
+
+**Auth-mode state machine:**
+
+```
+   ┌──────────────────┐  user picks API key in settings   ┌──────────────────┐
+   │  Unauthenticated │ ────────────────────────────────► │   API-key mode   │
+   │ (first launch /  │                                    │ (existing path,   │
+   │  signed out)     │ ◄──────────────────────────────── │  unchanged)       │
+   └────────┬─────────┘  user clicks "Sign out" /          └─────────┬────────┘
+            │            clears API key                              │
+            │ user picks subscription + sign-in succeeds              │ user switches
+            ▼                                                          ▼
+   ┌──────────────────┐  token expires + refresh fails    ┌──────────────────┐
+   │ Subscription mode│ ────────────────────────────────► │  Subscription:   │
+   │  + valid token   │                                    │  re-auth needed   │
+   └──────────────────┘ ◄──────────────────────────────── └──────────────────┘
+                          user signs in again
+```
+
+---
+
+## Implementation Units
+
+### U1. Auth-mode and token storage on the Settings layer
+
+**Goal:** Extend `core/settings.py` with the new auth-mode field, OAuth keyring constants, and symmetric token-blob helpers — the foundation every other unit reads from.
+
+**Requirements:** R4, R6, R9, R14, R17
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `core/settings.py`
+- Test: `tests/test_settings.py`
+
+**Approach:**
+- Add to `Settings` dataclass: `auth_mode: str = "api_key"` (values: `"api_key"`, `"subscription"`), `chatgpt_account_email: str = ""` (display-only, non-secret)
+- Add load/save handling for both fields in `_load_from_json` / `_settings_to_json`
+- Add new keyring constant `KEYRING_CHATGPT_OAUTH_TOKEN`
+- Add helpers `get_chatgpt_oauth_token()` / `set_chatgpt_oauth_token(token_blob: dict | None)` / `clear_chatgpt_oauth_token()`, mirroring the existing per-provider keyring helpers but operating on a JSON-serialized blob
+- Token blob shape: `{"access_token", "refresh_token", "id_token", "expires_at_unix", "account_email"}` — opaque to `core/settings.py`, parsed by `core/spine/chatgpt_auth.py`
+- No env-var override for the token (intentional, see Key Technical Decisions); env-var override fine for `auth_mode` if desired (low priority)
+
+**Execution note:** Test-first. Token persistence is high-blast-radius; mocks should drive the design.
+
+**Patterns to follow:**
+- `core/settings.py` existing keyring helpers (`_set_provider_api_key_in_keyring`, `_get_password_from_keyring_services`)
+- Tests at `tests/test_settings.py:209-227` for keyring mocking via `sys.modules` injection
+
+**Test scenarios:**
+- Happy path: set token blob → get returns the same blob → clear → get returns None
+- Edge case: JSON serialization round-trip preserves all fields and types (especially `expires_at_unix` int)
+- Edge case: `auth_mode` defaults to `"api_key"` for migrating users (existing config.json with no auth_mode key)
+- Error path: keyring set fails (no Keychain access) → helper returns False, no crash
+- Error path: keyring get returns malformed JSON → helper returns None, logs warning
+- Error path: keyring delete on missing key → no crash
+- Integration: `auth_mode = "subscription"` persists across `save_settings()` / `load_settings()` round trip
+
+**Verification:**
+- `tests/test_settings.py` passes for the new helpers
+- Loading an existing config.json without `auth_mode` produces a `Settings` with `auth_mode = "api_key"` (backward compatibility)
+
+---
+
+### U2. Auth-state module (spine-safe)
+
+**Goal:** Provide a neutral, zero-dependency module that owns the active auth state — what mode is on, is the token valid, when does it expire — read at call time by every consumer.
+
+**Requirements:** R5, R7, R8 (via the read-at-call-time discipline that makes AE5 work)
+
+**Dependencies:** U1
+
+**Files:**
+- Create: `core/spine/chatgpt_auth.py`
+- Test: `tests/test_chatgpt_auth.py`
+
+**Approach:**
+- Define `AuthMode` enum (`API_KEY`, `SUBSCRIPTION`) and `AuthIdentity` dataclass (`account_email`, `expires_at_unix`, `seconds_until_expiry`)
+- Top-level imports: stdlib only (`time`, `json`, `dataclasses`, `enum`). No PySide6, no LiteLLM, no httpx at module scope. Lazy-import `keyring` inside functions if needed (it's already used by `core/settings.py` so it'd be in `sys.modules` anyway).
+- Pure-function API:
+  - `load_active_auth() -> tuple[AuthMode, AuthIdentity | None]` — reads `Settings.auth_mode` + the token blob from keyring; returns the current state
+  - `is_token_expired(identity: AuthIdentity, leeway_seconds: int = 60) -> bool`
+  - Constants for `CLIENT_ID`, `AUTHORIZATION_ENDPOINT`, `TOKEN_ENDPOINT`, `REDIRECT_URI_HOST`, `SCOPES` — borrowed from Codex CLI source at implementation time (Deferred to Implementation question)
+- `tests/test_spine_imports.py` must continue to pass — this module must NOT trigger any forbidden imports
+
+**Execution note:** Test-first. The boundary test is enforced; structural mistakes here fail loudly.
+
+**Patterns to follow:**
+- `core/spine/words.py:451` — lazy import of `core/llm_client` inside a function body, the existing pattern for cross-layer access from spine
+- `tests/test_spine_imports.py` — list of forbidden imports
+
+**Test scenarios:**
+- Happy path: settings configured for API-key mode → `load_active_auth()` returns `(API_KEY, None)`
+- Happy path: settings configured for subscription mode with a valid blob → `load_active_auth()` returns `(SUBSCRIPTION, AuthIdentity(...))`
+- Edge case: settings configured for subscription but no blob in keyring → `(SUBSCRIPTION, None)` (the "re-auth needed" state)
+- Edge case: token expires at `now - 1s` → `is_token_expired()` returns True; at `now + 120s` with leeway 60 → False
+- Integration: importing `core.spine.chatgpt_auth` does not pull `PySide6`, `litellm`, or `mlx_vlm` into `sys.modules` (extend `tests/test_spine_imports.py`)
+
+**Verification:**
+- `tests/test_chatgpt_auth.py` passes
+- `tests/test_spine_imports.py` passes with the new module in the spine list
+
+---
+
+### U3. OAuth flow (PKCE + loopback, GUI-free)
+
+**Goal:** Implement the PKCE + loopback OAuth flow against OpenAI's Codex auth endpoint as a pure-Python module — no Qt dependency, fully unit-testable.
+
+**Requirements:** R1, R2, R3, R10
+
+**Dependencies:** U2
+
+**Files:**
+- Create: `core/spine/chatgpt_oauth_flow.py`
+- Test: `tests/test_chatgpt_oauth_flow.py`
+
+**Approach:**
+- Pure-Python module using `httpx` (already a core dep) and stdlib `http.server`, `secrets`, `hashlib`, `base64`, `urllib.parse`
+- Function-level API (no class state):
+  - `generate_pkce_pair() -> tuple[verifier, challenge]`
+  - `build_authorization_url(verifier_challenge, state) -> tuple[url, redirect_uri]` — picks a random free port on localhost for the loopback receiver
+  - `run_loopback_listener(port, expected_state, timeout_seconds) -> AuthorizationCode | None` — spawns an `http.server.HTTPServer`, accepts one redirect, validates `state`, returns the `code` query param (or None on timeout/cancel)
+  - `exchange_code_for_token(code, verifier, redirect_uri) -> TokenBlob` — POST to TOKEN_ENDPOINT
+  - `refresh_token(refresh_token: str) -> TokenBlob` — POST to TOKEN_ENDPOINT with `grant_type=refresh_token`
+- URL scheme validation everywhere: `https://` for OpenAI endpoints (constant), `http://localhost:*` for the redirect_uri (validated against scheme + hostname allowlist before use). See `docs/solutions/security-issues/url-scheme-validation-bypass.md`.
+- All HTTP via `httpx.Client` so the worker (U4) can inject a `httpx.MockTransport` for tests
+- `try/finally` around the loopback server: `server.server_close()` on every exit path (success, error, timeout, cancellation). See `docs/solutions/reliability-issues/subprocess-cleanup-on-exception.md`.
+- Errors raised as specific exception classes: `OAuthCancelledError`, `OAuthTimeoutError`, `OAuthHTTPError`, `OAuthMalformedResponseError`
+
+**Execution note:** Test-first throughout. Security-sensitive, externally-dependent, no prior art in the repo.
+
+**Technical design:** *(directional, not specification)*
+
+```
+generate_pkce_pair() ──► (verifier, challenge)
+                              │
+build_authorization_url(challenge, state) ──► (auth_url, redirect_uri_with_port)
+                              │
+   ┌──────────────────────────┘
+   │  GUI (U4/U5) opens auth_url in browser
+   ▼
+run_loopback_listener(port, expected_state, timeout) ──► AuthorizationCode
+                              │
+exchange_code_for_token(code, verifier, redirect_uri) ──► TokenBlob
+                              │
+                              ▼
+                        return to caller
+```
+
+**Patterns to follow:**
+- `core/transcription.py` for `httpx.Client` request patterns
+- `tests/test_settings.py` for HTTP mocking via test-injected transports
+
+**Test scenarios:**
+- Happy path: PKCE pair satisfies S256 transform (`challenge == BASE64URL(SHA256(verifier))` without padding)
+- Happy path: `build_authorization_url` produces a URL with `response_type=code`, `code_challenge_method=S256`, the right scopes, and a loopback `redirect_uri` whose port is free
+- Happy path: `run_loopback_listener` returns the `code` when the loopback receives a valid redirect matching `expected_state`
+- Edge case: redirect arrives with mismatched `state` → returns None and emits a specific log line (state-mismatch is a CSRF guard, must be explicit)
+- Edge case: redirect URL has scheme `javascript:` or `file:` → rejected by validator before any parsing
+- Edge case: loopback timeout (no redirect within window) → returns None, server cleanly closed
+- Error path: `exchange_code_for_token` 4xx → `OAuthHTTPError` with the status code and (non-secret-bearing) response body
+- Error path: response missing `access_token` → `OAuthMalformedResponseError`
+- Error path: `refresh_token` 401 → `OAuthHTTPError(401)`; caller (U6) interprets as "re-auth required"
+- Integration: full flow end-to-end via `httpx.MockTransport` — generate pair → build URL → simulate redirect → exchange → assert token blob shape
+
+**Verification:**
+- `tests/test_chatgpt_oauth_flow.py` passes with full path coverage
+- Loopback server confirmed closed (via `port` reusable on next iteration) on every exit path
+
+---
+
+### U4. OAuth worker (Qt wrapper around the flow)
+
+**Goal:** Wrap U3 in a `CancellableWorker` that opens the browser, runs the loopback listener, and emits typed signals back to the settings dialog — without freezing the UI or duplicating signals.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** U3
+
+**Files:**
+- Create: `ui/workers/oauth_worker.py`
+- Test: `tests/test_oauth_worker.py`
+
+**Approach:**
+- Subclass `CancellableWorker`. `run()` uses `asyncio.run(...)` over an async coroutine that orchestrates the U3 functions (the polling-style flow benefits from `await asyncio.sleep()` between cancellation checks, mirroring `ui/chat_worker.py`)
+- Signals (each declared on the class):
+  - `authorization_url_ready = Signal(str)` — emitted when the URL is built; the dialog's slot calls `QDesktopServices.openUrl(QUrl(url))` on the main thread
+  - `auth_complete = Signal(dict)` — emitted exactly once with the token blob; settings dialog persists it via U1 helpers
+  - `auth_failed = Signal(str, str)` — `(category, user_message)`; categories: `"cancelled"`, `"timeout"`, `"network"`, `"rejected"`, `"malformed"`
+- All `connect()` calls in the settings dialog use `Qt.UniqueConnection`. The worker reset its internal `_finished_handled` guard at the top of `run()` (mirrors `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`). Handler slots in the dialog use `@Slot()` decorators and guard their own `_oauth_in_progress` flag.
+- `try/finally` in `run()` ensures the loopback server is closed even on cancellation
+- Cancellation between every async iteration; in-flight `httpx.post()` is non-interruptible (acknowledged constraint from `ui/workers/free_association_worker.py:8`), but each call is short
+
+**Execution note:** Test-first. Signal-duplication and state-mutation-on-failure are the two prior bug classes this worker has to avoid.
+
+**Patterns to follow:**
+- `ui/chat_worker.py` — `asyncio.run()` inside `run()`
+- `ui/workers/free_association_worker.py` — cancellation discipline around blocking HTTP
+- `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md` — UniqueConnection + guard flag + @Slot pattern
+
+**Test scenarios:**
+- Happy path: full flow completes → `authorization_url_ready` fires once, `auth_complete` fires once with the expected token blob, no `auth_failed`
+- Happy path: signals emitted on the worker's thread, slots invoked on the main thread (Qt-standard for queued signals)
+- Edge case: user cancels mid-flow → `auth_failed("cancelled", ...)` fires exactly once; `auth_complete` does not fire; settings/keyring untouched
+- Edge case: loopback timeout → `auth_failed("timeout", ...)` exactly once; loopback server confirmed closed (port reusable)
+- Edge case: two successive sign-in attempts in the same dialog session → second attempt's signals do not bleed into the first attempt's slots (guard flag reset confirmed)
+- Error path: network error during token exchange → `auth_failed("network", ...)`; auth-mode in settings remains unchanged (R3)
+- Error path: malformed token response → `auth_failed("malformed", ...)`
+- Integration: `auth_complete` handler in a test harness writes blob to a mock keyring and updates `Settings.auth_mode` to `"subscription"`; no concurrent write or duplicate write
+
+**Verification:**
+- `tests/test_oauth_worker.py` passes
+- All `connect()` sites use `Qt.UniqueConnection`; `@Slot()` decorators present on every handler
+- No path through the worker mutates `Settings` directly — only via signals received by the settings dialog (single source of truth for state changes)
+
+---
+
+### U5. Settings dialog UI for sign-in
+
+**Goal:** Extend the existing settings dialog with the auth-mode toggle, the "Sign in with ChatGPT" affordance, identity display, and sign-out — wired to U4.
+
+**Requirements:** R4, R5, R6, R14, R17
+
+**Dependencies:** U1, U4
+
+**Files:**
+- Modify: `ui/settings_dialog.py`
+- Test: `tests/test_settings_dialog.py`
+
+**Approach:**
+- Place the new controls in the existing "API Keys" tab (`_create_api_keys_tab`), at the top — above the per-provider key fields. Visually grouped as "OpenAI authentication" with a `QRadioButton` pair: `Sign in with ChatGPT (use my subscription)` / `Use OpenAI API key`.
+- Subscription branch:
+  - When signed out: shows a "Sign in with ChatGPT" button. Click → instantiates `OAuthWorker`, connects signals with `Qt.UniqueConnection`, starts the worker. `authorization_url_ready` slot calls `QDesktopServices.openUrl(QUrl(url))`. `auth_complete` slot persists the blob via U1 helpers, updates the identity label, and clears the in-progress guard.
+  - When signed in: shows the signed-in identity (`Settings.chatgpt_account_email`) and a "Sign out" button. Sign out → `clear_chatgpt_oauth_token()` + reset `chatgpt_account_email`.
+- API-key branch: the existing per-provider key fields, unchanged. Hidden visually when subscription radio is selected (still functional — just not the active mode).
+- `_save_to_settings` writes `auth_mode` and `chatgpt_account_email`; keyring writes are gated as today (`_save_llm_api_keys`)
+- Mode propagation: existing `_apply_settings` in `ui/main_window.py` already recreates per-message chat workers and re-resolves api_keys per-call inside analysis modules; no additional propagation code needed — this is what makes AE5 structurally easy
+
+**Patterns to follow:**
+- `ui/settings_dialog.py:_create_api_keys_tab` (line ~949) for layout
+- `ui/main_window.py:_apply_settings` (line ~1718) for the existing propagation path
+
+**Test scenarios:**
+- Happy path: open dialog with `auth_mode = "api_key"` → API-key radio selected, API-key fields visible
+- Happy path: switch radio to subscription, click Sign In, mock OAuthWorker emits `auth_complete` with blob → blob persisted, identity label shows the account email, save dialog → `Settings.auth_mode = "subscription"` and `chatgpt_account_email` set
+- Happy path: open dialog with `auth_mode = "subscription"` and a valid stored blob → subscription radio selected, identity shown, Sign Out button present
+- Edge case: click Sign Out → `clear_chatgpt_oauth_token()` invoked, identity label cleared, Sign In button reappears
+- Error path: OAuthWorker emits `auth_failed("cancelled", ...)` → no persistence; auth-mode unchanged from its pre-click state; user-facing message visible briefly in the dialog
+- Error path: OAuthWorker emits `auth_failed("network", ...)` → same as cancelled, plus the network category surfaces a "could not reach OpenAI" message (covers AE1, R3)
+- Error path: OAuthWorker emits `auth_failed("timeout", ...)` → Sign-in button re-enabled, brief in-dialog message ("sign-in timed out — the browser window may not have opened; try again"); auth-mode unchanged
+- Error path: OAuthWorker emits `auth_failed("rejected", ...)` and `auth_failed("malformed", ...)` → mirror cancelled handling with category-specific user-facing message; auth-mode unchanged
+- Integration: switch from API-key mode to subscription mode and save → next `load_settings()` returns `auth_mode = "subscription"`; existing OpenAI API key in keyring is *not* deleted (R17)
+
+**Verification:**
+- `tests/test_settings_dialog.py` passes
+- Manual: open dialog, switch modes, save, reopen — state round-trips
+- AE2 holds: a user who never touches subscription mode sees zero behavioral change
+
+---
+
+### U6. LLM-routing chokepoint + Codex backend client
+
+**Goal:** Introduce one routing function in `core/llm_client.py` and a thin `core/codex_client.py` that backs it for subscription mode. This is the single seam every LLM call will go through after U7.
+
+**Requirements:** R7, R8, R10, R11
+
+**Dependencies:** U2, U3 (token refresh logic)
+
+**Files:**
+- Modify: `core/llm_client.py`
+- Create: `core/codex_client.py`
+- Test: `tests/test_llm_routing.py`, `tests/test_codex_client.py`
+
+**Approach:**
+- New function in `core/llm_client.py`: `complete_routed(model, messages, **kwargs)` — same signature shape as `litellm.completion`. At call time:
+  1. `load_active_auth()` from U2
+  2. If `AuthMode.API_KEY` → delegate to `litellm.completion(model, messages, **kwargs)` with the api_key resolved as today via `get_api_key_for_model(model)`. Behavior bit-identical to current code paths (R8)
+  3. If `AuthMode.SUBSCRIPTION` → delegate to `core/codex_client.py:complete(token_blob, model, messages, **kwargs)`. If the token is near expiry, refresh first via U3
+- `core/codex_client.py`:
+  - Thin httpx-based client targeting the Codex backend
+  - `complete(token_blob, model, messages, ...)` POSTs to the Codex completion endpoint with `Authorization: Bearer <access_token>`
+  - On 401 → `TokenExpiredError` (caught by U8)
+  - On 429 → `QuotaExceededError` (caught by U9)
+  - On other 4xx/5xx → `CodexBackendError(status, body)`
+  - Exact URL, request shape, and response normalization are Deferred to Implementation — designed to expose the same response surface (`choices[].message.content`, `usage.*`) that callers expect today
+- Existing `LLMClient.stream_chat` / `chat` / `complete_with_local_fallback` are updated to delegate to `complete_routed` for the cloud branch. The Ollama-fallback inside `complete_with_local_fallback` is gated to API-key mode only (in subscription mode, the auth/quota errors propagate so U8/U9 can handle them).
+
+**Patterns to follow:**
+- `tests/test_llm_client_fallback.py` — `monkeypatch.setattr("litellm.completion", fake)` for mocking
+- `core/transcription.py` for `httpx.Client` usage patterns
+
+**Test scenarios:**
+- Happy path (API-key mode): `complete_routed(model="gpt-4o", messages=[...])` calls `litellm.completion` with the OpenAI api_key from keyring; return shape matches current behavior bit-for-bit (R8)
+- Happy path (subscription mode): `complete_routed` calls into `core/codex_client.py:complete` with the bearer token; response normalized to the same dict shape callers expect
+- Happy path (token near expiry in subscription mode): refresh is called transparently before the LLM call; new blob persisted to keyring; LLM call proceeds with the new access_token
+- Edge case: `auth_mode = "subscription"` but no token in keyring → `TokenMissingError`; UI catches this in U8
+- Error path: `core/codex_client.py:complete` 401 → `TokenExpiredError`; routing helper attempts one refresh; if refresh also 401 → raise to caller
+- Error path: 429 → `QuotaExceededError` with the response body if it carries quota signals
+- Integration: a mock chat-agent call in subscription mode flows through `complete_routed` → `core/codex_client.py:complete` → `httpx.MockTransport` (no live network); assert the exact bearer header was sent and the response was normalized correctly
+- Integration: `complete_with_local_fallback` in subscription mode with the Codex backend returning 429 → `QuotaExceededError` raised, Ollama fallback NOT invoked
+
+**Verification:**
+- `tests/test_llm_routing.py` and `tests/test_codex_client.py` pass
+- API-key mode passes every existing `core/llm_client.py` test unmodified
+- No call to `litellm.completion` survives outside `complete_routed` (post U7)
+
+---
+
+### U7. Migrate direct `litellm.completion()` call sites
+
+**Goal:** Route the five direct `core/analysis/*` call sites through `complete_routed` so that R7 is delivered for every LLM-backed feature, not just chat.
+
+**Requirements:** R7
+
+**Dependencies:** U6
+
+**Files:**
+- Modify: `core/analysis/description.py`
+- Modify: `core/analysis/cinematography.py`
+- Modify: `core/analysis/custom_query.py`
+- Modify: `core/analysis/ocr.py`
+- Modify: `core/analysis/shots_cloud.py`
+- Test: extend `tests/test_description.py`, `tests/test_cinematography.py`, `tests/test_custom_query.py`, `tests/test_ocr.py`, `tests/test_shots_cloud.py` (file names match existing patterns; create if missing)
+
+**Approach:**
+- In each file, replace `litellm.completion(model=..., messages=..., api_key=..., **kwargs)` with `complete_routed(model=..., messages=..., **kwargs)`. The `api_key` resolution inside `complete_routed` handles API-key mode, so the explicit `api_key=` kwarg can be dropped (or left for `complete_routed` to ignore in subscription mode).
+- This is purely mechanical — five call sites, one swap each, identical call signatures
+- No behavior change in API-key mode (R8). Subscription mode now reaches these features (R7).
+
+**Patterns to follow:**
+- Existing call sites themselves — the swap is to use the new helper, not to redesign the calls
+
+**Test scenarios:**
+- Happy path per file (API-key mode): existing test expectations preserved bit-for-bit
+- Integration per file (subscription mode): a parameterized test fixture runs each feature under subscription mode with a `httpx.MockTransport` against `core/codex_client.py` — confirm the call reaches the Codex backend with the right model name and messages
+- Edge case: per-file feature called with `auth_mode = "subscription"` but no token → `TokenMissingError` surfaces (handled by U8)
+
+**Verification:**
+- All five test files pass under both auth modes
+- Grep confirms zero `litellm.completion` calls remain in `core/analysis/*`
+- Existing functional tests for description/cinematography/custom-query/ocr/shots_cloud unchanged in API-key mode
+
+---
+
+### U8. Subscription-mode error UX: re-auth and quota
+
+**Goal:** Translate the new exception types from U6 (`TokenExpiredError`, `TokenMissingError`, `QuotaExceededError`, `CodexBackendError`) into user-visible UX — re-auth prompts and quota-specific errors.
+
+**Requirements:** R3 (cases that surface from runtime), R11, R12, R13
+
+**Dependencies:** U6, U7
+
+**Files:**
+- Modify: `core/llm_client.py` (catch points within `complete_with_local_fallback`, `LLMClient.chat`/`stream_chat`)
+- Modify: `ui/chat_panel.py` (chat error display)
+- Modify: `ui/chat_worker.py` (catch in async path)
+- Modify: `ui/workers/description_worker.py`, `ui/workers/cinematography_worker.py`, `ui/workers/custom_query_worker.py`, `ui/workers/ocr_worker.py`, `ui/workers/shots_cloud_worker.py` (mirror the error-catch pattern across each batch worker matched to the 5 analysis files migrated in U7; confirm exact filenames via grep on the analysis-module imports)
+- Modify: `ui/main_window.py` (re-auth dialog launcher)
+- Test: `tests/test_subscription_error_ux.py`
+
+**Approach:**
+- Define `TokenExpiredError`, `TokenMissingError`, `QuotaExceededError`, `CodexBackendError` in `core/llm_client.py` (or a small `core/llm_errors.py` if it grows)
+- `ChatAgentWorker` and analysis workers catch these specific types and emit error signals carrying a structured payload (`category`, `user_message`)
+- Main window listens for `category="token_required"` and `category="token_expired"` → opens a small dialog with "Sign in again" / "Switch to API key mode" actions
+- Quota errors render with explicit Plus framing: "You've hit your ChatGPT Plus quota for this 3-hour window. Wait until <X>, or switch to API key mode to keep working." (Exact wording: Deferred to Implementation.)
+- AE3 covers token-expired surfaces; the same pattern handles `TokenMissingError` (the user picked subscription mode but never signed in, or signed out)
+
+**Patterns to follow:**
+- `ui/chat_panel.py` existing error rendering for the chat surface
+- `ui/workers/free_association_worker.py:8`-style cancellation discipline for the analysis workers
+- `docs/solutions/runtime-errors/transcription-mlx-auto-fallback-groq-key-20260512.md` — pre-flight configuration gate pattern (a `TokenMissingError` surfaced before the LLM call is the parallel)
+
+**Test scenarios:**
+- Happy path: Codex backend returns 401 → `TokenExpiredError` raised → routing helper attempts one refresh → if refresh succeeds, call retries transparently
+- Happy path: Codex backend returns 429 → `QuotaExceededError` raised → worker emits structured error → UI renders quota-specific message (covers AE4)
+- Error path: Codex backend returns 401, refresh also fails → `TokenExpiredError` surfaces; chat UI shows re-auth prompt (covers AE3, R11)
+- Error path: `auth_mode = "subscription"` but no stored token → `TokenMissingError` immediately on first LLM call; UI prompts sign-in or mode switch
+- Error path: unexpected 5xx from Codex backend → `CodexBackendError`; UI renders a generic-but-actionable message ("OpenAI's Codex service had a hiccup — try again or switch to API key mode")
+- Integration: mid-conversation token expiry — chat worker receives `TokenExpiredError`, surfaces the prompt; user clicks "Sign in again", succeeds, the next chat message works without app restart (covers R5, AE5)
+
+**Verification:**
+- `tests/test_subscription_error_ux.py` passes
+- AE3 and AE4 verifiable end-to-end via mock backend responses
+- No raw `TokenExpiredError`/`QuotaExceededError` stack traces ever reach the user
+
+---
+
+### U9. Quota pre-flight estimator
+
+**Goal:** Implement R12 — warn before starting a batch operation likely to exceed remaining quota. Heuristic-based, since the Codex backend's remaining-quota surface is not assumed.
+
+**Requirements:** R12
+
+**Dependencies:** U6, U8
+
+**Files:**
+- Create: `core/quota_estimator.py` (small, pure-function)
+- Modify: `ui/workers/description_worker.py`, `ui/workers/cinematography_worker.py` (or whatever the matching worker file is), and the batch-runner workers — wire the estimator before `run()` starts
+- Test: `tests/test_quota_estimator.py`
+
+**Approach:**
+- `core/quota_estimator.py` exposes `estimate_batch_load(operation, count) -> dict` returning `{estimated_messages, estimated_tokens}` based on per-operation heuristics (e.g., describe: ~1 message per clip; classify: ~1 message per clip; custom-query: ~1 message per clip per query)
+- Worker code, when in subscription mode, calls the estimator before starting and compares to a configurable per-3-hour budget (default value tuned by feel — see Deferred to Implementation)
+- If estimated load × safety margin > assumed remaining budget → emit a `quota_warning` signal; UI shows a confirm dialog: "This operation may exceed your ChatGPT Plus quota. Proceed? / Cancel / Switch to API key mode"
+- The warning is a heuristic — when subscription users hit quota anyway, U8 handles the mid-job error path (covers AE4)
+- API-key mode skips the estimator entirely (R8 unchanged)
+
+**Patterns to follow:**
+- Settings dialog confirm patterns for the "proceed / switch mode" UX
+- `core/feature_registry.py` for the small-stateless-helper-with-tests style
+
+**Test scenarios:**
+- Happy path: `estimate_batch_load("describe", 200)` returns a reasonable estimate that triggers a warning under default budget
+- Happy path: `estimate_batch_load("describe", 5)` does not trigger a warning
+- Edge case: unknown operation name → estimator returns zero with a debug log (no false alarm)
+- Edge case: per-operation heuristic constants tunable via a single module-level dict (so calibration changes are one-line)
+- Integration: a mock 200-clip describe job in subscription mode shows the warning dialog before starting; in API-key mode, the dialog never shows
+
+**Verification:**
+- `tests/test_quota_estimator.py` passes
+- AE4's pre-flight branch verifiable end-to-end (mock the dialog confirm)
+- Per-operation heuristics documented as tunable, not load-bearing
+
+---
+
+### U10. MCP server: per-call settings reload for LLM-routed tools
+
+**Goal:** Ensure the MCP server sees auth-mode changes made via the GUI without requiring a restart.
+
+**Requirements:** R7 (consistency: the MCP surface must respect the same auth-mode as the GUI)
+
+**Dependencies:** U6 (routing helper used inside spine/analysis paths must be live)
+
+**Files:**
+- Modify: `scene_ripper_mcp/server.py` (lifespan / context construction)
+- Modify: `scene_ripper_mcp/tools/jobs.py` (LLM-routed tool entry points: `start_describe`, `start_analyze_classify`, `start_analyze_cinematography`, `start_custom_query`, `start_analyze_clips`, `start_extract_text`)
+- Test: `scene_ripper_mcp/tests/test_auth_mode_propagation.py`
+
+**Approach:**
+- Add `get_current_settings()` helper in `scene_ripper_mcp/server.py` (or appropriate module) that calls `load_settings()` and returns a fresh `Settings` instance each call. JSON read + keyring read is microseconds; safe at per-tool-call frequency
+- Each LLM-routed tool calls `get_current_settings()` at the top of its handler (or the spine `analyze` calls do it). After U6/U7, the analysis modules already use `complete_routed`, which reads auth state at call time — so this unit's actual work is making sure no settings caching in the MCP server defeats that read.
+- ProjectModel and other non-auth context can remain cached at lifespan level — only the auth-related read needs to be per-call
+
+**Patterns to follow:**
+- `scene_ripper_mcp/server.py:lifespan` for the existing once-at-startup pattern (modify only the auth path)
+- `core/spine/chatgpt_auth.py:load_active_auth()` from U2 — the right entry point
+
+**Test scenarios:**
+- Happy path: change `auth_mode` and write a token blob to keyring; invoke a subscription-routed MCP tool; tool reaches the Codex backend (mock)
+- Happy path: switch `auth_mode` back to API key in the JSON config; invoke the same MCP tool; tool routes through `litellm.completion` (mock)
+- Edge case: MCP server running, GUI signs in (writes to keyring), then GUI signs out (clears keyring) — next MCP tool call sees `TokenMissingError` and surfaces it to the MCP client per `core/spine` error contracts (not crash)
+- Integration: subscription-mode MCP `start_describe` against a mock Codex backend completes a small job and returns results in the same shape as API-key mode
+
+**Verification:**
+- `scene_ripper_mcp/tests/test_auth_mode_propagation.py` passes
+- Manual: start MCP server, sign in via the GUI, observe that the next MCP tool call honors subscription mode without restart
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** The new auth abstraction is read by `core/llm_client.py:complete_routed`, which is called from `ui/chat_worker.py`, `core/analysis/*` (5 files post-U7), the 3 remix sequencers that use `complete_with_local_fallback` (storyteller, exquisite_corpus, free_association), `core/remix/drawing_vlm.py` (transitively, via `LLMClient.chat`), and indirectly by every MCP LLM-routed tool. The Settings dialog writes auth state; everyone else reads. No other component mutates auth state.
+- **Error propagation:** New exception types (`TokenExpiredError`, `TokenMissingError`, `QuotaExceededError`, `CodexBackendError`) flow from `core/codex_client.py` up through `complete_routed`, get caught by workers in `ui/workers/*` and `ui/chat_worker.py`, and surface to the user via structured error signals. The MCP server forwards these to its callers using its existing error-result conventions.
+- **State lifecycle risks:** The OAuth worker's `auth_complete` could double-fire under signal-duplication bugs (mitigated by U4's UniqueConnection + guard flag). Token refresh during an in-flight LLM call could race with a parallel call also trying to refresh — mitigated by serializing refresh inside `complete_routed` (one refresh attempt per failed call; if a parallel call already refreshed, the retry uses the fresh token).
+- **API surface parity:** The MCP server (U10) and the GUI (everywhere else) must honor the same auth mode. Spine layering ensures both read through `core/spine/chatgpt_auth.py:load_active_auth()`. Tests in `scene_ripper_mcp/tests/test_auth_mode_propagation.py` enforce parity.
+- **Integration coverage:** End-to-end happy paths under both modes (chat + each analysis feature) need real exercise with mocked HTTP. The flows F1–F5 from origin are testable end-to-end with `httpx.MockTransport`.
+- **Unchanged invariants:** Non-LLM features (transcription, scene detection, vision/ML, OCR-text-tier, embeddings, face detection, audio analysis) are not touched (R16). The existing per-provider API-key fields, env-var overrides, and `_save_llm_api_keys` flow remain functional and behaviorally identical in API-key mode (R8, R17). `tests/test_spine_imports.py`'s forbidden-import list is unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| OpenAI revokes the Codex CLI `client_id` or changes the auth endpoint shape | Token failures surface as `TokenExpiredError` with a clear re-auth prompt. If the endpoint moves entirely, API-key mode remains fully functional as the alternative (R17). Plan-level acceptance of ToS gray zone is documented in origin. |
+| Codex backend response shape changes silently | `core/codex_client.py` normalizes responses to the existing `choices[].message.content` shape. Schema drift surfaces as `CodexBackendError`; tests using `httpx.MockTransport` pin the expected shape. |
+| The chokepoint migration (U7) accidentally regresses an existing analysis feature | Each migrated file keeps its existing test suite; per-file integration tests confirm API-key-mode behavior is bit-identical. |
+| Quota estimator (U9) is too eager or too lax | Per-operation heuristics live in one module-level dict, tunable in a one-line change. Heuristic is acknowledged as approximate (Deferred to Implementation) and U8 handles the mid-job case as a safety net. |
+| OAuth worker signal duplication causes double-write to keyring or two browser tabs | UniqueConnection + guard flag + `@Slot()` decorators, tested explicitly in U4. Direct mirror of the prior solution in `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`. |
+| Spine boundary regression — accidentally imports PySide6/LiteLLM at module top level in `core/spine/chatgpt_auth.py` | `tests/test_spine_imports.py` enforces this; U2 explicitly extends the test to cover the new module. |
+| The 4 remix sequencers' Ollama fallback masks subscription-mode errors during dev | `complete_with_local_fallback` skips the fallback when `auth_mode = "subscription"` (Key Technical Decisions). Tests in U6 confirm. |
+| MCP server staleness — a long-running MCP server misses a GUI sign-in | U10 mandates per-call settings reload at the auth read; cheap operation, no realistic perf impact. |
+
+---
+
+## Documentation / Operational Notes
+
+- `docs/user-guide/` should gain a short page on "Signing in with ChatGPT" — covering when to use it vs. API keys, the quota caveat for batch jobs, and how to switch modes
+- The MCP server reference (`docs/user-guide/headless-mcp.md`) should note that subscription auth is honored automatically once configured in the GUI
+- No operational rollout / monitoring changes needed; the feature is fully client-side
+- After landing, capture the OAuth pattern as a new entry in `docs/solutions/` if any non-obvious bugs surface during implementation (per the project's `docs/solutions/` discipline)
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-12-chatgpt-subscription-auth-requirements.md](docs/brainstorms/2026-05-12-chatgpt-subscription-auth-requirements.md)
+- Related code:
+  - `core/llm_client.py`, `core/settings.py`, `core/spine/`, `core/analysis/`
+  - `ui/settings_dialog.py`, `ui/chat_worker.py`, `ui/workers/base.py`
+  - `scene_ripper_mcp/server.py`, `scene_ripper_mcp/tools/jobs.py`
+- Project guidance: `CLAUDE.md`, `AGENTS.md`
+- Institutional learnings: `docs/solutions/runtime-errors/transcription-mlx-auto-fallback-groq-key-20260512.md`, `docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md`, `docs/solutions/logic-errors/circular-import-config-consolidation.md`, `docs/solutions/security-issues/url-scheme-validation-bypass.md`, `docs/solutions/reliability-issues/subprocess-cleanup-on-exception.md`, `docs/solutions/ui-bugs/timeline-widget-sequence-mismatch-20260124.md`, `docs/solutions/ui-bugs/pyside6-thumbnail-source-id-mismatch.md`
+- External: Codex CLI source (open-source) for the OAuth flow shape; Hermes-agent for desktop-app precedent
+
+---
+
+## Review-Applied Revisions (2026-05-12 doc-review pass)
+
+This section is **authoritative** and supersedes the original plan body where they conflict. It captures every decision applied in the interactive document-review pass. The original body sections above remain readable for context but should be read alongside the revisions here.
+
+### Architectural revisions (P0)
+
+**R-A1. Split LLM-routing chokepoint into sync and async-streaming variants.** U6 introduces two helpers in `core/llm_client.py`:
+- `complete_routed(model, messages, **kwargs)` — sync, mirrors `litellm.completion` signature, used by the 5 `core/analysis/*` migration sites and by `complete_with_local_fallback`.
+- `stream_chat_routed(model, messages, tools, **kwargs)` — async generator, yields streaming chunks and surfaces `tool_calls`. Used by `LLMClient.stream_chat` / `chat` and consumed by `ui/chat_worker.py`.
+
+`core/codex_client.py` gains a corresponding `stream_complete(...)` async generator that handles Codex backend SSE/chunk decoding and `tool_calls` in streamed deltas. The plan's previous claim that `LLMClient.stream_chat` delegates through `complete_routed` is replaced by this two-helper design.
+
+**R-A2. Per-feature OpenAI-model substitution map for subscription mode.** In `core/codex_client.py`, a module-level dict maps each analysis feature's configured non-OpenAI model to a Codex-supported OpenAI equivalent: e.g. `cinematography_frame` (currently Gemini) → `gpt-4o`; `cinematography_video` (currently Gemini video) → falls back to **frame mode** in subscription (no video-content blocks sent); `description_video` → frame mode; `describe`, `classify`, `custom_query`, `ocr` → an OpenAI model declared per-feature in the substitution map. The substitution applies only when `auth_mode == SUBSCRIPTION`; API-key mode preserves the configured per-feature model. New Key Technical Decision documents which features lose video-input support in subscription mode.
+
+**R-A3. Pre-U7 kwargs compatibility matrix.** Before U7's mechanical swap lands, U6 produces a per-call-site kwargs matrix enumerating every kwarg each of the 5 analysis call sites passes today (`response_format`, video-content blocks, `tools`, `tool_choice`, `max_tokens`, etc.) and whether the Codex backend supports each. Sites with structured-output kwargs (cinematography `response_format: json_object`, shots_cloud JSON parsing) get explicit per-site treatment: translate, degrade with post-parse-and-retry, or remain API-key-only when no graceful path exists. The "purely mechanical" framing in U7 applies only to sites where kwargs cleanly map.
+
+**R-A4. Codex backend tool-calling support is explicitly designed for.** `core/codex_client.py:stream_complete` handles `tool_calls` in streamed deltas and final responses, mirroring OpenAI's function-call format. If the Codex auth endpoint does not support OpenAI-format function calls, chat-agent in subscription mode degrades to a no-tool-use chat with a clear in-chat banner ("Tool use is unavailable on ChatGPT subscription — switch to API key for full agent capabilities"). Verification required in U6 before U7 starts.
+
+### Auth-flow security hardening
+
+**R-S1. State parameter generated inside the flow module.** U3's `build_authorization_url` no longer accepts a caller-supplied `state`; it generates one internally via `secrets.token_urlsafe(32)` and returns `(url, redirect_uri, state)`. A test asserts successive calls produce distinct values of at least 256 bits.
+
+**R-S2. Loopback server binds explicitly to 127.0.0.1.** U3's `run_loopback_listener` calls `HTTPServer(('127.0.0.1', port), ...)` — never `''` or `'0.0.0.0'`. The single-shot handler also validates the request's `Host` header is `localhost` or `127.0.0.1` and the request path matches the expected callback path before parsing the query. A test asserts a second connection from another local socket cannot reach the handler after the first redirect lands.
+
+**R-S3. TLS scheme assertion tests on endpoint constants.** Add to `tests/test_chatgpt_auth.py`: `assert AUTHORIZATION_ENDPOINT.startswith('https://')`, `assert TOKEN_ENDPOINT.startswith('https://')`, `assert CODEX_COMPLETION_ENDPOINT.startswith('https://')`. One line per constant. Catches `http://` transcription mistakes at merge time.
+
+**R-S4. Bearer-token redaction in httpx exception messages.** `core/codex_client.py` defines `_sanitize_headers(headers: dict) -> dict` that replaces any case-insensitive `authorization` value with `[REDACTED]`. `httpx.HTTPStatusError` and `httpx.RequestError` are caught and re-raised as `CodexBackendError` with sanitized message text. A test triggers an httpx error against a bearer-bearing URL and asserts the raised exception message does not contain the token.
+
+**R-S5. Token-refresh mutex + GUI-only-refresh cross-process contract.** `core/spine/chatgpt_auth.py` exposes a module-level `threading.Lock` (sync) and `asyncio.Lock` (async) that serialize refresh inside one process. The holder re-reads the keyring blob after acquiring the lock and skips its own refresh if `expires_at_unix` is newer (another caller already refreshed). Cross-process: only the GUI process is permitted to call refresh; the MCP server treats keyring as read-only and on 401 surfaces a `TokenExpiredError` to its caller per existing MCP error-result conventions. Added to System-Wide Impact's State-lifecycle risks. Tests in `tests/test_codex_client.py` fire two threads against a mock 401-then-200 endpoint and assert exactly one refresh call.
+
+### Settings-dialog UX revisions (U5)
+
+**R-U1. Sign-in button gated on `_oauth_in_progress`.** While the OAuthWorker is running, the Sign-in button is disabled and relabeled ("Waiting for browser…"). Re-enabled on `auth_complete`, `auth_failed` (any category), or worker cancellation.
+
+**R-U2. Auth-mode radios locked during OAuth.** Both radios are disabled while `_oauth_in_progress` is true. Prevents the "mid-flight mode switch overwritten by late `auth_complete`" race. New test scenario in U5.
+
+**R-U3. OK/Save button gated when subscription radio + no token.** When the subscription radio is selected and no token blob exists in keyring, the dialog's OK button is disabled with an inline message: "Sign in first to use ChatGPT subscription mode." Re-enabled on `auth_complete` or when the user reverts to API-key radio. Prevents the silent broken state ("saved subscription but never signed in" → every LLM call raises `TokenMissingError`).
+
+**R-U4. Identity display fallback chain.** When the OAuth response omits `account_email`, the identity label decodes the `sub` claim from the `id_token` and shows that. If neither is available, falls back to `Signed in (ChatGPT Plus)`. Updates U1's token-blob handling to optionally surface `sub` and U5's display logic. Test scenario covers the email-absent response shape.
+
+### Error-UX revisions (U8)
+
+**R-E1. "Sign in again" routes to the settings dialog.** U8's re-auth dialog's "Sign in again" action opens the settings dialog focused on the API Keys tab with the subscription panel scrolled into view. The OAuthWorker is not instantiated from the main window directly. Reuses U5's sign-in flow as the single OAuth entry point.
+
+**R-E2. Mid-stream chat tool-use during token expiry.** When `TokenExpiredError` surfaces mid-turn (after one or more tool calls have already executed), the chat worker attempts one transparent refresh-and-retry of the in-flight LLM segment using R-S5's mutex pattern. If refresh fails, the chat surfaces "Your ChatGPT sign-in expired mid-response — please sign in again and rerun your last message" and the agent loop aborts cleanly with no half-executed tool calls left in inconsistent state. `core/plan_controller.py` multi-step plans use the same pattern. New test scenario in U8 covering refresh-during-tool-use.
+
+**R-E3. Refresh keyring-write failure policy.** When refresh succeeds against the Codex backend but the subsequent `set_chatgpt_oauth_token()` keyring write fails, the in-memory new access_token is used for the current call but a hard error is surfaced before the next call: "Could not persist refreshed sign-in to keyring — sign in again." Prevents the silent invalidate-the-refresh-chain failure mode. U6's Approach updated; test scenario added.
+
+### Quota UX revisions (U9 / U8)
+
+**R-Q1. Pre-flight dialog's "Switch to API key mode" is current-operation-only.** Selecting this option in U9's pre-flight quota dialog routes only the current operation through the API-key path; `Settings.auth_mode` is unchanged. Dialog includes a note: "This operation will run on your API key; your auth mode stays on subscription. Change permanently in Settings." Preserves R4 (single global toggle). Test asserts `Settings.auth_mode` round-trips unchanged after the dialog's Switch action.
+
+**R-Q2. Pre-flight + mid-job dialog single-owner flow.** Once the user proceeds past U9's pre-flight, that dialog is dismissed and does not reappear. The mid-job quota path is owned entirely by U8's `QuotaExceededError` toast. Test asserts no second pre-flight dialog appears after a Proceed-then-mid-job-error sequence.
+
+**R-Q3. U9 default to wide tolerance until calibration data exists.** Per-operation heuristic constants in `core/quota_estimator.py` default to permissive values for v1 (warn only on clearly-large batches: >300 clips for describe, >500 for classify). A calibration step is added to Documentation/Operational Notes: collect one week of subscription-mode usage data before tightening thresholds. Wide defaults prevent training users to dismiss warnings before the estimator is accurate.
+
+### Cross-process & MCP revisions
+
+**R-M1. Auth-state snapshot pinned to MCP jobs at start.** U10 revises the per-call reload behavior: the MCP server reloads settings + token blob at the **start of each job** (e.g., at the top of `start_describe`'s handler), then **pins that snapshot** to the job for its lifetime. Per-clip iterations inside the job use the snapshot. If the snapshot becomes invalid mid-job (refresh fails, mode changed externally), the job fails loudly with a clear status ("auth changed mid-job — restart in current mode") rather than silently switching backends per clip. Per-call reload still happens between jobs.
+
+**R-M2. MCP trust-boundary statement.** Added to U10 and to `docs/user-guide/headless-mcp.md`: "The MCP server is trusted to the same degree as the GUI because both run as the same OS user and share the keyring. This is acceptable for a local, single-user desktop application where the MCP server is launched by the GUI or by the user themselves. If the MCP server is ever exposed over a network socket rather than stdio, this decision must be revisited and an MCP-level auth layer added before that point."
+
+**R-M3. U10 test placement note.** U10's Files section clarifies: "Test placement at `scene_ripper_mcp/tests/test_auth_mode_propagation.py` is intentional, matching the existing `scene_ripper_mcp/tests/` convention for MCP-server-specific tests (e.g., `test_integration.py`, `test_jobs_runtime.py`). It is not inconsistent with U1–U9's `tests/` placement — those are app-wide tests; this is MCP-scoped."
+
+### Scope & coverage revisions
+
+**R-Sc1. Composer review R7 correction.** Added to Scope Boundaries (parallel to the gaze correction): "**LLM Composer** (`word_llm_composer` / `core/spine/words.py:compose_with_llm`) uses `complete_with_enum_constraint`, which is Ollama's JSON-schema enum constraint API — not exposed by the Codex/OpenAI backend. In v1, the LLM Composer remains Ollama-only regardless of auth mode. R7 listed it; this is a requirements correction surfaced during review." Plus added to Deferred to Follow-Up Work: "LLM Composer cloud path — add cloud-routed variant (LLM returns JSON, vocabulary validated client-side with retry on OOV) when the composer is extended."
+
+**R-Sc2. `drawing_vlm.py` transitive-coverage note.** Added to U7's Verification: "`core/remix/drawing_vlm.py` uses `LLMClient.chat` and is covered transitively by U6's split (it consumes `stream_chat_routed`). No direct migration needed in U7. Grep over `core/remix/` confirms no surviving `litellm.completion` calls after U6."
+
+### Implementation-discipline revisions
+
+**R-T1. Live sign-in smoke test acceptance step.** Added to U3 Verification: "A live sign-in smoke test (manual or env-var gated) exercises the real OpenAI Codex auth endpoint end-to-end once before U3/U4 can be claimed complete. Unit tests with `httpx.MockTransport` prove the implementation does what the code claims; the smoke test proves the code's claims match the real upstream contract." Explicitly notes that test-first does not substitute for contract verification.
+
+**R-T2. Ollama-fallback policy is availability-gated, not blanket-skipped.** Key Technical Decisions revision: in subscription mode, `complete_with_local_fallback` detects whether Ollama is reachable at call time before deciding whether to fall back. If reachable and configured for the relevant model → fall back with a clear message ("Subscription quota hit — falling back to local Ollama for this call"). If not reachable → surface the auth/quota error. Replaces the previous blanket "skip Ollama in subscription" policy.
+
+**R-T3. Linux plaintext keyring backend detection.** U1's `set_chatgpt_oauth_token()` detects the active keyring backend after a successful write. If the backend is `PlaintextKeyring` or any class from `keyrings.alt`, the helper refuses the write, calls `clear_chatgpt_oauth_token()` to remove the entry, returns False, and surfaces a user-facing error: "Secure storage is not available on this system — ChatGPT sign-in requires a system keychain (macOS Keychain, GNOME Keyring, KWallet, or Windows Credential Manager). API key mode remains available." Fail-closed for OAuth tokens; API-key path unchanged.
+
+### U8 / U9 worker-file dependency note
+
+**R-D1. U9's edits to worker pre-run hooks land on top of U8's exception-catch wiring.** U9's Approach gains a note: "Both U8 and U9 modify the same pre-`run()` block in `ui/workers/description_worker.py` (and the other analysis workers). U9 depends on U8 (declared) — U8's exception-catch wiring must land first; U9's quota-estimator calls slot in above it. Implementer should land U8's edit, run the worker, then land U9's edit on top."
+
+### Resolved-During-Planning additions
+
+The following questions are now resolved by the revisions above and should be considered settled (no longer open):
+
+- *How does the chat agent get streaming + tool-use in subscription mode?* → R-A1 (split chokepoint with streaming variant + tool_calls support).
+- *Which OpenAI model substitutes for each non-OpenAI configured model in subscription?* → R-A2 (per-feature substitution map in `core/codex_client.py`).
+- *Is the U7 migration mechanical?* → R-A3 (only for kwarg-compatible sites; structured-output sites get per-site treatment).
+- *How is refresh serialized across threads and processes?* → R-S5 (in-process locks + GUI-only-refresh contract).
+- *How is the OAuth state parameter generated?* → R-S1 (`secrets.token_urlsafe(32)` inside the flow module).
+- *How is the loopback callback hardened against local-process injection?* → R-S2 (explicit 127.0.0.1 + Host/path validation).
+- *What does "Switch to API key mode" in the quota dialog do?* → R-Q1 (current-operation-only override; settings unchanged).
+- *Where does "Sign in again" route?* → R-E1 (settings dialog focused on subscription panel).
+- *How is mid-stream token expiry handled?* → R-E2 (transparent refresh-retry + clean fallback).
+- *How does the MCP server handle long-running jobs across auth changes?* → R-M1 (snapshot at job start; fail loudly on mid-job invalidation).
+- *What happens on Linux without a Secret Service backend?* → R-T3 (refuse the write; user-facing error; API-key mode remains).
+- *Does subscription mode skip Ollama fallback unconditionally?* → R-T2 (availability-gated; falls back only if Ollama is reachable).
+- *What is the identity-display fallback when email is absent?* → R-U4 (id_token sub claim → "Signed in (ChatGPT Plus)" fallback).
+
+### Coverage from this review pass
+
+- **Total findings:** 33 (25 actionable @ confidence 75+, 8 FYI @ confidence 50)
+- **Applied:** 5 safe_auto (silent during headless pass) + 25 manual/gated (this section)
+- **Deferred:** 0
+- **Skipped:** 0
+- **FYI observations recorded (no plan body change):**
+  - Sign-out confirmation step not specified (P2): consider a confirm dialog before Sign Out, mirroring existing destructive-action patterns in the settings dialog
+  - Accessibility properties (`setAccessibleName`, focus order) not addressed for new controls in U5
+  - `core/quota_estimator.py` as a separate module may be over-abstracted given a single consumer — consider inlining if a second consumer doesn't appear
+  - `AuthMode` enum should NOT acquire abstract base classes / plugin registries / extension hooks beyond the two-value enum + branch-in-load_active_auth pattern; cap v1 there
+  - Malformed-JSON keyring entry should self-clear via `clear_chatgpt_oauth_token()` to break the perpetual `TokenMissingError` loop (defense-in-depth on top of R-T3)
+  - Auth-URL Qt slot in U5 should re-validate `url.startswith('https://')` before calling `QDesktopServices.openUrl` (defense-in-depth on top of R-S2)
+  - Codex backend response sanitization threat model — currently trusted equivalently to the OpenAI API under API-key mode; document if this becomes a concern
+  - Loopback port-collision and firewall-prompt UX — surface as a distinct `bind_failed` error category in U3 if the bind contention proves frequent in practice

--- a/scene_ripper_mcp/auth_snapshot.py
+++ b/scene_ripper_mcp/auth_snapshot.py
@@ -63,16 +63,17 @@ def take_auth_snapshot() -> AuthSnapshot:
     subsequent LLM call.
     """
     from core.settings import get_chatgpt_oauth_token, load_settings
+    from core.spine.chatgpt_auth import AuthMode
 
     settings = load_settings()
-    if settings.auth_mode != "subscription":
-        return AuthSnapshot(auth_mode="api_key", access_token=None)
+    if settings.auth_mode != AuthMode.SUBSCRIPTION:
+        return AuthSnapshot(auth_mode=AuthMode.API_KEY.value, access_token=None)
     blob = get_chatgpt_oauth_token()
     if not blob:
-        return AuthSnapshot(auth_mode="subscription", access_token=None)
+        return AuthSnapshot(auth_mode=AuthMode.SUBSCRIPTION.value, access_token=None)
     access_token = blob.get("access_token")
     return AuthSnapshot(
-        auth_mode="subscription",
+        auth_mode=AuthMode.SUBSCRIPTION.value,
         access_token=access_token if isinstance(access_token, str) else None,
     )
 

--- a/scene_ripper_mcp/auth_snapshot.py
+++ b/scene_ripper_mcp/auth_snapshot.py
@@ -1,0 +1,98 @@
+"""MCP-side auth snapshot helpers for subscription-mode jobs.
+
+The MCP server (``scene_ripper_mcp/server.py``) loads Settings *once* at
+startup and stashes them in the lifespan context. That works for paths
+and configuration, but it doesn't work for the ChatGPT subscription
+OAuth token — the user signs in / out / refreshes via the GUI, and
+the MCP server has to honor those changes without restart.
+
+R-M1 (auth snapshot per job): each LLM-routed MCP tool that launches a
+long-running job snapshots the current auth state at job start, pins
+that snapshot to the job's lifetime, and fails the job loudly if the
+snapshot becomes invalid mid-run rather than silently switching modes
+between clips. The snapshot is the per-clip iterator's source of truth.
+
+Trust-boundary statement (R-M2):
+
+  The MCP server is trusted to the same degree as the GUI because both
+  run as the same OS user and share the same keyring. This is acceptable
+  for a local, single-user desktop application where the MCP server is
+  launched by the GUI or by the user themselves. If the MCP server is
+  ever exposed over a network socket rather than stdio, this decision
+  must be revisited and an MCP-level auth layer added before that point.
+
+The MCP test placement note (R-M3): MCP-server tests live in
+``scene_ripper_mcp/tests/`` rather than ``tests/`` — that's the
+established convention for MCP-scoped behavior (see
+``scene_ripper_mcp/tests/test_integration.py``,
+``scene_ripper_mcp/tests/test_jobs_runtime.py``). This module's tests
+follow the same convention.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class AuthSnapshot:
+    """Frozen snapshot of auth state at the moment a job is launched.
+
+    The snapshot's identity is its ``access_token`` plus its mode — if
+    either changes between snapshot time and a per-clip LLM call, the
+    job recognises the drift and fails loudly rather than mixing modes.
+
+    ``access_token`` is None in API-key mode (no token to track) and
+    when subscription mode is active but no blob is stored (the
+    re-auth state).
+    """
+
+    auth_mode: str
+    access_token: Optional[str]
+
+
+def take_auth_snapshot() -> AuthSnapshot:
+    """Capture the active auth state as a frozen snapshot.
+
+    Reads ``Settings.auth_mode`` and the keyring blob fresh — same
+    discipline as :func:`core.spine.chatgpt_auth.load_active_auth`,
+    but typed for the snapshot use case. Call this once at the top
+    of an MCP job handler; pin the result to the job and check
+    against it via :func:`snapshot_still_valid` before each
+    subsequent LLM call.
+    """
+    from core.settings import get_chatgpt_oauth_token, load_settings
+
+    settings = load_settings()
+    if settings.auth_mode != "subscription":
+        return AuthSnapshot(auth_mode="api_key", access_token=None)
+    blob = get_chatgpt_oauth_token()
+    if not blob:
+        return AuthSnapshot(auth_mode="subscription", access_token=None)
+    access_token = blob.get("access_token")
+    return AuthSnapshot(
+        auth_mode="subscription",
+        access_token=access_token if isinstance(access_token, str) else None,
+    )
+
+
+def snapshot_still_valid(snapshot: AuthSnapshot) -> bool:
+    """True when the currently active auth state still matches the snapshot.
+
+    Drift cases this catches mid-job:
+    - User changes auth_mode in Settings while the job is running
+    - User signs out (token removed from keyring)
+    - Token was refreshed by another process in subscription mode
+      (the access_token changes; the GUI-only-refresh contract from
+      R-S5 means the MCP process should fail loudly rather than try
+      to refresh on its own)
+    """
+    current = take_auth_snapshot()
+    return (
+        current.auth_mode == snapshot.auth_mode
+        and current.access_token == snapshot.access_token
+    )
+
+
+__all__ = ["AuthSnapshot", "take_auth_snapshot", "snapshot_still_valid"]

--- a/scene_ripper_mcp/tests/test_auth_snapshot.py
+++ b/scene_ripper_mcp/tests/test_auth_snapshot.py
@@ -1,0 +1,91 @@
+"""Tests for the MCP-side auth-snapshot helpers (U10).
+
+Per the R-M3 placement convention, MCP-scoped tests live in
+``scene_ripper_mcp/tests/`` rather than ``tests/``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from core.settings import Settings
+from scene_ripper_mcp.auth_snapshot import (
+    AuthSnapshot,
+    snapshot_still_valid,
+    take_auth_snapshot,
+)
+
+
+def _settings(mode: str) -> Settings:
+    s = Settings()
+    s.auth_mode = mode
+    return s
+
+
+class TestTakeAuthSnapshot:
+    def test_api_key_mode_snapshot(self):
+        with patch("core.settings.load_settings", return_value=_settings("api_key")):
+            snap = take_auth_snapshot()
+            assert snap.auth_mode == "api_key"
+            assert snap.access_token is None
+
+    def test_subscription_with_token_snapshot(self):
+        with patch(
+            "core.settings.load_settings", return_value=_settings("subscription")
+        ), patch(
+            "core.settings.get_chatgpt_oauth_token",
+            return_value={"access_token": "at_abc", "refresh_token": "rt"},
+        ):
+            snap = take_auth_snapshot()
+            assert snap.auth_mode == "subscription"
+            assert snap.access_token == "at_abc"
+
+    def test_subscription_without_token_snapshot(self):
+        with patch(
+            "core.settings.load_settings", return_value=_settings("subscription")
+        ), patch(
+            "core.settings.get_chatgpt_oauth_token",
+            return_value=None,
+        ):
+            snap = take_auth_snapshot()
+            assert snap.auth_mode == "subscription"
+            assert snap.access_token is None
+
+
+class TestSnapshotStillValid:
+    def test_unchanged_state_remains_valid(self):
+        snap = AuthSnapshot(auth_mode="subscription", access_token="at_abc")
+        with patch(
+            "core.settings.load_settings", return_value=_settings("subscription")
+        ), patch(
+            "core.settings.get_chatgpt_oauth_token",
+            return_value={"access_token": "at_abc"},
+        ):
+            assert snapshot_still_valid(snap) is True
+
+    def test_mode_change_invalidates_snapshot(self):
+        snap = AuthSnapshot(auth_mode="subscription", access_token="at_abc")
+        with patch("core.settings.load_settings", return_value=_settings("api_key")):
+            assert snapshot_still_valid(snap) is False
+
+    def test_token_rotation_invalidates_snapshot(self):
+        snap = AuthSnapshot(auth_mode="subscription", access_token="at_old")
+        with patch(
+            "core.settings.load_settings", return_value=_settings("subscription")
+        ), patch(
+            "core.settings.get_chatgpt_oauth_token",
+            return_value={"access_token": "at_new"},
+        ):
+            assert snapshot_still_valid(snap) is False
+
+    def test_signout_invalidates_snapshot(self):
+        snap = AuthSnapshot(auth_mode="subscription", access_token="at_abc")
+        with patch(
+            "core.settings.load_settings", return_value=_settings("subscription")
+        ), patch(
+            "core.settings.get_chatgpt_oauth_token",
+            return_value=None,
+        ):
+            assert snapshot_still_valid(snap) is False

--- a/tests/test_auth_errors.py
+++ b/tests/test_auth_errors.py
@@ -1,0 +1,71 @@
+"""Tests for core/auth_errors.classify_subscription_error.
+
+Each category string is part of the workers' branching contract — once
+they're wired into U5's re-auth dialog, the category names become a
+load-bearing invariant.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from core.auth_errors import (
+    CATEGORY_CODEX_BACKEND,
+    CATEGORY_NONE,
+    CATEGORY_QUOTA_EXCEEDED,
+    CATEGORY_TOKEN_EXPIRED,
+    CATEGORY_TOKEN_REQUIRED,
+    CodexBackendError,
+    MalformedCodexResponseError,
+    QuotaExceededError,
+    TokenExpiredError,
+    TokenMissingError,
+    classify_subscription_error,
+    user_message_for_category,
+)
+
+
+class TestClassifyErrors:
+    @pytest.mark.parametrize(
+        "exc, expected_category",
+        [
+            (TokenMissingError("no blob"), CATEGORY_TOKEN_REQUIRED),
+            (TokenExpiredError("401"), CATEGORY_TOKEN_EXPIRED),
+            (QuotaExceededError("429"), CATEGORY_QUOTA_EXCEEDED),
+            (CodexBackendError(status=500, message="upstream"), CATEGORY_CODEX_BACKEND),
+            (MalformedCodexResponseError("bad json"), CATEGORY_CODEX_BACKEND),
+            (ValueError("unrelated"), CATEGORY_NONE),
+            (RuntimeError("unrelated"), CATEGORY_NONE),
+        ],
+    )
+    def test_classification(self, exc, expected_category):
+        assert classify_subscription_error(exc) == expected_category
+
+
+class TestUserMessages:
+    @pytest.mark.parametrize(
+        "category",
+        [
+            CATEGORY_TOKEN_REQUIRED,
+            CATEGORY_TOKEN_EXPIRED,
+            CATEGORY_QUOTA_EXCEEDED,
+            CATEGORY_CODEX_BACKEND,
+        ],
+    )
+    def test_returns_non_empty_for_real_categories(self, category):
+        msg = user_message_for_category(category)
+        assert isinstance(msg, str) and msg
+
+    def test_returns_empty_for_unknown_category(self):
+        assert user_message_for_category("garbage") == ""
+
+    def test_codex_backend_includes_raw_when_provided(self):
+        msg = user_message_for_category(
+            CATEGORY_CODEX_BACKEND, raw_message="503 upstream"
+        )
+        assert "503 upstream" in msg
+
+    def test_token_required_mentions_settings_and_api_key_path(self):
+        msg = user_message_for_category(CATEGORY_TOKEN_REQUIRED)
+        assert "Settings" in msg
+        assert "API-key" in msg

--- a/tests/test_chatgpt_auth.py
+++ b/tests/test_chatgpt_auth.py
@@ -1,0 +1,205 @@
+"""Tests for the spine-safe ChatGPT subscription auth-state module.
+
+Covers:
+
+- TLS scheme on OAuth endpoint constants (catches accidental ``http://``)
+- ``load_active_auth()`` across all three states (API-key, subscription
+  with valid blob, subscription with missing blob)
+- ``is_token_expired()`` boundary behavior with the default leeway
+- The ``AuthMode`` / ``str`` equality contract callers rely on for
+  comparing against ``Settings.auth_mode``'s JSON string values
+
+The spine boundary check itself lives in ``tests/test_spine_imports.py``.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from core.spine.chatgpt_auth import (
+    AUTHORIZATION_ENDPOINT,
+    AuthIdentity,
+    AuthMode,
+    CODEX_COMPLETION_ENDPOINT,
+    REDIRECT_URI_HOST,
+    SCOPES,
+    TOKEN_ENDPOINT,
+    is_token_expired,
+    load_active_auth,
+)
+
+
+class TestEndpointConstants:
+    """OAuth endpoint constants must use HTTPS (or the loopback IPv4 host)."""
+
+    @pytest.mark.parametrize(
+        "constant_name, value",
+        [
+            ("AUTHORIZATION_ENDPOINT", AUTHORIZATION_ENDPOINT),
+            ("TOKEN_ENDPOINT", TOKEN_ENDPOINT),
+            ("CODEX_COMPLETION_ENDPOINT", CODEX_COMPLETION_ENDPOINT),
+        ],
+    )
+    def test_endpoint_uses_https(self, constant_name, value):
+        """Every external endpoint must start with ``https://`` — no plaintext."""
+        assert value.startswith("https://"), (
+            f"{constant_name} = {value!r} is not HTTPS. "
+            "OAuth tokens and inference requests must transit TLS."
+        )
+
+    def test_redirect_uri_host_is_loopback(self):
+        """Loopback host is explicitly 127.0.0.1, never 0.0.0.0 / empty."""
+        assert REDIRECT_URI_HOST == "127.0.0.1", (
+            f"REDIRECT_URI_HOST = {REDIRECT_URI_HOST!r}. Binding to anything "
+            "other than 127.0.0.1 exposes the OAuth callback to other local "
+            "processes — see docs/solutions/security-issues/url-scheme-validation-bypass.md"
+        )
+
+    def test_scopes_is_non_empty_tuple(self):
+        """SCOPES must be a tuple of non-empty strings."""
+        assert isinstance(SCOPES, tuple)
+        assert len(SCOPES) > 0
+        for scope in SCOPES:
+            assert isinstance(scope, str) and scope
+
+
+class TestAuthModeEnum:
+    """AuthMode is a str-enum so it compares directly with Settings string values."""
+
+    def test_values_are_canonical_strings(self):
+        assert AuthMode.API_KEY.value == "api_key"
+        assert AuthMode.SUBSCRIPTION.value == "subscription"
+
+    def test_str_comparison_works_for_settings_interop(self):
+        """``mode == "api_key"`` returns True when mode is AuthMode.API_KEY."""
+        assert AuthMode.API_KEY == "api_key"
+        assert AuthMode.SUBSCRIPTION == "subscription"
+        assert AuthMode.API_KEY != "subscription"
+
+
+class TestIsTokenExpired:
+    """Boundary checks for ``is_token_expired``."""
+
+    def test_expired_token_returns_true(self):
+        identity = AuthIdentity(
+            account_email="a@b.com",
+            expires_at_unix=int(time.time()) - 1,
+        )
+        assert is_token_expired(identity) is True
+
+    def test_fresh_token_with_default_leeway_returns_false(self):
+        identity = AuthIdentity(
+            account_email="a@b.com",
+            expires_at_unix=int(time.time()) + 600,
+        )
+        assert is_token_expired(identity) is False
+
+    def test_near_expiry_within_leeway_returns_true(self):
+        """Within the leeway window, the token is treated as expired."""
+        identity = AuthIdentity(
+            account_email="a@b.com",
+            expires_at_unix=int(time.time()) + 30,
+        )
+        assert is_token_expired(identity, leeway_seconds=60) is True
+
+    def test_strict_boundary_with_zero_leeway(self):
+        """leeway_seconds=0 exercises the boundary case directly."""
+        identity = AuthIdentity(
+            account_email="a@b.com",
+            expires_at_unix=int(time.time()) + 5,
+        )
+        assert is_token_expired(identity, leeway_seconds=0) is False
+
+
+class TestLoadActiveAuth:
+    """``load_active_auth()`` across the three reachable states."""
+
+    def _make_settings(self, auth_mode):
+        from core.settings import Settings
+
+        s = Settings()
+        s.auth_mode = auth_mode
+        return s
+
+    def test_api_key_mode_returns_no_identity(self):
+        """API-key mode short-circuits and returns no identity."""
+        settings = self._make_settings("api_key")
+        with patch("core.settings.load_settings", return_value=settings):
+            mode, identity = load_active_auth()
+            assert mode == AuthMode.API_KEY
+            assert identity is None
+
+    def test_subscription_mode_with_valid_blob_returns_identity(self):
+        """Subscription mode + keyring blob -> identity populated from blob."""
+        settings = self._make_settings("subscription")
+        blob = {
+            "access_token": "at_abc",
+            "refresh_token": "rt_xyz",
+            "id_token": "id_def",
+            "expires_at_unix": int(time.time()) + 3600,
+            "account_email": "derrick@example.com",
+        }
+        with patch("core.settings.load_settings", return_value=settings), \
+             patch("core.settings.get_chatgpt_oauth_token", return_value=blob):
+            mode, identity = load_active_auth()
+            assert mode == AuthMode.SUBSCRIPTION
+            assert identity is not None
+            assert identity.account_email == "derrick@example.com"
+            assert identity.expires_at_unix == blob["expires_at_unix"]
+
+    def test_subscription_mode_without_blob_returns_none_identity(self):
+        """Subscription mode but no token in keyring -> re-auth-needed state."""
+        settings = self._make_settings("subscription")
+        with patch("core.settings.load_settings", return_value=settings), \
+             patch("core.settings.get_chatgpt_oauth_token", return_value=None):
+            mode, identity = load_active_auth()
+            assert mode == AuthMode.SUBSCRIPTION
+            assert identity is None
+
+    def test_subscription_mode_with_malformed_blob_returns_defensive_identity(self):
+        """A non-empty blob missing expected fields parses defensively, not by raising.
+
+        Distinct from empty / None — those are the "no blob, re-auth needed"
+        state. A blob with unrecognized fields (e.g., from a future format
+        we haven't shipped yet, or a partial write) should yield an identity
+        with empty/zero defaults so the routing layer's expiry check fires.
+        """
+        settings = self._make_settings("subscription")
+        with patch("core.settings.load_settings", return_value=settings), \
+             patch(
+                 "core.settings.get_chatgpt_oauth_token",
+                 return_value={"unrecognized_field": "x"},
+             ):
+            mode, identity = load_active_auth()
+            assert mode == AuthMode.SUBSCRIPTION
+            assert identity is not None
+            assert identity.account_email == ""
+            assert identity.expires_at_unix == 0
+
+    def test_subscription_mode_with_empty_blob_returns_none_identity(self):
+        """An empty dict from get_chatgpt_oauth_token is equivalent to None."""
+        settings = self._make_settings("subscription")
+        with patch("core.settings.load_settings", return_value=settings), \
+             patch("core.settings.get_chatgpt_oauth_token", return_value={}):
+            mode, identity = load_active_auth()
+            assert mode == AuthMode.SUBSCRIPTION
+            assert identity is None
+
+    def test_load_reads_fresh_state_on_every_call(self):
+        """Two consecutive calls reflect a settings change between them.
+
+        Guards the read-at-call-time discipline that makes AE5 work: no
+        caching of mode or identity inside load_active_auth.
+        """
+        settings_first = self._make_settings("api_key")
+        settings_second = self._make_settings("subscription")
+
+        with patch("core.settings.load_settings", side_effect=[settings_first, settings_second]), \
+             patch("core.settings.get_chatgpt_oauth_token", return_value=None):
+            mode1, _ = load_active_auth()
+            mode2, _ = load_active_auth()
+            assert mode1 == AuthMode.API_KEY
+            assert mode2 == AuthMode.SUBSCRIPTION

--- a/tests/test_chatgpt_oauth_flow.py
+++ b/tests/test_chatgpt_oauth_flow.py
@@ -1,0 +1,368 @@
+"""Tests for the PKCE + loopback OAuth flow module.
+
+Uses ``httpx.MockTransport`` everywhere so tests don't touch the network.
+The loopback listener is exercised via direct HTTP requests against a
+real local server bound to 127.0.0.1.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import threading
+import time
+import urllib.parse
+from http import HTTPStatus
+
+import httpx
+import pytest
+
+from core.spine.chatgpt_oauth_flow import (
+    AuthorizationCode,
+    AuthorizationRequest,
+    OAuthCancelledError,
+    OAuthHTTPError,
+    OAuthMalformedResponseError,
+    OAuthTimeoutError,
+    PKCEPair,
+    TokenBlob,
+    _pick_free_loopback_port,
+    _redact_authorization,
+    _try_extract_email_from_id_token,
+    build_authorization_url,
+    exchange_code_for_token,
+    generate_pkce_pair,
+    refresh_token_blob,
+    run_loopback_listener,
+)
+from core.spine.chatgpt_auth import (
+    AUTHORIZATION_ENDPOINT,
+    CLIENT_ID,
+    REDIRECT_URI_HOST,
+    TOKEN_ENDPOINT,
+)
+
+
+# --- PKCE --------------------------------------------------------------------
+
+
+class TestPKCE:
+    def test_generate_pkce_pair_shape(self):
+        pair = generate_pkce_pair()
+        assert isinstance(pair, PKCEPair)
+        # Verifier per RFC 7636: 43-128 chars, URL-safe.
+        assert 43 <= len(pair.verifier) <= 128
+        # Challenge has no base64 padding.
+        assert "=" not in pair.challenge
+
+    def test_s256_transform_holds(self):
+        """challenge == BASE64URL(SHA256(verifier)) without padding."""
+        pair = generate_pkce_pair()
+        expected = base64.urlsafe_b64encode(
+            hashlib.sha256(pair.verifier.encode("ascii")).digest()
+        ).rstrip(b"=").decode("ascii")
+        assert pair.challenge == expected
+
+    def test_consecutive_calls_return_distinct_pairs(self):
+        a = generate_pkce_pair()
+        b = generate_pkce_pair()
+        assert a.verifier != b.verifier
+        assert a.challenge != b.challenge
+
+
+# --- Authorization URL -------------------------------------------------------
+
+
+class TestBuildAuthorizationURL:
+    def test_url_includes_required_oauth_params(self):
+        pair = generate_pkce_pair()
+        req = build_authorization_url(pair.challenge)
+        assert isinstance(req, AuthorizationRequest)
+        parsed = urllib.parse.urlsplit(req.url)
+        # Same scheme + host as configured endpoint
+        expected_endpoint = urllib.parse.urlsplit(AUTHORIZATION_ENDPOINT)
+        assert parsed.scheme == expected_endpoint.scheme
+        assert parsed.netloc == expected_endpoint.netloc
+
+        params = urllib.parse.parse_qs(parsed.query)
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == [CLIENT_ID]
+        assert params["code_challenge_method"] == ["S256"]
+        assert params["code_challenge"] == [pair.challenge]
+        assert "state" in params and len(params["state"][0]) >= 32
+
+    def test_redirect_uri_points_at_loopback(self):
+        pair = generate_pkce_pair()
+        req = build_authorization_url(pair.challenge)
+        parsed = urllib.parse.urlsplit(req.redirect_uri)
+        assert parsed.scheme == "http"
+        assert parsed.hostname == REDIRECT_URI_HOST
+        assert parsed.port == req.port
+        assert parsed.path == "/callback"
+
+    def test_state_is_generated_internally(self):
+        """build_authorization_url must NOT accept a caller-supplied state."""
+        # Sanity: signature has just one positional arg (challenge).
+        import inspect
+
+        sig = inspect.signature(build_authorization_url)
+        params = list(sig.parameters)
+        assert params == ["challenge"], (
+            f"build_authorization_url should generate state internally, not accept it; "
+            f"got params: {params}"
+        )
+
+    def test_state_high_entropy(self):
+        """The internally-generated state must have at least 256 bits of entropy."""
+        pair = generate_pkce_pair()
+        states = {build_authorization_url(pair.challenge).state for _ in range(20)}
+        # 20 distinct values from a 256-bit generator — collisions are astronomical.
+        assert len(states) == 20
+
+
+# --- Loopback listener -------------------------------------------------------
+
+
+def _fire_redirect(
+    port: int, query: str, *, host_header: str | None = None
+) -> None:
+    """Open a socket to the loopback listener and send an HTTP/1.1 GET."""
+    import socket
+
+    host_line = host_header if host_header is not None else f"127.0.0.1:{port}"
+    request = (
+        f"GET /callback?{query} HTTP/1.1\r\n"
+        f"Host: {host_line}\r\n"
+        "Connection: close\r\n\r\n"
+    )
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(5.0)
+    try:
+        s.connect(("127.0.0.1", port))
+        s.sendall(request.encode("ascii"))
+        s.recv(4096)  # drain
+    finally:
+        s.close()
+
+
+class TestLoopbackListener:
+    def test_happy_path_returns_authorization_code(self):
+        port = _pick_free_loopback_port()
+        state = "expected-state-value"
+
+        def deliver():
+            time.sleep(0.05)
+            _fire_redirect(port, f"code=abc123&state={state}")
+
+        t = threading.Thread(target=deliver)
+        t.start()
+        try:
+            result = run_loopback_listener(port, expected_state=state, timeout_seconds=5)
+        finally:
+            t.join()
+        assert isinstance(result, AuthorizationCode)
+        assert result.code == "abc123"
+        assert result.state == state
+
+    def test_state_mismatch_raises_cancelled(self):
+        port = _pick_free_loopback_port()
+
+        def deliver():
+            time.sleep(0.05)
+            _fire_redirect(port, "code=abc123&state=attacker-supplied")
+
+        t = threading.Thread(target=deliver)
+        t.start()
+        try:
+            with pytest.raises(OAuthCancelledError):
+                run_loopback_listener(port, expected_state="real-state", timeout_seconds=5)
+        finally:
+            t.join()
+
+    def test_timeout_raises_timeout_error(self):
+        port = _pick_free_loopback_port()
+        with pytest.raises(OAuthTimeoutError):
+            run_loopback_listener(port, expected_state="x", timeout_seconds=0.5)
+
+    def test_error_param_in_redirect_raises_http_error(self):
+        port = _pick_free_loopback_port()
+
+        def deliver():
+            time.sleep(0.05)
+            _fire_redirect(port, "error=access_denied&state=x")
+
+        t = threading.Thread(target=deliver)
+        t.start()
+        try:
+            with pytest.raises(OAuthHTTPError) as excinfo:
+                run_loopback_listener(port, expected_state="x", timeout_seconds=5)
+        finally:
+            t.join()
+        assert "access_denied" in str(excinfo.value)
+
+
+# --- Token endpoint via MockTransport ----------------------------------------
+
+
+def _make_mock_client(handler) -> httpx.Client:
+    """Wrap an httpx.MockTransport around a single handler callable."""
+    transport = httpx.MockTransport(handler)
+    return httpx.Client(transport=transport)
+
+
+class TestExchangeCodeForToken:
+    def test_happy_path_returns_token_blob(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            assert request.method == "POST"
+            assert str(request.url) == TOKEN_ENDPOINT
+            body = urllib.parse.parse_qs(request.content.decode("ascii"))
+            assert body["grant_type"] == ["authorization_code"]
+            assert body["code"] == ["abc123"]
+            assert body["code_verifier"] == ["verifier-xyz"]
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "at_real",
+                    "refresh_token": "rt_real",
+                    "id_token": "",
+                    "expires_in": 3600,
+                    "email": "derrick@example.com",
+                },
+            )
+
+        client = _make_mock_client(handler)
+        blob = exchange_code_for_token(
+            code="abc123",
+            verifier="verifier-xyz",
+            redirect_uri="http://127.0.0.1:5050/callback",
+            client=client,
+        )
+        assert isinstance(blob, TokenBlob)
+        assert blob.access_token == "at_real"
+        assert blob.refresh_token == "rt_real"
+        assert blob.account_email == "derrick@example.com"
+        # expires_at_unix is set to now + expires_in
+        assert int(time.time()) <= blob.expires_at_unix <= int(time.time()) + 3700
+
+    def test_4xx_raises_oauth_http_error(self):
+        def handler(request):
+            return httpx.Response(400, json={"error": "invalid_grant"})
+
+        client = _make_mock_client(handler)
+        with pytest.raises(OAuthHTTPError) as excinfo:
+            exchange_code_for_token(
+                code="c",
+                verifier="v",
+                redirect_uri="http://127.0.0.1:5050/callback",
+                client=client,
+            )
+        assert excinfo.value.status == 400
+
+    def test_missing_access_token_raises_malformed(self):
+        def handler(request):
+            return httpx.Response(200, json={"refresh_token": "rt"})
+
+        client = _make_mock_client(handler)
+        with pytest.raises(OAuthMalformedResponseError):
+            exchange_code_for_token(
+                code="c",
+                verifier="v",
+                redirect_uri="http://127.0.0.1:5050/callback",
+                client=client,
+            )
+
+
+class TestRefreshToken:
+    def test_happy_path_returns_new_blob(self):
+        def handler(request):
+            body = urllib.parse.parse_qs(request.content.decode("ascii"))
+            assert body["grant_type"] == ["refresh_token"]
+            assert body["refresh_token"] == ["rt_old"]
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "at_new",
+                    "refresh_token": "rt_new",
+                    "expires_in": 1800,
+                },
+            )
+
+        client = _make_mock_client(handler)
+        blob = refresh_token_blob("rt_old", client=client)
+        assert blob.access_token == "at_new"
+        assert blob.refresh_token == "rt_new"
+
+    def test_response_without_new_refresh_preserves_old(self):
+        """If the response omits refresh_token, the prior one is preserved."""
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                json={"access_token": "at_new", "expires_in": 1800},
+            )
+
+        client = _make_mock_client(handler)
+        blob = refresh_token_blob("rt_keepme", client=client)
+        assert blob.refresh_token == "rt_keepme"
+
+    def test_empty_refresh_token_raises(self):
+        with pytest.raises(OAuthMalformedResponseError):
+            refresh_token_blob("")
+
+    def test_401_raises_oauth_http_error(self):
+        def handler(request):
+            return httpx.Response(401, json={"error": "invalid_grant"})
+
+        client = _make_mock_client(handler)
+        with pytest.raises(OAuthHTTPError) as excinfo:
+            refresh_token_blob("rt_old", client=client)
+        assert excinfo.value.status == 401
+
+
+# --- Bearer-token redaction --------------------------------------------------
+
+
+class TestRedactAuthorization:
+    def test_redacts_bearer_token_in_message(self):
+        msg = "Failed: Authorization: Bearer sk-abc123xyz789 was rejected"
+        redacted = _redact_authorization(msg)
+        assert "sk-abc123xyz789" not in redacted
+        assert "[REDACTED]" in redacted
+
+    def test_redacts_case_insensitive(self):
+        msg = "authorization=Bearer abc.def.ghi"
+        redacted = _redact_authorization(msg)
+        assert "abc.def.ghi" not in redacted
+        assert "[REDACTED]" in redacted
+
+    def test_passes_through_messages_without_tokens(self):
+        msg = "Connection refused — endpoint unreachable"
+        assert _redact_authorization(msg) == msg
+
+
+# --- ID token email extraction -----------------------------------------------
+
+
+class TestIDTokenEmail:
+    def _make_id_token(self, payload: dict) -> str:
+        """Build a fake unsigned JWT with the given payload."""
+        header_b64 = base64.urlsafe_b64encode(
+            json.dumps({"alg": "none"}).encode("utf-8")
+        ).rstrip(b"=").decode("ascii")
+        payload_b64 = base64.urlsafe_b64encode(
+            json.dumps(payload).encode("utf-8")
+        ).rstrip(b"=").decode("ascii")
+        return f"{header_b64}.{payload_b64}.signature_ignored"
+
+    def test_extracts_email_when_present(self):
+        token = self._make_id_token({"email": "derrick@example.com", "sub": "user-1"})
+        assert _try_extract_email_from_id_token(token) == "derrick@example.com"
+
+    def test_returns_empty_when_email_absent(self):
+        token = self._make_id_token({"sub": "user-1"})
+        assert _try_extract_email_from_id_token(token) == ""
+
+    def test_returns_empty_for_malformed_token(self):
+        assert _try_extract_email_from_id_token("not.a.jwt") == ""
+        assert _try_extract_email_from_id_token("") == ""

--- a/tests/test_codex_client.py
+++ b/tests/test_codex_client.py
@@ -1,0 +1,296 @@
+"""Tests for core/codex_client.py — the Codex backend HTTP client."""
+
+from __future__ import annotations
+
+import urllib.parse
+
+import httpx
+import pytest
+
+from core import codex_client
+from core.codex_client import (
+    CodexBackendError,
+    CodexError,
+    MalformedCodexResponseError,
+    QuotaExceededError,
+    TokenExpiredError,
+    TokenMissingError,
+    _sanitize_for_log,
+    coerce_model_for_codex,
+    complete,
+)
+
+
+def _mock_client(handler) -> httpx.Client:
+    """Build a sync httpx.Client backed by a MockTransport."""
+    transport = httpx.MockTransport(handler)
+    return httpx.Client(transport=transport)
+
+
+# --- Model coercion ---------------------------------------------------------
+
+
+class TestCoerceModelForCodex:
+    @pytest.mark.parametrize(
+        "input_model, expected",
+        [
+            ("gemini-2.5-flash", "gpt-4o-mini"),
+            ("gemini-2.5-pro", "gpt-4o"),
+            ("gemini-3.1-flash-lite-preview", "gpt-4o-mini"),
+            ("gemini/gemini-2.5-flash", "gpt-4o-mini"),
+            ("claude-sonnet-4-5", "gpt-4o"),
+            ("claude-opus-4", "gpt-4o"),
+            ("claude-haiku-3.5", "gpt-4o-mini"),
+            ("anthropic/claude-sonnet-4", "gpt-4o"),  # claude-sonnet rule wins (more specific)
+            ("openrouter/anthropic/claude", "gpt-4o-mini"),
+            ("openai/gpt-4o", "gpt-4o"),  # passthrough, strip prefix
+            ("gpt-5.2", "gpt-5.2"),  # already an OpenAI model, no change
+            ("gpt-4o-mini", "gpt-4o-mini"),
+            ("", "gpt-4o-mini"),  # empty falls back to safe default
+        ],
+    )
+    def test_substitutions(self, input_model, expected):
+        assert coerce_model_for_codex(input_model) == expected
+
+
+# --- Errors -----------------------------------------------------------------
+
+
+class TestErrorTaxonomy:
+    def test_all_errors_inherit_from_codex_error(self):
+        for exc_cls in (
+            TokenMissingError,
+            TokenExpiredError,
+            QuotaExceededError,
+            CodexBackendError,
+            MalformedCodexResponseError,
+        ):
+            assert issubclass(exc_cls, CodexError)
+
+    def test_codex_backend_error_carries_status_and_body(self):
+        exc = CodexBackendError(status=502, message="upstream", body="gateway error")
+        assert exc.status == 502
+        assert exc.body == "gateway error"
+        assert "upstream" in str(exc)
+
+
+# --- Bearer-token redaction -------------------------------------------------
+
+
+class TestSanitizeForLog:
+    def test_redacts_bearer_in_message(self):
+        msg = "Failed: Authorization: Bearer sk-abc.def.ghi was rejected"
+        cleaned = _sanitize_for_log(msg)
+        assert "sk-abc.def.ghi" not in cleaned
+        assert "[REDACTED]" in cleaned
+
+    def test_passes_through_messages_without_tokens(self):
+        msg = "Connection refused"
+        assert _sanitize_for_log(msg) == msg
+
+
+# --- complete() -------------------------------------------------------------
+
+
+class TestComplete:
+    def _blob(self, access_token: str = "at_real") -> dict:
+        return {
+            "access_token": access_token,
+            "refresh_token": "rt_keep",
+            "expires_at_unix": 9999999999,
+            "account_email": "user@example.com",
+            "id_token": "",
+        }
+
+    def test_happy_path_returns_response_dict(self):
+        captured = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["auth"] = request.headers.get("Authorization", "")
+            captured["payload"] = request.content
+            return httpx.Response(
+                200,
+                json={
+                    "choices": [{"message": {"content": "hello"}}],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 1},
+                },
+            )
+
+        client = _mock_client(handler)
+        response = complete(
+            self._blob(),
+            model="gemini-2.5-flash",
+            messages=[{"role": "user", "content": "say hi"}],
+            client=client,
+        )
+        assert response["choices"][0]["message"]["content"] == "hello"
+        # The bearer goes out untouched
+        assert captured["auth"] == "Bearer at_real"
+        # Model was coerced
+        import json
+
+        sent = json.loads(captured["payload"].decode("utf-8"))
+        assert sent["model"] == "gpt-4o-mini"
+
+    def test_401_raises_token_expired(self):
+        def handler(request):
+            return httpx.Response(401, json={"error": "invalid_token"})
+
+        client = _mock_client(handler)
+        with pytest.raises(TokenExpiredError):
+            complete(
+                self._blob(),
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "x"}],
+                client=client,
+            )
+
+    def test_429_raises_quota_exceeded(self):
+        def handler(request):
+            return httpx.Response(429, json={"error": "rate_limited"})
+
+        client = _mock_client(handler)
+        with pytest.raises(QuotaExceededError):
+            complete(
+                self._blob(),
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "x"}],
+                client=client,
+            )
+
+    def test_500_raises_codex_backend_error_with_status(self):
+        def handler(request):
+            return httpx.Response(500, text="gateway")
+
+        client = _mock_client(handler)
+        with pytest.raises(CodexBackendError) as excinfo:
+            complete(
+                self._blob(),
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "x"}],
+                client=client,
+            )
+        assert excinfo.value.status == 500
+
+    def test_missing_access_token_raises_token_missing(self):
+        with pytest.raises(TokenMissingError):
+            complete(
+                {"refresh_token": "rt"},  # no access_token
+                model="gpt-4o",
+                messages=[],
+                client=_mock_client(lambda r: httpx.Response(200, json={})),
+            )
+
+    def test_passthrough_kwargs_reach_payload(self):
+        captured = {}
+
+        def handler(request):
+            import json
+
+            captured["payload"] = json.loads(request.content.decode("utf-8"))
+            return httpx.Response(
+                200,
+                json={"choices": [{"message": {"content": "ok"}}]},
+            )
+
+        client = _mock_client(handler)
+        complete(
+            self._blob(),
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "x"}],
+            temperature=0.2,
+            response_format={"type": "json_object"},
+            client=client,
+        )
+        assert captured["payload"]["temperature"] == 0.2
+        assert captured["payload"]["response_format"] == {"type": "json_object"}
+
+
+# --- complete_routed (in llm_client.py) -------------------------------------
+
+
+class TestCompleteRouted:
+    """The chokepoint helper in core.llm_client routes by auth_mode."""
+
+    def test_api_key_mode_delegates_to_litellm(self, monkeypatch):
+        from core import llm_client
+
+        captured = {}
+
+        def fake_completion(model, messages, api_key=None, **kwargs):
+            captured["model"] = model
+            captured["api_key"] = api_key
+            captured["kwargs"] = kwargs
+            return {"choices": [{"message": {"content": "from-litellm"}}]}
+
+        monkeypatch.setattr("litellm.completion", fake_completion)
+
+        # Force load_active_auth to return API_KEY mode.
+        from core.spine.chatgpt_auth import AuthMode
+
+        monkeypatch.setattr(
+            "core.spine.chatgpt_auth.load_active_auth",
+            lambda: (AuthMode.API_KEY, None),
+        )
+
+        result = llm_client.complete_routed(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+            api_key="sk-test",
+            temperature=0.5,
+        )
+        assert result["choices"][0]["message"]["content"] == "from-litellm"
+        assert captured["model"] == "gpt-4o"
+        assert captured["api_key"] == "sk-test"
+        assert captured["kwargs"]["temperature"] == 0.5
+
+    def test_subscription_mode_no_token_raises_token_missing(self, monkeypatch):
+        from core import llm_client
+
+        from core.spine.chatgpt_auth import AuthMode
+
+        monkeypatch.setattr(
+            "core.spine.chatgpt_auth.load_active_auth",
+            lambda: (AuthMode.SUBSCRIPTION, None),
+        )
+        monkeypatch.setattr(
+            "core.settings.get_chatgpt_oauth_token",
+            lambda: None,
+        )
+
+        with pytest.raises(TokenMissingError):
+            llm_client.complete_routed(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+    def test_subscription_mode_with_token_calls_codex(self, monkeypatch):
+        from core import llm_client
+
+        from core.spine.chatgpt_auth import AuthMode, AuthIdentity
+
+        identity = AuthIdentity(account_email="a@b.com", expires_at_unix=9999999999)
+        monkeypatch.setattr(
+            "core.spine.chatgpt_auth.load_active_auth",
+            lambda: (AuthMode.SUBSCRIPTION, identity),
+        )
+        monkeypatch.setattr(
+            "core.settings.get_chatgpt_oauth_token",
+            lambda: {"access_token": "at_x", "refresh_token": "rt_x"},
+        )
+
+        captured = {}
+
+        def fake_complete(blob, *, model, messages, **kwargs):
+            captured["blob"] = blob
+            captured["model"] = model
+            return {"choices": [{"message": {"content": "from-codex"}}]}
+
+        monkeypatch.setattr("core.codex_client.complete", fake_complete)
+
+        result = llm_client.complete_routed(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert result["choices"][0]["message"]["content"] == "from-codex"
+        assert captured["blob"]["access_token"] == "at_x"

--- a/tests/test_oauth_worker.py
+++ b/tests/test_oauth_worker.py
@@ -1,0 +1,136 @@
+"""Tests for ui/workers/oauth_worker.OAuthWorker.
+
+Focus: the signal-duplication guard pattern (R-S5's UniqueConnection
+buddy) and the terminal-emission contract — auth_complete OR
+auth_failed fires exactly once per run, never both.
+
+The PySide6 QApplication is required for signal connection. Tests use
+QSignalSpy to capture emissions without running an event loop.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+# Skip the whole module on headless CI runs where PySide6 isn't installed.
+PySide6 = pytest.importorskip("PySide6", reason="PySide6 not available")
+
+from PySide6.QtCore import QCoreApplication, QObject
+from PySide6.QtTest import QSignalSpy
+
+from ui.workers.oauth_worker import (
+    AUTH_FAILED_CANCELLED,
+    AUTH_FAILED_TIMEOUT,
+    AUTH_FAILED_NETWORK,
+    AUTH_FAILED_REJECTED,
+    AUTH_FAILED_MALFORMED,
+    OAuthWorker,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Module-scoped QCoreApplication for signal handling.
+
+    QCoreApplication is sufficient — no widgets are constructed here, so
+    the heavier QApplication isn't necessary.
+    """
+    app = QCoreApplication.instance() or QCoreApplication(sys.argv)
+    yield app
+
+
+class TestTerminalEmissionGuard:
+    """auth_complete / auth_failed must fire at most once per run."""
+
+    def test_complete_fires_once_then_suppresses_repeat(self, qapp):
+        worker = OAuthWorker()
+        spy_complete = QSignalSpy(worker.auth_complete)
+
+        worker._emit_terminal_complete({"access_token": "at_abc"})
+        worker._emit_terminal_complete({"access_token": "at_abc"})
+
+        assert spy_complete.count() == 1
+
+    def test_failed_fires_once_then_suppresses_repeat(self, qapp):
+        worker = OAuthWorker()
+        spy_failed = QSignalSpy(worker.auth_failed)
+
+        worker._emit_terminal_failed(AUTH_FAILED_CANCELLED, "Cancelled.")
+        worker._emit_terminal_failed(AUTH_FAILED_NETWORK, "Network error.")
+
+        assert spy_failed.count() == 1
+
+    def test_complete_blocks_subsequent_failed(self, qapp):
+        """After auth_complete, a failed emission is suppressed."""
+        worker = OAuthWorker()
+        spy_complete = QSignalSpy(worker.auth_complete)
+        spy_failed = QSignalSpy(worker.auth_failed)
+
+        worker._emit_terminal_complete({"access_token": "at"})
+        worker._emit_terminal_failed(AUTH_FAILED_NETWORK, "Late error.")
+
+        assert spy_complete.count() == 1
+        assert spy_failed.count() == 0
+
+    def test_failed_blocks_subsequent_complete(self, qapp):
+        worker = OAuthWorker()
+        spy_complete = QSignalSpy(worker.auth_complete)
+        spy_failed = QSignalSpy(worker.auth_failed)
+
+        worker._emit_terminal_failed(AUTH_FAILED_CANCELLED, "Cancelled.")
+        worker._emit_terminal_complete({"access_token": "at"})
+
+        assert spy_failed.count() == 1
+        assert spy_complete.count() == 0
+
+
+class TestGuardResetAcrossRuns:
+    """The guard flag resets at the top of each run() so the same worker
+    instance can be reused for sequential sign-in attempts.
+    """
+
+    def test_finished_handled_resets_on_run(self, qapp, monkeypatch):
+        worker = OAuthWorker()
+
+        # Force the flag set, simulating end of a prior run.
+        worker._finished_handled = True
+
+        # Replace _async_run with an immediate no-op so run() reaches the
+        # guard reset without doing real network work.
+        async def _noop():
+            return None
+
+        monkeypatch.setattr(worker, "_async_run", _noop)
+
+        worker.run()
+        # After the no-op coroutine completes, the flag should have been
+        # reset to False at the top of run() — even though _async_run
+        # never emitted a terminal signal.
+        assert worker._finished_handled is False
+
+
+class TestFailureCategoryConstants:
+    """The constants must be stable strings — U5 branches on them."""
+
+    def test_distinct_values(self):
+        values = {
+            AUTH_FAILED_CANCELLED,
+            AUTH_FAILED_TIMEOUT,
+            AUTH_FAILED_NETWORK,
+            AUTH_FAILED_REJECTED,
+            AUTH_FAILED_MALFORMED,
+        }
+        # All distinct — no accidental collisions.
+        assert len(values) == 5
+
+    def test_values_are_strings(self):
+        for v in (
+            AUTH_FAILED_CANCELLED,
+            AUTH_FAILED_TIMEOUT,
+            AUTH_FAILED_NETWORK,
+            AUTH_FAILED_REJECTED,
+            AUTH_FAILED_MALFORMED,
+        ):
+            assert isinstance(v, str) and v

--- a/tests/test_quota_estimator.py
+++ b/tests/test_quota_estimator.py
@@ -1,0 +1,65 @@
+"""Tests for the heuristic ChatGPT Plus quota estimator."""
+
+from __future__ import annotations
+
+import pytest
+
+from core.quota_estimator import (
+    BatchLoadEstimate,
+    adjust_threshold,
+    estimate_batch_load,
+)
+
+
+class TestEstimateBatchLoad:
+    def test_returns_typed_estimate(self):
+        result = estimate_batch_load("describe", 50)
+        assert isinstance(result, BatchLoadEstimate)
+        assert result.operation == "describe"
+        assert result.count == 50
+        assert result.estimated_messages == 50
+        assert result.estimated_tokens > 0
+
+    def test_below_threshold_no_warn(self):
+        result = estimate_batch_load("describe", 10)
+        assert result.should_warn is False
+
+    def test_above_threshold_warns(self):
+        # Wide v1 default for describe is 300 — push well past it.
+        result = estimate_batch_load("describe", 500)
+        assert result.should_warn is True
+
+    def test_unknown_operation_silent(self):
+        """Unknown operation names produce zero estimate, no warning."""
+        result = estimate_batch_load("totally-unknown-op", 10000)
+        assert result.should_warn is False
+        assert result.estimated_messages == 0
+        assert result.estimated_tokens == 0
+
+    def test_negative_count_silent(self):
+        result = estimate_batch_load("describe", -5)
+        assert result.should_warn is False
+        assert result.count == 0
+
+    def test_zero_count_silent(self):
+        result = estimate_batch_load("describe", 0)
+        assert result.should_warn is False
+        assert result.estimated_messages == 0
+
+
+class TestThresholdAdjustment:
+    def test_adjust_threshold_takes_effect(self):
+        # Capture current threshold, lower it, confirm estimate flips,
+        # then restore it so the change doesn't leak to other tests.
+        original = estimate_batch_load("describe", 1).warn_threshold_units
+        try:
+            adjust_threshold("describe", 5)
+            result = estimate_batch_load("describe", 10)
+            assert result.should_warn is True
+            assert result.warn_threshold_units == 5
+        finally:
+            adjust_threshold("describe", original)
+
+    def test_adjust_unknown_operation_is_noop(self):
+        # Should not raise even though the operation isn't in the table.
+        adjust_threshold("totally-unknown-op", 10)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -432,8 +432,23 @@ class TestJSONSettings:
                     assert "appearance" in data
                     assert "youtube" in data
 
-                    # API key should NOT be in JSON
-                    assert "api_key" not in json.dumps(data)
+                    # Credential field NAMES should NOT be in JSON — keys live in keyring.
+                    # The literal string "api_key" can appear as a value (auth.mode = "api_key"
+                    # is a legitimate mode name distinct from any credential).
+                    json_str = json.dumps(data)
+                    for credential_field in (
+                        "youtube_api_key",
+                        "openai_api_key",
+                        "anthropic_api_key",
+                        "gemini_api_key",
+                        "groq_api_key",
+                        "openrouter_api_key",
+                        "replicate_api_key",
+                        "chatgpt_oauth_token",
+                    ):
+                        assert credential_field not in json_str, (
+                            f"Sensitive field {credential_field!r} leaked into JSON"
+                        )
 
     def test_load_settings_nonexistent_file(self):
         """Test loading settings when config file doesn't exist."""
@@ -694,3 +709,190 @@ class TestSequenceSelectedCategory:
                 with patch("core.settings._get_api_key_from_keyring", return_value=""):
                     loaded = load_settings()
                     assert loaded.sequence_selected_category == "All"
+
+
+class TestChatGPTOAuthToken:
+    """Tests for the ChatGPT subscription OAuth token blob storage.
+
+    The token is a JSON-serialized blob under a single keyring key.
+    Plaintext backends (Linux without Secret Service) must be refused —
+    OAuth refresh tokens warrant fail-closed behavior on insecure storage.
+    """
+
+    def _make_fake_keyring(self, *, backend_module="keyring.backends.macOS", backend_name="Keyring"):
+        """Build a MagicMock standing in for the `keyring` module."""
+        backend_cls = type(backend_name, (), {})
+        backend_cls.__module__ = backend_module
+        backend_instance = backend_cls()
+
+        keyring = MagicMock()
+        keyring.get_keyring.return_value = backend_instance
+        # Storage simulating successful set/get with no prior value
+        keyring.get_password.side_effect = [None]
+        return keyring
+
+    def test_round_trip_set_then_get(self):
+        """Setting a blob then reading it back returns an equal dict."""
+        from core.settings import (
+            get_chatgpt_oauth_token,
+            set_chatgpt_oauth_token,
+            KEYRING_CHATGPT_OAUTH_TOKEN,
+            KEYRING_SERVICE,
+        )
+
+        keyring = self._make_fake_keyring()
+        stored = {"value": None}
+
+        def fake_set(service, key, value):
+            stored["value"] = value
+        def fake_get(service, key):
+            return stored["value"]
+
+        keyring.set_password.side_effect = fake_set
+        keyring.get_password.side_effect = lambda service, key: fake_get(service, key)
+
+        blob = {
+            "access_token": "at_abc",
+            "refresh_token": "rt_xyz",
+            "id_token": "id_def",
+            "expires_at_unix": 1747000000,
+            "account_email": "derrick@example.com",
+        }
+
+        with patch.dict(sys.modules, {"keyring": keyring}):
+            assert set_chatgpt_oauth_token(blob) is True
+            keyring.set_password.assert_called_once()
+            args = keyring.set_password.call_args.args
+            assert args[0] == KEYRING_SERVICE
+            assert args[1] == KEYRING_CHATGPT_OAUTH_TOKEN
+            # Stored value is JSON-serialized
+            assert json.loads(args[2]) == blob
+
+            assert get_chatgpt_oauth_token() == blob
+
+    def test_set_none_deletes_entry(self):
+        """Setting None clears the stored token via the delete path."""
+        from core.settings import set_chatgpt_oauth_token
+
+        keyring = self._make_fake_keyring()
+        # Make a mock errors module so delete-path doesn't blow up
+        keyring.errors = MagicMock()
+        keyring.errors.PasswordDeleteError = type("PasswordDeleteError", (Exception,), {})
+
+        with patch.dict(sys.modules, {"keyring": keyring}):
+            assert set_chatgpt_oauth_token(None) is True
+            assert keyring.delete_password.called
+            keyring.set_password.assert_not_called()
+
+    def test_get_returns_none_when_no_token(self):
+        """get_chatgpt_oauth_token returns None when no entry is stored."""
+        from core.settings import get_chatgpt_oauth_token
+
+        keyring = MagicMock()
+        keyring.get_password.return_value = None
+
+        with patch.dict(sys.modules, {"keyring": keyring}):
+            assert get_chatgpt_oauth_token() is None
+
+    def test_get_self_clears_on_malformed_json(self):
+        """Malformed JSON is logged and the entry is cleared to break retry loops."""
+        from core.settings import get_chatgpt_oauth_token
+
+        keyring = MagicMock()
+        keyring.errors = MagicMock()
+        keyring.errors.PasswordDeleteError = type("PasswordDeleteError", (Exception,), {})
+        keyring.get_password.return_value = "this is not json {"
+
+        with patch.dict(sys.modules, {"keyring": keyring}):
+            assert get_chatgpt_oauth_token() is None
+            assert keyring.delete_password.called
+
+    def test_set_refuses_plaintext_keyring_backend(self):
+        """A PlaintextKeyring backend is refused; no entry is created."""
+        from core.settings import set_chatgpt_oauth_token
+
+        keyring = self._make_fake_keyring(
+            backend_module="keyrings.alt.file",
+            backend_name="PlaintextKeyring",
+        )
+
+        with patch.dict(sys.modules, {"keyring": keyring}):
+            assert set_chatgpt_oauth_token({"access_token": "at_abc"}) is False
+            keyring.set_password.assert_not_called()
+
+    def test_set_refuses_any_keyrings_alt_backend(self):
+        """Anything from keyrings.alt is treated as plaintext-equivalent."""
+        from core.settings import set_chatgpt_oauth_token
+
+        keyring = self._make_fake_keyring(
+            backend_module="keyrings.alt.pyfs",
+            backend_name="EncryptedKeyring",
+        )
+
+        with patch.dict(sys.modules, {"keyring": keyring}):
+            assert set_chatgpt_oauth_token({"access_token": "at_abc"}) is False
+            keyring.set_password.assert_not_called()
+
+    def test_set_accepts_macos_keychain_backend(self):
+        """The macOS Keychain backend is accepted; the blob is written."""
+        from core.settings import set_chatgpt_oauth_token
+
+        keyring = self._make_fake_keyring(
+            backend_module="keyring.backends.macOS",
+            backend_name="Keyring",
+        )
+
+        with patch.dict(sys.modules, {"keyring": keyring}):
+            assert set_chatgpt_oauth_token({"access_token": "at_abc"}) is True
+            keyring.set_password.assert_called_once()
+
+
+class TestAuthModeSettings:
+    """Tests for the auth_mode and chatgpt_account_email Settings fields."""
+
+    def test_auth_mode_defaults_to_api_key(self):
+        """New Settings instances default to api_key mode for backward compat."""
+        s = Settings()
+        assert s.auth_mode == "api_key"
+        assert s.chatgpt_account_email == ""
+
+    def test_auth_mode_persists_through_save_and_load(self):
+        """Setting subscription mode survives the JSON round trip."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.json"
+            with patch("core.settings._get_config_path", return_value=config_path):
+                with patch("core.settings._get_api_key_from_keyring", return_value=""):
+                    s = Settings()
+                    s.auth_mode = "subscription"
+                    s.chatgpt_account_email = "derrick@example.com"
+                    assert save_settings(s) is True
+
+                    loaded = load_settings()
+                    assert loaded.auth_mode == "subscription"
+                    assert loaded.chatgpt_account_email == "derrick@example.com"
+
+    def test_load_without_auth_section_keeps_defaults(self):
+        """A config.json without 'auth' loads cleanly with api_key mode default."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.json"
+            config_path.write_text(json.dumps({"version": "1.0"}))
+
+            with patch("core.settings._get_config_path", return_value=config_path):
+                with patch("core.settings._get_api_key_from_keyring", return_value=""):
+                    loaded = load_settings()
+                    assert loaded.auth_mode == "api_key"
+                    assert loaded.chatgpt_account_email == ""
+
+    def test_load_rejects_unknown_auth_mode(self):
+        """Unknown mode strings are ignored; the default applies."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.json"
+            config_path.write_text(json.dumps({
+                "version": "1.0",
+                "auth": {"mode": "garbage"},
+            }))
+
+            with patch("core.settings._get_config_path", return_value=config_path):
+                with patch("core.settings._get_api_key_from_keyring", return_value=""):
+                    loaded = load_settings()
+                    assert loaded.auth_mode == "api_key"

--- a/tests/test_spine_imports.py
+++ b/tests/test_spine_imports.py
@@ -32,6 +32,7 @@ SPINE_MODULES: tuple[str, ...] = (
     "core.spine.project_io",
     "core.spine._agent_formatting",
     "core.spine.audio_sources",
+    "core.spine.chatgpt_auth",
     "core.spine.clips",
     "core.spine.exports",
     "core.spine.frames",

--- a/tests/test_spine_imports.py
+++ b/tests/test_spine_imports.py
@@ -33,6 +33,7 @@ SPINE_MODULES: tuple[str, ...] = (
     "core.spine._agent_formatting",
     "core.spine.audio_sources",
     "core.spine.chatgpt_auth",
+    "core.spine.chatgpt_oauth_flow",
     "core.spine.clips",
     "core.spine.exports",
     "core.spine.frames",

--- a/tests/test_spine_imports.py
+++ b/tests/test_spine_imports.py
@@ -38,6 +38,7 @@ SPINE_MODULES: tuple[str, ...] = (
     "core.spine.exports",
     "core.spine.frames",
     "core.spine.glossary",
+    "core.spine.log_redaction",
     "core.spine.project_save",
     "core.spine.queries",
     "core.spine.sequence_analysis",

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -67,6 +67,7 @@ from core.settings import (
     set_chatgpt_oauth_token,
     clear_chatgpt_oauth_token,
 )
+from core.spine.chatgpt_auth import AuthMode
 from core.llm_client import get_provider_models
 from core.update_models import UpdateChannel
 from ui.theme import theme, UISizes
@@ -324,7 +325,8 @@ class SettingsDialog(QDialog):
         # _oauth_in_progress mirrors OAuthWorker's _finished_handled guard
         # at the dialog level — gates the Sign In button, the auth-mode
         # radios, and the OK button while a flow is running.
-        self._oauth_worker = None
+        # _has_oauth_token is cached from the keyring at load time to keep
+        # _refresh_signin_row / _refresh_ok_gate off the keyring read path.
         self._oauth_in_progress = False
         self._has_oauth_token = False
 
@@ -1329,8 +1331,8 @@ class SettingsDialog(QDialog):
         )
         worker.auth_complete.connect(self._on_auth_complete, Qt.UniqueConnection)
         worker.auth_failed.connect(self._on_auth_failed, Qt.UniqueConnection)
-        # Keep a reference so the QThread isn't garbage-collected mid-run.
-        self._oauth_worker = worker
+        # Worker stays alive because parent=self gives Qt ownership of it;
+        # no explicit reference field needed.
         self._oauth_in_progress = True
         self.signin_status_lbl.setText("Opening browser…")
         self._refresh_signin_row()
@@ -2132,7 +2134,7 @@ class SettingsDialog(QDialog):
         # identity row reflects whether a token blob is in keyring.
         token_blob = get_chatgpt_oauth_token()
         self._has_oauth_token = token_blob is not None
-        if self.settings.auth_mode == "subscription":
+        if self.settings.auth_mode == AuthMode.SUBSCRIPTION:
             self.auth_mode_subscription_radio.setChecked(True)
         else:
             self.auth_mode_apikey_radio.setChecked(True)
@@ -2280,9 +2282,9 @@ class SettingsDialog(QDialog):
 
         # Auth mode — the radio is the source of truth in the dialog.
         if self.auth_mode_subscription_radio.isChecked():
-            self.settings.auth_mode = "subscription"
+            self.settings.auth_mode = AuthMode.SUBSCRIPTION.value
         else:
-            self.settings.auth_mode = "api_key"
+            self.settings.auth_mode = AuthMode.API_KEY.value
         self.settings.youtube_results_count = self.youtube_results_spin.value()
         self.settings.youtube_parallel_downloads = self.youtube_parallel_spin.value()
 

--- a/ui/settings_dialog.py
+++ b/ui/settings_dialog.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QRadioButton,
     QDoubleSpinBox,
     QSpinBox,
     QCheckBox,
@@ -24,7 +25,8 @@ from PySide6.QtWidgets import (
     QDialogButtonBox,
     QScrollArea,
 )
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QUrl, Slot
+from PySide6.QtGui import QDesktopServices
 
 from ui.widgets.styled_slider import StyledSlider
 
@@ -60,6 +62,10 @@ from core.settings import (
     get_groq_api_key,
     set_groq_api_key,
     is_api_key_from_env,
+    # ChatGPT subscription OAuth (U1)
+    get_chatgpt_oauth_token,
+    set_chatgpt_oauth_token,
+    clear_chatgpt_oauth_token,
 )
 from core.llm_client import get_provider_models
 from core.update_models import UpdateChannel
@@ -313,6 +319,14 @@ class SettingsDialog(QDialog):
         self.setWindowTitle("Settings")
         self.setMinimumSize(1000, 400)
         self.setModal(True)
+
+        # ChatGPT subscription auth state (U5)
+        # _oauth_in_progress mirrors OAuthWorker's _finished_handled guard
+        # at the dialog level — gates the Sign In button, the auth-mode
+        # radios, and the OK button while a flow is running.
+        self._oauth_worker = None
+        self._oauth_in_progress = False
+        self._has_oauth_token = False
 
         self._setup_ui()
         self._load_settings()
@@ -951,6 +965,12 @@ class SettingsDialog(QDialog):
         tab = QWidget()
         layout = QVBoxLayout(tab)
 
+        # ChatGPT subscription auth — sits above the per-provider API keys
+        # because it's the primary path for the "I already have ChatGPT Plus"
+        # power user. The two paths coexist; one is active at a time per
+        # auth_mode.
+        layout.addWidget(self._create_chatgpt_auth_group())
+
         # LLM API Keys group
         llm_group = QGroupBox("LLM Provider API Keys")
         llm_layout = QVBoxLayout(llm_group)
@@ -1166,6 +1186,202 @@ class SettingsDialog(QDialog):
         else:
             edit.setEchoMode(QLineEdit.Password)
             btn.setText("Show")
+
+    # ---------- ChatGPT subscription auth (U5) ----------
+
+    def _create_chatgpt_auth_group(self) -> QGroupBox:
+        """Build the auth-mode toggle group at the top of the API Keys tab.
+
+        Layout: a radio pair selecting auth_mode, plus a dynamic
+        sign-in/sign-out row below. The radios drive the rest of the
+        widget — when API-key mode is selected the per-provider key
+        fields below this group remain the authoritative input; when
+        subscription mode is selected the user authenticates here.
+        """
+        group = QGroupBox("OpenAI Authentication")
+        layout = QVBoxLayout(group)
+
+        intro = QLabel(
+            "Use your ChatGPT Plus/Pro subscription, or supply an OpenAI "
+            "API key below."
+        )
+        intro.setWordWrap(True)
+        layout.addWidget(intro)
+
+        # Radio pair — the source of truth for auth_mode.
+        self.auth_mode_subscription_radio = QRadioButton(
+            "Sign in with ChatGPT (use my Plus/Pro subscription)"
+        )
+        self.auth_mode_apikey_radio = QRadioButton("Use OpenAI API key (below)")
+        self.auth_mode_subscription_radio.toggled.connect(
+            self._on_auth_mode_radio_toggled
+        )
+        layout.addWidget(self.auth_mode_subscription_radio)
+        layout.addWidget(self.auth_mode_apikey_radio)
+
+        # Sign-in row — visibility flips between "Sign in" and identity+Sign out.
+        self._signin_row = QHBoxLayout()
+        self.sign_in_btn = QPushButton("Sign in with ChatGPT")
+        self.sign_in_btn.clicked.connect(self._on_sign_in_clicked)
+        self._signin_row.addWidget(self.sign_in_btn)
+
+        self.signin_identity_lbl = QLabel("")
+        self._signin_row.addWidget(self.signin_identity_lbl)
+
+        self.sign_out_btn = QPushButton("Sign out")
+        self.sign_out_btn.clicked.connect(self._on_sign_out_clicked)
+        self._signin_row.addWidget(self.sign_out_btn)
+
+        self._signin_row.addStretch()
+        layout.addLayout(self._signin_row)
+
+        self.signin_status_lbl = QLabel("")
+        self.signin_status_lbl.setWordWrap(True)
+        layout.addWidget(self.signin_status_lbl)
+
+        return group
+
+    def _refresh_signin_row(self):
+        """Show/hide sign-in vs identity+sign-out widgets based on state."""
+        is_subscription = self.auth_mode_subscription_radio.isChecked()
+
+        # While OAuth is in flight, lock the radios and the sign-in button
+        # (R-U1, R-U2). API-key fields below stay unaffected.
+        self.auth_mode_subscription_radio.setEnabled(not self._oauth_in_progress)
+        self.auth_mode_apikey_radio.setEnabled(not self._oauth_in_progress)
+
+        if not is_subscription:
+            self.sign_in_btn.setVisible(False)
+            self.signin_identity_lbl.setVisible(False)
+            self.sign_out_btn.setVisible(False)
+            self.signin_status_lbl.setVisible(False)
+            self._refresh_ok_gate()
+            return
+
+        if self._oauth_in_progress:
+            self.sign_in_btn.setText("Waiting for browser…")
+            self.sign_in_btn.setEnabled(False)
+            self.sign_in_btn.setVisible(True)
+            self.signin_identity_lbl.setVisible(False)
+            self.sign_out_btn.setVisible(False)
+        elif self._has_oauth_token:
+            self.sign_in_btn.setVisible(False)
+            email = (self.settings.chatgpt_account_email or "Signed in (ChatGPT Plus)").strip()
+            self.signin_identity_lbl.setText(f"Signed in as {email}")
+            self.signin_identity_lbl.setVisible(True)
+            self.sign_out_btn.setVisible(True)
+        else:
+            self.sign_in_btn.setText("Sign in with ChatGPT")
+            self.sign_in_btn.setEnabled(True)
+            self.sign_in_btn.setVisible(True)
+            self.signin_identity_lbl.setVisible(False)
+            self.sign_out_btn.setVisible(False)
+
+        self._refresh_ok_gate()
+
+    def _refresh_ok_gate(self):
+        """Disable OK when subscription mode is selected but no token exists.
+
+        Prevents the silent-broken state where a user picks the radio,
+        forgets to click Sign In, hits OK, then sees "TokenMissingError"
+        on every LLM call. R-U3 in the doc-review pass.
+        """
+        if not hasattr(self, "button_box") or self.button_box is None:
+            return
+        ok_btn = self.button_box.button(QDialogButtonBox.Ok)
+        if ok_btn is None:
+            return
+
+        if (
+            self.auth_mode_subscription_radio.isChecked()
+            and not self._has_oauth_token
+            and not self._oauth_in_progress
+        ):
+            ok_btn.setEnabled(False)
+            self.signin_status_lbl.setText(
+                "Sign in first to use ChatGPT subscription mode."
+            )
+        else:
+            ok_btn.setEnabled(True)
+            if not self._oauth_in_progress:
+                self.signin_status_lbl.setText("")
+
+    @Slot()
+    def _on_auth_mode_radio_toggled(self, _checked: bool = False):
+        """Auth-mode radio changed — refresh the sign-in row state."""
+        self._refresh_signin_row()
+
+    @Slot()
+    def _on_sign_in_clicked(self):
+        """Start the OAuthWorker flow for Sign in with ChatGPT."""
+        if self._oauth_in_progress:
+            return
+        # Lazy import — only pulled in when the user clicks. Keeps the
+        # initial dialog open cheap and avoids cyclic-import hazards.
+        from ui.workers.oauth_worker import OAuthWorker
+
+        worker = OAuthWorker(parent=self)
+        # Qt.UniqueConnection guards us against accidental double-wiring
+        # if the slot is connected twice — the symmetric in-worker guard
+        # lives in OAuthWorker._emit_terminal_*.
+        worker.authorization_url_ready.connect(
+            self._on_auth_url_ready, Qt.UniqueConnection
+        )
+        worker.auth_complete.connect(self._on_auth_complete, Qt.UniqueConnection)
+        worker.auth_failed.connect(self._on_auth_failed, Qt.UniqueConnection)
+        # Keep a reference so the QThread isn't garbage-collected mid-run.
+        self._oauth_worker = worker
+        self._oauth_in_progress = True
+        self.signin_status_lbl.setText("Opening browser…")
+        self._refresh_signin_row()
+        worker.start()
+
+    @Slot()
+    def _on_sign_out_clicked(self):
+        """Clear the stored OAuth token and reset the identity display."""
+        clear_chatgpt_oauth_token()
+        self.settings.chatgpt_account_email = ""
+        self._has_oauth_token = False
+        self.signin_status_lbl.setText("Signed out. Sign in again to continue.")
+        self._refresh_signin_row()
+
+    @Slot(str)
+    def _on_auth_url_ready(self, url: str):
+        """Worker says the OAuth URL is ready — open it in the browser."""
+        # Defense in depth: validate scheme before handing to the OS.
+        # Mirrors docs/solutions/security-issues/url-scheme-validation-bypass.md.
+        if not url.startswith("https://"):
+            logger.error("Refusing to open non-HTTPS authorization URL")
+            return
+        QDesktopServices.openUrl(QUrl(url))
+
+    @Slot(dict)
+    def _on_auth_complete(self, blob: dict):
+        """OAuth flow succeeded — persist the blob and update the dialog."""
+        if not set_chatgpt_oauth_token(blob):
+            self._oauth_in_progress = False
+            self.signin_status_lbl.setText(
+                "Sign in succeeded but secure storage was unavailable. "
+                "Install a system keychain or use API-key mode."
+            )
+            self._refresh_signin_row()
+            return
+
+        account_email = blob.get("account_email", "") or ""
+        if isinstance(account_email, str):
+            self.settings.chatgpt_account_email = account_email
+        # The subscription radio remains selected; user clicks OK to apply.
+        self._has_oauth_token = True
+        self._oauth_in_progress = False
+        self.signin_status_lbl.setText("Signed in. Click OK to apply.")
+        self._refresh_signin_row()
+
+    @Slot(str, str)
+    def _on_auth_failed(self, category: str, user_message: str):
+        """OAuth flow failed — display the friendly message; leave state untouched."""
+        self._oauth_in_progress = False
+        self.signin_status_lbl.setText(user_message)
+        self._refresh_signin_row()
 
     def _toggle_api_key_visibility(self, show: bool):
         """Toggle API key visibility."""
@@ -1912,6 +2128,16 @@ class SettingsDialog(QDialog):
         self.openrouter_api_key_edit.setText(get_openrouter_api_key())
         self.groq_api_key_edit.setText(get_groq_api_key())
 
+        # ChatGPT subscription auth state — radio reflects auth_mode,
+        # identity row reflects whether a token blob is in keyring.
+        token_blob = get_chatgpt_oauth_token()
+        self._has_oauth_token = token_blob is not None
+        if self.settings.auth_mode == "subscription":
+            self.auth_mode_subscription_radio.setChecked(True)
+        else:
+            self.auth_mode_apikey_radio.setChecked(True)
+        self._refresh_signin_row()
+
         # Apply environment override indicators for LLM API keys
         self._apply_llm_env_override("anthropic", self.anthropic_api_key_edit,
                                       self.anthropic_api_key_lbl, self.anthropic_show_btn,
@@ -2051,6 +2277,12 @@ class SettingsDialog(QDialog):
 
         # YouTube
         self.settings.youtube_api_key = self.youtube_api_key_edit.text()
+
+        # Auth mode — the radio is the source of truth in the dialog.
+        if self.auth_mode_subscription_radio.isChecked():
+            self.settings.auth_mode = "subscription"
+        else:
+            self.settings.auth_mode = "api_key"
         self.settings.youtube_results_count = self.youtube_results_spin.value()
         self.settings.youtube_parallel_downloads = self.youtube_parallel_spin.value()
 

--- a/ui/workers/oauth_worker.py
+++ b/ui/workers/oauth_worker.py
@@ -1,0 +1,283 @@
+"""Qt worker that drives the Sign in with ChatGPT flow off the UI thread.
+
+Wraps the GUI-free OAuth primitives in ``core/spine/chatgpt_oauth_flow``.
+The orchestration sequence:
+
+  1. ``run()`` generates a PKCE pair and the authorization URL
+  2. emits ``authorization_url_ready(url)`` — the settings dialog's slot
+     opens this in the user's default browser via ``QDesktopServices``
+  3. blocks on ``run_loopback_listener`` until the redirect lands or
+     timeout fires; checking ``is_cancelled()`` between iterations is
+     handled by the underlying listener (a small per-iteration timeout
+     plus this worker checking the cancel flag in between).
+  4. exchanges the code for a token blob and emits ``auth_complete(blob)``
+  5. on any failure path, emits ``auth_failed(category, user_message)``
+     exactly once
+
+Signal-duplication discipline (mirrors the prior bug fix in
+docs/solutions/runtime-errors/qthread-destroyed-duplicate-signal-delivery-20260124.md):
+
+- ``_finished_handled`` is reset to False at the top of every ``run()``
+  call so two sequential sign-in attempts on the same worker instance
+  fire exactly one terminal signal each
+- The handler slot in the settings dialog (U5) connects with
+  ``Qt.UniqueConnection`` and guards its own ``_oauth_in_progress``
+  flag for the per-handler half of the pattern
+- Every emission path goes through ``_emit_terminal()`` which sets the
+  flag and short-circuits on a re-entry
+
+Cancellation: ``litellm.completion``-style "non-interruptible during one
+blocking HTTP call" applies here too. The token-endpoint POST is bounded
+to ~30s by httpx; the loopback listener checks for cancellation between
+its short (~1s) waits. The acceptable worst-case freeze on cancel is one
+in-flight HTTP call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Optional
+
+from PySide6.QtCore import Signal
+
+from ui.workers.base import CancellableWorker
+
+logger = logging.getLogger(__name__)
+
+
+# Auth failure categories surfaced to the settings dialog. Stable strings —
+# the dialog branches on the value, so keep them consistent with the U5
+# error-path test scenarios.
+AUTH_FAILED_CANCELLED = "cancelled"
+AUTH_FAILED_TIMEOUT = "timeout"
+AUTH_FAILED_NETWORK = "network"
+AUTH_FAILED_REJECTED = "rejected"
+AUTH_FAILED_MALFORMED = "malformed"
+
+
+class OAuthWorker(CancellableWorker):
+    """Cancellable worker that performs the Sign in with ChatGPT OAuth flow."""
+
+    # Emitted once when the authorization URL is ready for the browser.
+    authorization_url_ready = Signal(str)
+
+    # Emitted exactly once at the end of a successful flow. Payload is
+    # the token blob dict (the shape persisted by
+    # ``core.settings.set_chatgpt_oauth_token``).
+    auth_complete = Signal(dict)
+
+    # Emitted exactly once on any failure. (category, user_message)
+    # where category is one of the AUTH_FAILED_* constants.
+    auth_failed = Signal(str, str)
+
+    def __init__(self, timeout_seconds: float = 300.0, parent=None):
+        super().__init__(parent)
+        self._timeout_seconds = timeout_seconds
+        self._finished_handled = False
+
+    # -- Internal: terminal-emission guard ----------------------------------
+
+    def _emit_terminal_complete(self, blob: dict) -> None:
+        """Emit auth_complete exactly once, even under signal-duplication."""
+        if self._finished_handled:
+            logger.warning("OAuthWorker: suppressed duplicate auth_complete emission")
+            return
+        self._finished_handled = True
+        self.auth_complete.emit(blob)
+
+    def _emit_terminal_failed(self, category: str, user_message: str) -> None:
+        """Emit auth_failed exactly once, even under signal-duplication."""
+        if self._finished_handled:
+            logger.warning(
+                "OAuthWorker: suppressed duplicate auth_failed emission "
+                f"(category={category})"
+            )
+            return
+        self._finished_handled = True
+        self.auth_failed.emit(category, user_message)
+
+    # -- QThread.run --------------------------------------------------------
+
+    def run(self) -> None:
+        """Thread entry point. Runs the async coroutine via asyncio.run."""
+        # Reset guard each run so the same worker instance can be reused
+        # across sign-in attempts without a stale flag short-circuiting
+        # the next attempt's terminal signal.
+        self._finished_handled = False
+
+        try:
+            asyncio.run(self._async_run())
+        except Exception as exc:  # final safety net — should not reach here
+            logger.exception("OAuthWorker: unexpected error in run()")
+            self._emit_terminal_failed(
+                AUTH_FAILED_NETWORK, f"Unexpected sign-in error: {exc}"
+            )
+
+    # -- Async orchestration -----------------------------------------------
+
+    async def _async_run(self) -> None:
+        from core.spine.chatgpt_oauth_flow import (
+            OAuthCancelledError,
+            OAuthHTTPError,
+            OAuthHostMismatchError,
+            OAuthMalformedResponseError,
+            OAuthTimeoutError,
+            build_authorization_url,
+            exchange_code_for_token,
+            generate_pkce_pair,
+            run_loopback_listener,
+        )
+
+        # 1. Build the authorization URL on this thread (cheap) and signal
+        #    the dialog so it can open the browser on the main thread.
+        try:
+            pair = generate_pkce_pair()
+            auth_request = build_authorization_url(pair.challenge)
+        except Exception as exc:
+            logger.exception("OAuthWorker: failed to build authorization URL")
+            self._emit_terminal_failed(
+                AUTH_FAILED_NETWORK,
+                f"Could not start sign-in: {exc}",
+            )
+            return
+
+        if self.is_cancelled():
+            self._emit_terminal_failed(
+                AUTH_FAILED_CANCELLED, "Sign-in was cancelled before it started."
+            )
+            return
+
+        self.authorization_url_ready.emit(auth_request.url)
+
+        # 2. Run the loopback listener. This blocks until a redirect lands,
+        #    timeout fires, or the user cancels. We run it in a worker
+        #    thread so the asyncio loop can check cancellation between
+        #    short waits — each handle_request() call has a 1s ceiling
+        #    on its blocking wait set by the listener internally.
+        try:
+            auth_code = await asyncio.get_running_loop().run_in_executor(
+                None,
+                self._run_listener_with_cancellation,
+                auth_request.port,
+                auth_request.state,
+            )
+        except OAuthCancelledError as exc:
+            self._emit_terminal_failed(
+                AUTH_FAILED_CANCELLED, _user_message_for_cancellation(exc)
+            )
+            return
+        except OAuthTimeoutError:
+            self._emit_terminal_failed(
+                AUTH_FAILED_TIMEOUT,
+                "Sign-in timed out — the browser window may not have opened.",
+            )
+            return
+        except OAuthHostMismatchError as exc:
+            self._emit_terminal_failed(
+                AUTH_FAILED_REJECTED,
+                f"Sign-in rejected: {exc}",
+            )
+            return
+        except OAuthHTTPError as exc:
+            self._emit_terminal_failed(
+                AUTH_FAILED_REJECTED,
+                f"Sign-in rejected by OpenAI: {exc}",
+            )
+            return
+        except Exception as exc:
+            logger.exception("OAuthWorker: loopback listener failed")
+            self._emit_terminal_failed(
+                AUTH_FAILED_NETWORK, f"Sign-in failed: {exc}"
+            )
+            return
+
+        if auth_code is None:
+            # Cancellation while waiting in the listener thread.
+            self._emit_terminal_failed(
+                AUTH_FAILED_CANCELLED, "Sign-in was cancelled."
+            )
+            return
+
+        if self.is_cancelled():
+            self._emit_terminal_failed(
+                AUTH_FAILED_CANCELLED, "Sign-in was cancelled."
+            )
+            return
+
+        # 3. Exchange the code for a token blob. httpx call bounded to 30s.
+        try:
+            blob = await asyncio.get_running_loop().run_in_executor(
+                None,
+                exchange_code_for_token,
+                auth_code.code,
+                pair.verifier,
+                auth_request.redirect_uri,
+            )
+        except OAuthMalformedResponseError as exc:
+            self._emit_terminal_failed(
+                AUTH_FAILED_MALFORMED,
+                f"Sign-in response was malformed: {exc}",
+            )
+            return
+        except OAuthHTTPError as exc:
+            self._emit_terminal_failed(
+                AUTH_FAILED_REJECTED,
+                f"Sign-in rejected by OpenAI: {exc}",
+            )
+            return
+        except Exception as exc:
+            logger.exception("OAuthWorker: code exchange failed")
+            self._emit_terminal_failed(
+                AUTH_FAILED_NETWORK,
+                f"Could not complete sign-in: {exc}",
+            )
+            return
+
+        self._emit_terminal_complete(blob.as_dict())
+
+    # -- Loopback-listener cancellation wrapper ----------------------------
+
+    def _run_listener_with_cancellation(
+        self, port: int, expected_state: str
+    ):
+        """Run the loopback listener in short iterations so cancellation
+        is observable. Returns None when cancelled; otherwise the
+        AuthorizationCode from the listener (or raises an OAuth* error).
+        """
+        from core.spine.chatgpt_oauth_flow import (
+            OAuthTimeoutError,
+            run_loopback_listener,
+        )
+
+        deadline = time.time() + self._timeout_seconds
+        # Poll in 2s slices so the user's cancel is observed within
+        # ~2s of pressing the cancel button.
+        slice_seconds = 2.0
+        while time.time() < deadline:
+            if self.is_cancelled():
+                return None
+            remaining = deadline - time.time()
+            this_slice = min(slice_seconds, remaining)
+            try:
+                return run_loopback_listener(
+                    port=port,
+                    expected_state=expected_state,
+                    timeout_seconds=this_slice,
+                )
+            except OAuthTimeoutError:
+                # This slice expired with no redirect — check cancel,
+                # then loop back into another slice.
+                continue
+        raise OAuthTimeoutError(
+            f"Loopback receiver timed out after {self._timeout_seconds:.0f}s"
+        )
+
+
+def _user_message_for_cancellation(exc: Exception) -> str:
+    """Map cancellation causes to a user-friendly message."""
+    text = str(exc)
+    if "state" in text.lower():
+        return "Sign-in was rejected — please try again from Scene Ripper."
+    return "Sign-in was cancelled."

--- a/ui/workers/oauth_worker.py
+++ b/ui/workers/oauth_worker.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from enum import StrEnum
 from typing import Optional
 
 from PySide6.QtCore import Signal
@@ -47,14 +48,27 @@ from ui.workers.base import CancellableWorker
 logger = logging.getLogger(__name__)
 
 
-# Auth failure categories surfaced to the settings dialog. Stable strings —
-# the dialog branches on the value, so keep them consistent with the U5
-# error-path test scenarios.
-AUTH_FAILED_CANCELLED = "cancelled"
-AUTH_FAILED_TIMEOUT = "timeout"
-AUTH_FAILED_NETWORK = "network"
-AUTH_FAILED_REJECTED = "rejected"
-AUTH_FAILED_MALFORMED = "malformed"
+class OAuthFailureCategory(StrEnum):
+    """OAuth failure categories the settings dialog branches on.
+
+    StrEnum (Python 3.11+) so ``category == "cancelled"`` continues to
+    work for the existing string-comparison call sites. Matches the
+    precedent set by ``core.update_models.UpdateChannel``.
+    """
+
+    CANCELLED = "cancelled"
+    TIMEOUT = "timeout"
+    NETWORK = "network"
+    REJECTED = "rejected"
+    MALFORMED = "malformed"
+
+
+# Backwards-compatible module-level constant aliases.
+AUTH_FAILED_CANCELLED = OAuthFailureCategory.CANCELLED
+AUTH_FAILED_TIMEOUT = OAuthFailureCategory.TIMEOUT
+AUTH_FAILED_NETWORK = OAuthFailureCategory.NETWORK
+AUTH_FAILED_REJECTED = OAuthFailureCategory.REJECTED
+AUTH_FAILED_MALFORMED = OAuthFailureCategory.MALFORMED
 
 
 class OAuthWorker(CancellableWorker):


### PR DESCRIPTION
## Summary

Lays the full ChatGPT-Plus / Pro subscription-auth foundation (U1–U10 from the plan), behind a default-off auth mode that leaves the existing API-key path completely unchanged. Subscription mode is **scaffolding-complete with two `PLACEHOLDER_UNTIL_U3` constants** — exact OAuth `client_id` + endpoints, deferred to a follow-up that reads Codex CLI's open-source source. The default `auth_mode` is `"api_key"`, so no existing user sees behavioral change. R8 (API-key mode bit-identical) holds throughout.

11 atomic commits + the brainstorm and plan that drove them. The plan's **Review-Applied Revisions** section (authored after `/ce-doc-review`) is authoritative — every `R-A* / R-S* / R-U* / R-E* / R-Q* / R-M* / R-T* / R-Sc*` marker in the commit messages is defined there.

## What landed

| Unit | What | Files |
|------|------|-------|
| U1 | `auth_mode` + `chatgpt_account_email` Settings fields; OAuth-token keyring helpers; Linux plaintext-keyring fail-closed | `core/settings.py` |
| U2 | Spine-safe `AuthMode` / `AuthIdentity` / `load_active_auth` + refresh locks; placeholder endpoint constants with HTTPS-guard tests | `core/spine/chatgpt_auth.py` |
| U3 | PKCE + loopback OAuth flow with internally-generated state, 127.0.0.1-only bind, Host validation, bearer redaction | `core/spine/chatgpt_oauth_flow.py` |
| U4 | `OAuthWorker` with terminal-emission guard + reset-per-run | `ui/workers/oauth_worker.py` |
| U5 | Sign-in UI in API Keys tab; button gate, radio lock, OK gate | `ui/settings_dialog.py` (additive) |
| U6 | `complete_routed` chokepoint + thin Codex HTTP client; refresh-and-retry through `REFRESH_LOCK`; model-coercion map | `core/llm_client.py`, `core/codex_client.py` |
| U7 | Mechanical migration of 5 `litellm.completion` sites in `core/analysis/*` | `core/analysis/{description,cinematography,custom_query,ocr,shots_cloud}.py` |
| U8 (partial) | `core/auth_errors.classify_subscription_error` + user-message helper | `core/auth_errors.py` |
| U9 | Heuristic Plus-quota estimator with wide v1 defaults | `core/quota_estimator.py` |
| U10 | MCP-side `take_auth_snapshot` + drift check for per-job pinning | `scene_ripper_mcp/auth_snapshot.py` |

## Security hardening (Review-Applied Revisions)

- **R-S1** State generated inside `core/spine/chatgpt_oauth_flow` via `secrets.token_urlsafe(32)`; signature does not accept caller-supplied state (structural test asserts this)
- **R-S2** Loopback bound explicitly to `127.0.0.1`; Host header + path validation in the handler
- **R-S3** HTTPS-prefix unit tests on `AUTHORIZATION_ENDPOINT`, `TOKEN_ENDPOINT`, `CODEX_COMPLETION_ENDPOINT` (catches `http://` typos at merge time)
- **R-S4** Bearer-token redaction (`_redact_authorization` / `_sanitize_for_log`) on every exception body and log message
- **R-S5** Process-local `REFRESH_LOCK` + GUI-only-refresh cross-process contract (MCP fails loudly rather than racing the GUI for a single-use refresh_token)
- **R-T3** Linux plaintext-keyring backend detection — `set_chatgpt_oauth_token` refuses the write on `keyrings.alt.*` backends

## Tests

**208 passing** across the full feature surface:

- `tests/test_settings.py` — 71 (existing + 11 new for U1)
- `tests/test_chatgpt_auth.py` — 14
- `tests/test_chatgpt_oauth_flow.py` — 18
- `tests/test_oauth_worker.py` — 7
- `tests/test_codex_client.py` — 26
- `tests/test_auth_errors.py` — 14
- `tests/test_quota_estimator.py` — 8
- `tests/test_spine_imports.py` — 30 (boundary check extended to cover new spine modules)
- `tests/test_llm_client_fallback.py` + `tests/test_llm_client_constrained.py` — 18 (regression check that R8 still holds)
- `scene_ripper_mcp/tests/test_auth_snapshot.py` — 7

## Test plan

- [ ] Run `pytest tests/ scene_ripper_mcp/tests/ -q` locally — expect 208+ passes for the auth surface (broader suite may have unrelated environment-specific flakes per earlier exploration)
- [ ] Open Scene Ripper, go to Settings → API Keys — confirm the new "OpenAI Authentication" group renders with the radio pair, and switching radios doesn't break the per-provider API key fields below
- [ ] With API-key mode selected, run a clip description against an existing OpenAI key — should behave bit-identically to today
- [ ] (Post-merge follow-up) Replace the two `PLACEHOLDER_UNTIL_U3` constants in `core/spine/chatgpt_auth.py` with real values from Codex CLI source; run the live smoke test step from R-T1 before declaring the feature itself shipped

## Deferred follow-ups (explicit in commit messages)

- Real OAuth `CLIENT_ID` + endpoint URLs from Codex CLI source (U3 placeholder replacement)
- `LLMClient.stream_chat`/`chat` delegation through `stream_chat_routed` (chat-worker streaming + tool-call loop integration)
- Worker-by-worker wiring of `core.auth_errors.classify_subscription_error` (U8 mechanical follow-up)
- Per-tool `take_auth_snapshot()` integration at the top of each MCP `start_*` handler (U10 mechanical follow-up)
- Quota-estimator threshold calibration against real Plus usage data (R-Q3 follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)